### PR TITLE
Add reward standard deviation reporting

### DIFF
--- a/src/art/unsloth/api.py
+++ b/src/art/unsloth/api.py
@@ -256,8 +256,10 @@ class UnslothAPI(API):
 
         # Collect all metrics (including reward) across all trajectories
         all_metrics: dict[str, list[float]] = {"reward": [], "exception_rate": []}
+        group_rewards = []
 
         for group in trajectory_groups:
+            group_reward_values = []
             for trajectory in group:
                 if isinstance(trajectory, BaseException):
                     all_metrics["exception_rate"].append(1)
@@ -266,18 +268,39 @@ class UnslothAPI(API):
                     all_metrics["exception_rate"].append(0)
                 # Add reward metric
                 all_metrics["reward"].append(trajectory.reward)
+                if not isinstance(trajectory, BaseException):
+                    group_reward_values.append(trajectory.reward)
 
                 # Collect other custom metrics
                 for metric, value in trajectory.metrics.items():
                     if metric not in all_metrics:
                         all_metrics[metric] = []
                     all_metrics[metric].append(value)
+            
+            # Store rewards for each group for standard deviation calculation
+            if group_reward_values:
+                group_rewards.append(group_reward_values)
 
         # Calculate averages for all metrics
         averages = {}
         for metric, values in all_metrics.items():
             if len(values) > 0:
                 averages[metric] = sum(values) / len(values)
+        
+        # Calculate average standard deviation of rewards within groups
+        if group_rewards:
+            # Calculate standard deviation within each group
+            group_std_devs = []
+            for rewards in group_rewards:
+                if len(rewards) > 1:  # Need at least 2 values for std dev
+                    mean = sum(rewards) / len(rewards)
+                    variance = sum((r - mean) ** 2 for r in rewards) / len(rewards)
+                    std_dev = variance ** 0.5
+                    group_std_devs.append(std_dev)
+            
+            # Calculate average of the standard deviations
+            if group_std_devs:
+                averages["reward_std_dev"] = sum(group_std_devs) / len(group_std_devs)
 
         self._log_wandb_data(model, averages, name)
 


### PR DESCRIPTION
## Summary
- Add standard deviation reporting for rewards within trajectory groups
- Calculates and logs std-dev to help track consistency of reward values across similar prompts

🤖 Generated with [Claude Code](https://claude.ai/code)

<img width="1136" alt="Screenshot 2025-04-01 at 6 31 12 PM" src="https://github.com/user-attachments/assets/e34df335-24d2-44a0-a2c0-a1bbf334e7b7" />
