### PR TITLE
Revert some of the thread safe changes

### DIFF
--- a/src/mp_actors/move.py
+++ b/src/mp_actors/move.py
@@ -148,16 +148,12 @@ class Proxy:
             # Return a regular function wrapper
             @streamline_tracebacks()
             def method_wrapper(*args: Any, **kwargs: Any) -> Any:
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
-                    fut = asyncio.run_coroutine_threadsafe(get_response(args, kwargs), loop)
-                    return fut.result()
-                else:
-                    return asyncio.run(get_response(args, kwargs))
+                return asyncio.run(get_response(args, kwargs))
 
             return method_wrapper
         else:
-            return asyncio.run(get_response(tuple(), {}))
+            # For non-callable attributes, get them directly
+            return asyncio.run(get_response(tuple(), dict()))
 
     def close(self):
         # signal the response loop to exit


### PR DESCRIPTION
There was an issue where training would sometimes hang, this seems to fix the issue, while still keeping the fix for the overall hanging.