### PR TITLE
Add asymmetric PPO clipping

### DIFF
--- a/src/art/local/train.py
+++ b/src/art/local/train.py
@@ -122,10 +122,14 @@ def get_compute_loss_fn(trainer: "GRPOTrainer") -> Callable[..., torch.Tensor]:
             old_logprobs,
         )
         prob_ratio = torch.exp(new_logprobs - old_logprobs)
-        epsilon = _config.get("epsilon", 0.2)
         policy_loss = -torch.min(
             prob_ratio * advantages,
-            torch.clip(prob_ratio, 1 - epsilon, 1 + epsilon) * advantages,
+            torch.clip(
+                prob_ratio,
+                1 - config.clip_epsilon_low,
+                1 + config.clip_epsilon_high,
+            )
+            * advantages,
         )
         if ref_logprobs is not None:
             kl_div = (

--- a/src/art/types.py
+++ b/src/art/types.py
@@ -14,6 +14,8 @@ Tools = list[ChatCompletionToolParam]
 class TrainConfig(pydantic.BaseModel):
     learning_rate: float = 5e-6
     beta: float = 0.0
+    clip_epsilon_low: float = 0.2
+    clip_epsilon_high: float = 0.28
 
 
 Verbosity = Literal[0, 1, 2]


### PR DESCRIPTION
## Summary
- add `clip_epsilon_low` and `clip_epsilon_high` to `TrainConfig`
- use new clipping values during policy loss computation

This is based on the [DAPO paper](https://arxiv.org/abs/2503.14476), which found better results with these values. I haven't yet tested independently.

## Meta

Implemented this with OpenAI Codex. Took 3 tries to get it to implement it the way I was imagining. Would have been faster with Cursor. However, the good part is that somehow the context switching is easier since I don't have to create a new branch, open the PR myself, etc.