### PR TITLE
Properly log trajectories and metrics via remote backend

### DIFF
--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -47,10 +47,17 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
     app.get("/healthcheck")(lambda: {"status": "ok"})
     app.post("/close")(backend.close)
     app.post("/register")(backend.register)
-    app.post("/_log")(backend._log)
     app.post("/_prepare_backend_for_training")(backend._prepare_backend_for_training)
     app.post("/_get_step")(backend._get_step)
     app.post("/_delete_checkpoints")(backend._delete_checkpoints)
+
+    @app.post("/_log")
+    async def _log(
+        model: Model,
+        trajectory_groups: list[TrajectoryGroup],
+        split: str = Body("val"),
+    ):
+        await backend._log(model, trajectory_groups, split)
 
     @app.post("/_train_model")
     async def _train_model(

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -238,7 +238,7 @@ class LocalBackend(Backend):
         os.makedirs(parent_dir, exist_ok=True)
 
         # Get the file name for the current iteration, or default to 0 for non-trainable models
-        iteration = self.__get_step(model) if isinstance(model, TrainableModel) else 0
+        iteration = self.__get_step(model) if model.trainable else 0
         file_name = f"{iteration:04d}.yaml"
 
         # Write the logs to the file
@@ -273,7 +273,7 @@ class LocalBackend(Backend):
         # Calculate average standard deviation of rewards within groups
         averages["reward_std_dev"] = calculate_step_std_dev(trajectory_groups)
 
-        if isinstance(model, TrainableModel):
+        if model.trainable:
             self._log_metrics(model, averages, split)
 
     def _trajectory_log(self, trajectory: Trajectory) -> str:
@@ -338,9 +338,7 @@ class LocalBackend(Backend):
             if split
             else metrics
         )
-        step = (
-            self.__get_step(model) if isinstance(model, TrainableModel) else 0
-        ) + step_offset
+        step = (self.__get_step(model) if model.trainable else 0) + step_offset
 
         # If we have a W&B run, log the data there
         if run := self._get_wandb_run(model):

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -95,7 +95,7 @@ class Model(BaseModel):
             return self._openai_client
 
         if self.inference_api_key is None or self.inference_base_url is None:
-            if isinstance(self, TrainableModel):
+            if self.trainable:
                 raise ValueError(
                     "OpenAI client not yet available on this trainable model. You must call `model.register()` first."
                 )


### PR DESCRIPTION
Previously we were checking if a model was an instance of TrainableModel to determine whether it was trainable or a comparison model. However, when models are serialized on a local computer and sent via http to SkyPilot, they're by default deserialized into Model objects. This means that the check `isinstance(model, TrainableModel)` will fail. Instead, we can check whether `model.trainable` is true to achieve the same logic in a less bug-prone manner.

### Changes
* Check whether models are trainable using the `train` attribute
* Explicitly write out `_log` function endpoint in ART server to properly set `val` as the default split instead of overwriting whatever was sent