### PR TITLE
Fix training stability issues with new vLLM version

### DIFF
--- a/src/art/dev/model.py
+++ b/src/art/dev/model.py
@@ -43,6 +43,7 @@ def get_model_config(
         # which is the fallback for devices with compute capability < 8.0
         num_scheduler_steps=16 if torch.cuda.get_device_capability()[0] >= 8 else 1,
         enable_sleep_mode=enable_sleep_mode,
+        generation_config="vllm",
     )
     engine_args.update(config.get("engine_args", {}))
     init_args.update(config.get("init_args", {}))

--- a/src/art/dev/openai_server.py
+++ b/src/art/dev/openai_server.py
@@ -27,6 +27,7 @@ def get_openai_server_config(
         num_scheduler_steps=16,
         served_model_name=base_model,
         disable_log_requests=True,
+        generation_config="vllm",
     )
     engine_args.update(config.get("engine_args", {}))
     return OpenAIServerConfig(

--- a/src/art/local/vllm.py
+++ b/src/art/local/vllm.py
@@ -265,17 +265,18 @@ def patch_get_lora_tokenizer_async() -> None:
     Specifically, Unsloth patches get_lora_tokenizer_async with a non-async function, which causes issues.
     """
     import vllm.transformers_utils.tokenizer
+    import vllm.transformers_utils.tokenizer_group
 
     async def _return_nothing(*_, **__) -> None:
         return None
-
-    vllm.transformers_utils.tokenizer.get_lora_tokenizer_async = _return_nothing  # type: ignore
-
+    
     async def get_self_lora_tokenizer_async(self, *args, **kwargs):
         return self.tokenizer
 
-    import vllm.transformers_utils.tokenizer_group
-
+    vllm.transformers_utils.tokenizer.get_lora_tokenizer_async = _return_nothing  # type: ignore
+    vllm.transformers_utils.tokenizer_group.get_lora_tokenizer_async = (
+        _return_nothing  # type: ignore
+    )
     vllm.transformers_utils.tokenizer_group.TokenizerGroup.get_lora_tokenizer_async = get_self_lora_tokenizer_async  # type: ignore
 
 

--- a/src/art/local/vllm.py
+++ b/src/art/local/vllm.py
@@ -264,12 +264,19 @@ def patch_get_lora_tokenizer_async() -> None:
 
     Specifically, Unsloth patches get_lora_tokenizer_async with a non-async function, which causes issues.
     """
-    import vllm.transformers_utils.tokenizer_group as tg
+    import vllm.transformers_utils.tokenizer
+
+    async def _return_nothing(*_, **__) -> None:
+        return None
+
+    vllm.transformers_utils.tokenizer.get_lora_tokenizer_async = _return_nothing  # type: ignore
 
     async def get_self_lora_tokenizer_async(self, *args, **kwargs):
         return self.tokenizer
 
-    tg.TokenizerGroup.get_lora_tokenizer_async = get_self_lora_tokenizer_async  # type: ignore
+    import vllm.transformers_utils.tokenizer_group
+
+    vllm.transformers_utils.tokenizer_group.TokenizerGroup.get_lora_tokenizer_async = get_self_lora_tokenizer_async  # type: ignore
 
 
 def patch_listen_for_disconnect() -> None:


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/12622 -- since this commit in vLLM, if you don't pass in a generation-config, it uses whatever it finds in generation_config.json from the model if it exists. if you want to use vllm defaults, you have to explicitly pass in generation_config="vllm". which is what used to happen by default before this commit.

For RL training, we need
repetition_penalty = 1.0
top_p = 1.0
top_k = 0
temperature = 1

Changes to the above changes the logprobs returned from vLLM which we use to calculate losses and gradient updates, which leads to unstable training.

we're setting the default generation config to "vllm" to have the above sampling params, instead of the generation_config.json from the model.