### PR TITLE
Enable asymmetric PPO clipping

### DIFF
--- a/src/art/dev/train.py
+++ b/src/art/dev/train.py
@@ -3,4 +3,5 @@ from typing_extensions import TypedDict
 
 class TrainConfig(TypedDict, total=False):
     epsilon: float  # clip epsilon, using the same name as TRL
+    epsilon_high: float | None  # asymmetric clip upper bound. Defaults to epsilon when None
     logprob_calculation_chunk_size: int

--- a/src/art/local/train.py
+++ b/src/art/local/train.py
@@ -123,9 +123,12 @@ def get_compute_loss_fn(trainer: "GRPOTrainer") -> Callable[..., torch.Tensor]:
         )
         prob_ratio = torch.exp(new_logprobs - old_logprobs)
         epsilon = _config.get("epsilon", 0.2)
+        epsilon_high = _config.get("epsilon_high", epsilon)
+        if epsilon_high is None:
+            epsilon_high = epsilon
         policy_loss = -torch.min(
             prob_ratio * advantages,
-            torch.clip(prob_ratio, 1 - epsilon, 1 + epsilon) * advantages,
+            torch.clip(prob_ratio, 1 - epsilon, 1 + epsilon_high) * advantages,
         )
         if ref_logprobs is not None:
             kl_div = (


### PR DESCRIPTION
## Summary
- support an optional `epsilon_high` parameter in `TrainConfig`
- use `epsilon_high` when computing PPO clip bounds and default to symmetrical clipping

## Testing
- `git status --short`