### PR TITLE
Support `close` method on remote backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 
 [project.scripts]
 art = "art.cli:app"
+stop-server = "art.skypilot.stop_server:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/art/backend.py
+++ b/src/art/backend.py
@@ -28,7 +28,7 @@ class Backend:
         """
         If running vLLM in a separate process, this will kill that process and close the communication threads.
         """
-        response = await self._client.post("/close")
+        response = await self._client.post("/close", timeout=None)
         response.raise_for_status()
 
     async def register(

--- a/src/art/backend.py
+++ b/src/art/backend.py
@@ -24,6 +24,13 @@ class Backend:
         self._base_url = base_url
         self._client = httpx.AsyncClient(base_url=base_url)
 
+    async def close(self) -> None:
+        """
+        If running vLLM in a separate process, this will kill that process and close the communication threads.
+        """
+        response = await self._client.post("/close")
+        response.raise_for_status()
+
     async def register(
         self,
         model: "Model",

--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -45,6 +45,7 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
     backend = LocalBackend()
     app = FastAPI()
     app.get("/healthcheck")(lambda: {"status": "ok"})
+    app.post("/close")(backend.close)
     app.post("/register")(backend.register)
     app.post("/_log")(backend._log)
     app.post("/_prepare_backend_for_training")(backend._prepare_backend_for_training)

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -81,8 +81,11 @@ class LocalBackend(Backend):
 
     def __exit__(self, *excinfo):
         self.close()
-    
+
     def close(self):
+        """
+        If running vLLM in a separate process, this will kill that process and close the communication threads.
+        """
         for _, service in self._services.items():
             close_method = getattr(service, "close", None)
             if callable(close_method):

--- a/src/art/skypilot/stop_server.py
+++ b/src/art/skypilot/stop_server.py
@@ -24,7 +24,7 @@ async def stop_server() -> None:
     if len(cluster_status) == 0 or cluster_status[0]["status"] != sky.ClusterStatus.UP:
         raise ValueError(f"Cluster {args.cluster} is not running")
 
-    if not is_task_created(cluster_name=args.cluster, task_name="art_server"):
+    if not await is_task_created(cluster_name=args.cluster, task_name="art_server"):
         raise ValueError(f"Art server task for cluster {args.cluster} is not running")
 
     backend = await SkyPilotBackend.initialize_cluster(

--- a/src/art/skypilot/stop_server.py
+++ b/src/art/skypilot/stop_server.py
@@ -1,0 +1,40 @@
+import argparse
+import asyncio
+
+import sky
+from art.skypilot.backend import SkyPilotBackend
+from art.skypilot.utils import is_task_created, to_thread_typed
+
+parser = argparse.ArgumentParser(
+    description="Close the art server hosted on a skypilot cluster"
+)
+parser.add_argument(
+    "--cluster",
+    type=str,
+    required=True,
+    help="The name of the skypilot cluster to close the art server on",
+)
+args = parser.parse_args()
+
+
+async def stop_server() -> None:
+    cluster_status = await to_thread_typed(
+        lambda: sky.status(cluster_names=[args.cluster])
+    )
+    if len(cluster_status) == 0 or cluster_status[0]["status"] != sky.ClusterStatus.UP:
+        raise ValueError(f"Cluster {args.cluster} is not running")
+
+    if not is_task_created(cluster_name=args.cluster, task_name="art_server"):
+        raise ValueError(f"Art server task for cluster {args.cluster} is not running")
+
+    backend = await SkyPilotBackend.initialize_cluster(
+        cluster_name=args.cluster, art_version=".", env_path=".env", gpu="H100"
+    )
+    await backend.close()
+
+    # cancel the art server task
+    await to_thread_typed(lambda: sky.cancel(cluster_name=args.cluster, all=True))
+
+
+def main() -> None:
+    asyncio.run(stop_server())


### PR DESCRIPTION
### Changes
* Add docstring to LocalBackend `close` method
* Add `/close` endpoint to art server
* Add `close` method to Backend

When using SkyPilotBackend, you can now stop your server and the vLLM process by running:

```
uv run stop-server --cluster <cluster-name>
```