### PR TITLE
feat: make GRPO clip epsilon configurable

### DIFF
--- a/src/art/local/train.py
+++ b/src/art/local/train.py
@@ -124,7 +124,7 @@ def get_compute_loss_fn(trainer: "GRPOTrainer") -> Callable[..., torch.Tensor]:
         prob_ratio = torch.exp(new_logprobs - old_logprobs)
         policy_loss = -torch.min(
             prob_ratio * advantages,
-            torch.clip(prob_ratio, 1 - 0.2, 1 + 0.2) * advantages,
+            torch.clip(prob_ratio, 1 - config.clip_eps, 1 + config.clip_eps) * advantages,
         )
         if ref_logprobs is not None:
             kl_div = (

--- a/src/art/types.py
+++ b/src/art/types.py
@@ -14,6 +14,7 @@ Tools = list[ChatCompletionToolParam]
 class TrainConfig(pydantic.BaseModel):
     learning_rate: float = 5e-6
     beta: float = 0.0
+    clip_eps: float = 0.2
 
 
 Verbosity = Literal[0, 1, 2]


### PR DESCRIPTION
This PR extends the `TrainConfig` to allow configuring the clip epsilon, for more or less aggressive clipping.