### PR TITLE
Serialize model config

### DIFF
--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -47,9 +47,15 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
     app.get("/healthcheck")(lambda: {"status": "ok"})
     app.post("/close")(backend.close)
     app.post("/register")(backend.register)
-    app.post("/_prepare_backend_for_training")(backend._prepare_backend_for_training)
     app.post("/_get_step")(backend._get_step)
     app.post("/_delete_checkpoints")(backend._delete_checkpoints)
+
+    @app.post("/_prepare_backend_for_training")
+    async def _prepare_backend_for_training(
+        model: TrainableModel,
+        config: dev.OpenAIServerConfig | None = Body(None),
+    ):
+        return await backend._prepare_backend_for_training(model, config)
 
     @app.post("/_log")
     async def _log(

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -176,6 +176,11 @@ class TrainableModel(Model):
             # Bypass BaseModel __setattr__ to allow setting private attr
             object.__setattr__(self, "_internal_config", internal_cfg)
 
+    def model_dump(self, *args, **kwargs) -> dict:
+        data = super().model_dump(*args, **kwargs)
+        data["_internal_config"] = self._internal_config
+        return data
+
     async def register(
         self,
         backend: "Backend",


### PR DESCRIPTION
### Changes
* Properly serialize `TrainableModel`'s `_internal_config`
* Read config from `_prepare_backend_for_training` argument