### PR TITLE
couple of fixes for skypilot backend to work more simply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "awscli>=1.38.1",
     "hf-xet>=1.1.0",
     "panza",
+    "semver>=3.0.4",
 ]
 
 [project.scripts]
@@ -50,7 +51,6 @@ dev-dependencies = [
     "openpipe>=4.49.0",
     "skypilot[aws,cudo,do,fluidstack,gcp,lambda,paperspace,runpod]>=0.8.0",
     "hatch>=1.14.1",
-    "semver>=3.0.4",
 ]
 override-dependencies = [
     "bitsandbytes; sys_platform == 'linux'",

--- a/src/art/backend.py
+++ b/src/art/backend.py
@@ -80,6 +80,7 @@ class Backend:
                 "trajectory_groups": [tg.model_dump() for tg in trajectory_groups],
                 "split": split,
             },
+            timeout=None,
         )
         response.raise_for_status()
 


### PR DESCRIPTION
- Semver is required for running skypilot backend, which is only present in the dev dependencies at the moment and not the main dependencies. This PR moves it over to the main deps.
- When logging trajectories with `model.log()`, logging more than 50 trajectories at once leads to timeout. This does not happen during `model.train()` since timeout is set to None. This PR sets the timeout to None for `model.log()` too which lets larger number of trajs through.