### PR TITLE
Helpers to load model files from S3 and push a model to S3.

### DIFF
--- a/examples/hn_title_generator/train.py
+++ b/examples/hn_title_generator/train.py
@@ -19,7 +19,7 @@ BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
 MAX_COMPLETION_LENGTH = 100
 MAX_PROMPT_LENGTH = 8192 - MAX_COMPLETION_LENGTH
 LEARNING_RATE = 1.2e-5
-ENTRIES_PER_STEP = 1
+GROUPS_PER_STEP = 1
 EVAL_STEPS = 50
 VAL_SET_SIZE = 100
 TRAINING_DATASET_SIZE = 5000
@@ -285,7 +285,7 @@ async def main():
 
     data_iterator = iterate_dataset(
         dataset=train_data_list,
-        batch_size=ENTRIES_PER_STEP,
+        groups_per_step=GROUPS_PER_STEP,
         num_epochs=NUM_EPOCHS,
         initial_step=start_step,
         use_tqdm=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "tblib>=3.0.0",
     "litellm>=1.63.0",
     "polars>=1.26.0",
+    "awscli>=1.38.1",
 ]
 
 [build-system]

--- a/src/art/local/s3_sync.py
+++ b/src/art/local/s3_sync.py
@@ -19,6 +19,7 @@ async def s3_sync(
     *,
     profile: Optional[str] = None,
     verbose: bool = False,
+    delete: bool = False,
 ) -> None:
     """Synchronise *source* and *destination* using the AWS CLI.
 
@@ -42,7 +43,11 @@ async def s3_sync(
     cmd: list[str] = ["aws"]
     if profile:
         cmd += ["--profile", profile]
-    cmd += ["s3", "sync", "--delete", source, destination]
+
+    cmd += ["s3", "sync"]
+    if delete:
+        cmd.append("--delete")
+    cmd += [source, destination]
 
     # Suppress output unless verbose mode is requested.
     stdout = None if verbose else DEVNULL

--- a/src/art/local/s3_sync.py
+++ b/src/art/local/s3_sync.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+from asyncio.subprocess import DEVNULL
+from typing import Optional, Sequence
+from ..utils import limit_concurrency
+
+__all__: Sequence[str] = ("s3_sync",)
+
+
+class S3SyncError(RuntimeError):
+    """Raised when the underlying *aws s3 sync* command exits with a non‑zero status."""
+
+
+@limit_concurrency(1)
+async def s3_sync(
+    source: str,
+    destination: str,
+    *,
+    profile: Optional[str] = None,
+    verbose: bool = False,
+) -> None:
+    """Synchronise *source* and *destination* using the AWS CLI.
+
+    Either *source* or *destination* (or both) can point to an S3 URI, making it
+    possible to copy from local disk to S3 or from S3 to local disk.
+
+    The function is asynchronous: while the `aws` process runs, control is
+    yielded back to the event loop so other tasks can continue executing.
+
+    Args:
+        source: The *from* path. Can be a local path or an ``s3://`` URI.
+        destination: The *to* path. Can be a local path or an ``s3://`` URI.
+        profile: Optional AWS profile name to pass to the CLI.
+        verbose: When *True*, the output of the AWS CLI is streamed to the
+            calling process; otherwise it is suppressed.
+
+    Raises:
+        S3SyncError: If the *aws s3 sync* command exits with a non‑zero status.
+    """
+
+    cmd: list[str] = ["aws"]
+    if profile:
+        cmd += ["--profile", profile]
+    cmd += ["s3", "sync", "--delete", source, destination]
+
+    # Suppress output unless verbose mode is requested.
+    stdout = None if verbose else DEVNULL
+    stderr = None if verbose else DEVNULL
+
+    process = await asyncio.create_subprocess_exec(*cmd, stdout=stdout, stderr=stderr)
+    return_code = await process.wait()
+
+    if return_code != 0:
+        raise S3SyncError(f"{' '.join(cmd)} exited with status {return_code}")

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -76,53 +76,6 @@ class Model(BaseModel):
             split,
         )
 
-    async def pull_from_s3(
-        self,
-        s3_bucket: str,
-        *,
-        prefix: str | None = None,
-        verbose: bool = False,
-    ) -> None:
-        """Sync the model directory from S3 into the local output directory.
-
-        Args:
-            s3_bucket: The name of the S3 bucket (without the ``s3://`` scheme).
-            prefix: Optional key prefix inside the bucket. Do **not** include leading or trailing slashes.
-            verbose: When *True*, stream `aws` output; otherwise, suppress it.
-        """
-        await self.api()._pull_from_s3(
-            self, s3_bucket=s3_bucket, prefix=prefix, verbose=verbose
-        )
-        # Cache for later pushes.
-        self._s3_bucket, self._s3_prefix = s3_bucket, prefix
-
-    async def push_to_s3(
-        self,
-        s3_bucket: str | None = None,
-        *,
-        prefix: str | None = None,
-        verbose: bool = False,
-    ) -> None:
-        """Sync the local model directory **to** S3.
-
-        Args:
-            s3_bucket: The bucket to upload to. If omitted, the bucket from the most recent pull/push is reused.
-            prefix: Optional prefix; if omitted, reuse the stored prefix from the last pull/push.
-            verbose: When *True*, stream `aws` output; otherwise, suppress it.
-        """
-        s3_bucket = s3_bucket or self._s3_bucket
-        if s3_bucket is None:
-            raise ValueError(
-                "No S3 bucket specified — pass `s3_bucket=` explicitly or call `pull_from_s3` first."
-            )
-        prefix = prefix if prefix is not None else self._s3_prefix
-
-        await self.api()._push_to_s3(
-            self, s3_bucket=s3_bucket, prefix=prefix, verbose=verbose
-        )
-        # Remember for next time.
-        self._s3_bucket, self._s3_prefix = s3_bucket, prefix
-
 
 class TrainableModel(Model):
     base_model: str

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -30,6 +30,8 @@ class Model(BaseModel):
 
     trainable: bool = False
     _api: Optional["LocalAPI"] = None
+    _s3_bucket: str | None = None
+    _s3_prefix: str | None = None
 
     def api(self) -> "LocalAPI":
         if self._api is None:
@@ -73,6 +75,53 @@ class Model(BaseModel):
             trajectory_groups,
             split,
         )
+
+    async def pull_from_s3(
+        self,
+        s3_bucket: str,
+        *,
+        prefix: str | None = None,
+        verbose: bool = False,
+    ) -> None:
+        """Sync the model directory from S3 into the local output directory.
+
+        Args:
+            s3_bucket: The name of the S3 bucket (without the ``s3://`` scheme).
+            prefix: Optional key prefix inside the bucket. Do **not** include leading or trailing slashes.
+            verbose: When *True*, stream `aws` output; otherwise, suppress it.
+        """
+        await self.api()._pull_from_s3(
+            self, s3_bucket=s3_bucket, prefix=prefix, verbose=verbose
+        )
+        # Cache for later pushes.
+        self._s3_bucket, self._s3_prefix = s3_bucket, prefix
+
+    async def push_to_s3(
+        self,
+        s3_bucket: str | None = None,
+        *,
+        prefix: str | None = None,
+        verbose: bool = False,
+    ) -> None:
+        """Sync the local model directory **to** S3.
+
+        Args:
+            s3_bucket: The bucket to upload to. If omitted, the bucket from the most recent pull/push is reused.
+            prefix: Optional prefix; if omitted, reuse the stored prefix from the last pull/push.
+            verbose: When *True*, stream `aws` output; otherwise, suppress it.
+        """
+        s3_bucket = s3_bucket or self._s3_bucket
+        if s3_bucket is None:
+            raise ValueError(
+                "No S3 bucket specified — pass `s3_bucket=` explicitly or call `pull_from_s3` first."
+            )
+        prefix = prefix if prefix is not None else self._s3_prefix
+
+        await self.api()._push_to_s3(
+            self, s3_bucket=s3_bucket, prefix=prefix, verbose=verbose
+        )
+        # Remember for next time.
+        self._s3_bucket, self._s3_prefix = s3_bucket, prefix
 
 
 class TrainableModel(Model):

--- a/src/art/utils/iterate_dataset.py
+++ b/src/art/utils/iterate_dataset.py
@@ -8,7 +8,7 @@ T = TypeVar("T")
 
 def iterate_dataset(
     dataset: List[T],
-    batch_size: int = 1,
+    groups_per_step: int = 1,
     num_epochs: int = 1,
     initial_step: int = 0,
     use_tqdm: bool = True,
@@ -18,7 +18,7 @@ def iterate_dataset(
 
     Args:
         dataset: The list of data items.
-        batch_size: The size of each batch. Defaults to 1.
+        groups_per_step: The size of each batch. Defaults to 1.
         num_epochs: The number of times to iterate over the dataset. Defaults to 1.
         initial_step: The global step number to start from. Defaults to 0.
                            Useful for resuming training.
@@ -35,7 +35,7 @@ def iterate_dataset(
     if dataset_size == 0:
         return
 
-    steps_per_epoch = math.ceil(dataset_size / batch_size)
+    steps_per_epoch = math.ceil(dataset_size / groups_per_step)
     total_steps = steps_per_epoch * num_epochs
 
     progress_bar = None
@@ -53,8 +53,8 @@ def iterate_dataset(
         random.seed(epoch)  # Ensure shuffling is the same for a given epoch
         random.shuffle(indices)
 
-        for i in range(0, dataset_size, batch_size):
-            epoch_step = i // batch_size
+        for i in range(0, dataset_size, groups_per_step):
+            epoch_step = i // groups_per_step
             # Calculate global step number before skipping
             global_step = epoch * steps_per_epoch + epoch_step
 
@@ -68,7 +68,7 @@ def iterate_dataset(
                     pass  # tqdm handles the initial value
                 continue
 
-            batch_indices = indices[i : i + batch_size]
+            batch_indices = indices[i : i + groups_per_step]
             batch = [dataset[idx] for idx in batch_indices]
             yield batch, epoch, global_step, epoch_step
 

--- a/uv.lock
+++ b/uv.lock
@@ -3267,6 +3267,7 @@ name = "openpipe-art"
 version = "0.1.25"
 source = { editable = "." }
 dependencies = [
+    { name = "awscli" },
     { name = "bitsandbytes", marker = "sys_platform == 'linux'" },
     { name = "litellm" },
     { name = "matplotlib" },
@@ -3299,6 +3300,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "awscli", specifier = ">=1.38.1" },
     { name = "bitsandbytes", marker = "sys_platform == 'linux'", specifier = ">=0.45.2" },
     { name = "litellm", specifier = ">=1.63.0" },
     { name = "matplotlib", specifier = ">=3.10.1" },


### PR DESCRIPTION
@bradhilton I haven't tested this yet, but wanted to open a PR in case you have feedback on the API shape before investing more time. Idea is to make it easy to save/load your full ART runs to S3, so you can preserve them if your machine crashes, you're using an ephermeral instance, or you want to set the machine to auto shut down when a run ends.

In the current implementation there's no way to pass s3 credentials, we're just assuming the user has set them via env vars.

It would be nice to support other storage sources like r2 / b2, but probably a lower priority.

cc @arcticfly @angkywilliam 

Usage would look something like:

```python
import art
import asyncio
from dotenv import load_dotenv
import json
import openai
import random
import re
from typing import TypedDict

load_dotenv()


class TemporalCluePuzzle(TypedDict):
    num_clues: int
    prompt: str
    solution: dict[str, str]


puzzles: list[TemporalCluePuzzle] = json.load(open("./data/temporal-clue/puzzles.json"))
val_puzzles = puzzles[:64]
test_puzzles = puzzles[64:128]
train_puzzles = puzzles[128:]
random.seed(42)
random.shuffle(train_puzzles)


model = art.TrainableModel(
    name="001",
    project="temporal-clue",
    base_model="Qwen/Qwen2.5-14B-Instruct",
    _internal_config={"init_args": {"gpu_memory_utilization": 0.775}},
)
api = art.LocalAPI()
await model.register(api)
await api._experimental_push_to_s3(
    model,
    s3_bucket=os.environ["BACKUP_BUCKET"],
)


async def rollout(
    client: openai.AsyncOpenAI, puzzle: TemporalCluePuzzle
) -> art.Trajectory:
    messages: art.Messages = [{"role": "user", "content": puzzle["prompt"]}]
    chat_completion = await client.chat.completions.create(
        messages=messages, model=model.name
    )
    choice = chat_completion.choices[0]
    content = choice.message.content
    assert isinstance(content, str)
    num_correct = 0
    for key, value in puzzle["solution"].items():
        if matches := re.findall(rf"{key}\. ([A-Za-z \.:-]+)", content):
            match = matches[-1]
            if match.strip().lower() == value.lower():
                num_correct += 1
    reward = acc = num_correct / len(puzzle["solution"])
    return art.Trajectory(
        messages_and_choices=[*messages, choice], reward=reward, metrics={"acc": acc}
    )


stride = 4
openai_client = model.openai_client()
for i in range(await model.get_step(), 1_000):
    val_groups, train_groups = await asyncio.gather(
        art.gather_trajectory_groups(
            (
                art.TrajectoryGroup(rollout(openai_client, puzzle) for _ in range(2))
                for puzzle in val_puzzles
            ),
            pbar_desc="val",
        ),
        art.gather_trajectory_groups(
            (
                art.TrajectoryGroup(rollout(openai_client, puzzle) for _ in range(50))
                for puzzle in train_puzzles[i * stride : (i + 1) * stride]
            ),
            pbar_desc="train",
        ),
    )
    await model.log(val_groups)
    await model.delete_checkpoints()
    await model.train(
        train_groups,
        config=art.TrainConfig(learning_rate=5e-5),
    )
    if i % 10 == 0:
            await api._experimental_pull_from_s3(
                model,
                s3_bucket=os.environ["BACKUP_BUCKET"],
            )

```