### PR TITLE
fix internal config issue

### DIFF
--- a/src/art/model.py
+++ b/src/art/model.py
@@ -168,6 +168,14 @@ class TrainableModel(Model):
     # Use at your own risk.
     _internal_config: dev.InternalModelConfig | None = None
 
+    def __init__(self, **data):
+        # Pop any internal config provided at construction and assign it
+        internal_cfg = data.pop("_internal_config", None)
+        super().__init__(**data)
+        if internal_cfg is not None:
+            # Bypass BaseModel __setattr__ to allow setting private attr
+            object.__setattr__(self, "_internal_config", internal_cfg)
+
     async def register(
         self,
         backend: "Backend",


### PR DESCRIPTION
- This PR lets you set the _internal_config directly from the constructor instead of requiring you to set it separately after the constructor. Currently in examples such as temporal-clue.py, the _internal_config params are just ignored. This PR fixes this.

This PR directly resolves #114 