### PR TITLE
Use a public reward model URL for the hn title generator examples

### DIFF
--- a/examples/hn_title_generator/reference_grpo_trainer.py
+++ b/examples/hn_title_generator/reference_grpo_trainer.py
@@ -14,12 +14,11 @@ from utils import (
     cache,
     prompt_for_title,
 )
-from panza import limit_concurrency
+from art.utils import limit_concurrency
 import os
 from transformers.trainer_callback import TrainerCallback
 from vllm import SamplingParams
 
-# Load environment variables (like REWARD_MODEL_URL)
 load_dotenv()
 
 # --- Hyperparameters (Inlined from model11.yaml and script defaults) ---
@@ -110,17 +109,7 @@ async def load_title_data(
 
 @limit_concurrency(10)  # Limit concurrency for external calls
 async def score_title_async(row_data: dict) -> float:
-    """Asynchronously scores a title using the reward model."""
-    # Assuming score_title takes the row dict and the reward model service name/URL
-    # The REWARD_MODEL_URL should be set in your .env file or environment
-    reward_model_identifier = os.getenv(
-        "REWARD_MODEL_URL", "rm"
-    )  # Default to "rm" if not set
-    if not reward_model_identifier:
-        print(
-            "Warning: REWARD_MODEL_URL environment variable not set. Using default 'rm'."
-        )
-    return await score_title(row_data, reward_model_identifier)
+    return await score_title(row_data)
 
 
 # 1. Load Model and Tokenizer

--- a/examples/hn_title_generator/skypilot-reference-grpo-trainer.yaml
+++ b/examples/hn_title_generator/skypilot-reference-grpo-trainer.yaml
@@ -13,7 +13,6 @@ workdir: .
 envs:
   HF_HUB_ENABLE_HF_TRANSFER: 1
   VLLM_CONFIGURE_LOGGING: 0
-  REWARD_MODEL_URL:
 
 setup: |
   apt-get update && apt-get install -y git

--- a/examples/hn_title_generator/skypilot.yaml
+++ b/examples/hn_title_generator/skypilot.yaml
@@ -1,12 +1,11 @@
 # To launch, run the following command from the root directory of the art repository:
-# `uv run sky launch examples/hn_title_generator/skypilot.yaml --cluster=kyle-hn-title-generator-001 --env-file=.env --yes --retry-until-up --down --idle-minutes-to-autostop 60`
+# `uv run sky launch examples/hn_title_generator/skypilot.yaml --cluster=kyle-hn-title-generator-001 --env-file=.env --yes --retry-until-up --down --idle-minutes-to-autostop 10`
 
 workdir: .
 resources:
   accelerators: ["H100-SXM:1"]
 envs:
   HF_HUB_ENABLE_HF_TRANSFER: 1
-  REWARD_MODEL_URL:
 
 setup: |
   curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/examples/hn_title_generator/utils.py
+++ b/examples/hn_title_generator/utils.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Optional, Dict
 import os
 import httpx
-from panza import SQLiteCache, limit_concurrency
+from panza import SQLiteCache
 from dotenv import load_dotenv
 from datasets import load_dataset, Dataset
 
@@ -85,12 +85,15 @@ def calculate_metrics_by_split(df: pl.DataFrame) -> pl.DataFrame:
     return pl.DataFrame(metrics)
 
 
-REWARD_MODEL_URL = os.getenv("REWARD_MODEL_URL", "http://localhost:80/score")
+REWARD_MODEL_URL = os.getenv(
+    "REWARD_MODEL_URL", "https://openpipe-dev--hn-title-rm-serve-rm.modal.run/score"
+)
 
 
 @cache.cache()
 async def score_title(
-    story_dict: Dict, _reward_model: str = os.environ["REWARD_MODEL_URL"]
+    story_dict: Dict,
+    _reward_model: str = REWARD_MODEL_URL,
 ) -> float:
     """Get the reward model score for a story asynchronously.
 


### PR DESCRIPTION
I've now deployed the reward model used for the HN title generator examples to a public URL, served by Modal. It's set to autoscale down to 0 when idle, which should save some money, and also autoscale up when there's a queue of more than 10 requests, which will hopefully prevent runs from interfering with each other leading to timeouts.

The cold start time for the RM is about 45 seconds, and it has a 5-minute timeout before it spins back down.