### PR TITLE
reverting to older vllm version, since the latest one shows regressions in convergence of grpo training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "torchao>=0.9.0",
     "unsloth==2025.5.1 ; sys_platform == 'linux'",
     "unsloth-zoo==2025.5.1 ; sys_platform == 'linux'",
-    "vllm==0.7.3",
+    "vllm==0.8.4",
     "wandb>=0.19.8",
     "peft>=0.14.0",
     "typer>=0.15.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "torchao>=0.9.0",
     "unsloth==2025.5.1 ; sys_platform == 'linux'",
     "unsloth-zoo==2025.5.1 ; sys_platform == 'linux'",
-    "vllm>=0.8.5",
+    "vllm==0.7.3",
     "wandb>=0.19.8",
     "peft>=0.14.0",
     "typer>=0.15.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "torchao>=0.9.0",
     "unsloth==2025.5.1 ; sys_platform == 'linux'",
     "unsloth-zoo==2025.5.1 ; sys_platform == 'linux'",
-    "vllm==0.8.4",
+    "vllm==0.7.3",
     "wandb>=0.19.8",
     "peft>=0.14.0",
     "typer>=0.15.2",

--- a/src/art/local/vllm.py
+++ b/src/art/local/vllm.py
@@ -264,6 +264,7 @@ def patch_get_lora_tokenizer_async() -> None:
 
     Specifically, Unsloth patches get_lora_tokenizer_async with a non-async function, which causes issues.
     """
+    import vllm.transformer_utls.tokenizer
     import vllm.transformers_utils.tokenizer_group.tokenizer_group
 
     async def _return_nothing(*_, **__) -> None:
@@ -272,6 +273,7 @@ def patch_get_lora_tokenizer_async() -> None:
     vllm.transformers_utils.tokenizer_group.tokenizer_group.get_lora_tokenizer_async = (
         _return_nothing  # type: ignore
     )
+    vllm.transformer_utls.tokenizer.get_lora_tokenizer_async = _return_nothing  # type: ignore
 
 
 def patch_listen_for_disconnect() -> None:

--- a/src/art/local/vllm.py
+++ b/src/art/local/vllm.py
@@ -264,12 +264,14 @@ def patch_get_lora_tokenizer_async() -> None:
 
     Specifically, Unsloth patches get_lora_tokenizer_async with a non-async function, which causes issues.
     """
-    import vllm.transformers_utils.tokenizer_group as tg
+    import vllm.transformers_utils.tokenizer_group.tokenizer_group
 
-    async def get_self_lora_tokenizer_async(self, *args, **kwargs):
-        return self.tokenizer
+    async def _return_nothing(*_, **__) -> None:
+        return None
 
-    tg.TokenizerGroup.get_lora_tokenizer_async = get_self_lora_tokenizer_async  # type: ignore
+    vllm.transformers_utils.tokenizer_group.tokenizer_group.get_lora_tokenizer_async = (
+        _return_nothing  # type: ignore
+    )
 
 
 def patch_listen_for_disconnect() -> None:

--- a/src/art/local/vllm.py
+++ b/src/art/local/vllm.py
@@ -269,11 +269,15 @@ def patch_get_lora_tokenizer_async() -> None:
 
     async def _return_nothing(*_, **__) -> None:
         return None
+    
+    async def get_self_lora_tokenizer_async(self, *args, **kwargs):
+        return self.tokenizer
 
+    vllm.transformers_utils.tokenizer.get_lora_tokenizer_async = _return_nothing  # type: ignore
     vllm.transformers_utils.tokenizer_group.tokenizer_group.get_lora_tokenizer_async = (
         _return_nothing  # type: ignore
     )
-    vllm.transformers_utils.tokenizer.get_lora_tokenizer_async = _return_nothing  # type: ignore
+    vllm.transformers_utils.tokenizer_group.tokenizer_group.TokenizerGroup.get_lora_tokenizer_async = get_self_lora_tokenizer_async  # type: ignore
 
 
 def patch_listen_for_disconnect() -> None:

--- a/src/art/local/vllm.py
+++ b/src/art/local/vllm.py
@@ -264,7 +264,7 @@ def patch_get_lora_tokenizer_async() -> None:
 
     Specifically, Unsloth patches get_lora_tokenizer_async with a non-async function, which causes issues.
     """
-    import vllm.transformer_utls.tokenizer
+    import vllm.transformers_utils.tokenizer
     import vllm.transformers_utils.tokenizer_group.tokenizer_group
 
     async def _return_nothing(*_, **__) -> None:
@@ -273,7 +273,7 @@ def patch_get_lora_tokenizer_async() -> None:
     vllm.transformers_utils.tokenizer_group.tokenizer_group.get_lora_tokenizer_async = (
         _return_nothing  # type: ignore
     )
-    vllm.transformer_utls.tokenizer.get_lora_tokenizer_async = _return_nothing  # type: ignore
+    vllm.transformers_utils.tokenizer.get_lora_tokenizer_async = _return_nothing  # type: ignore
 
 
 def patch_listen_for_disconnect() -> None:


### PR DESCRIPTION
reverting to older vllm version, since the latest one shows regressions in convergence of grpo training. Qwen 3 training won't be possible due to the outdated vllm version, but convergence is more important, so once we identify and fix the root cause, we will update the vllm version and re-support qwen 3