### PR TITLE
Limit number of metrics shown in `gather_trajectory_groups`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openpipe-art"
-version = "0.3.9"
+version = "0.3.10"
 description = "The OpenPipe Agent Reinforcement Training (ART) library"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -3272,7 +3272,7 @@ wheels = [
 
 [[package]]
 name = "openpipe-art"
-version = "0.3.9"
+version = "0.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "awscli" },


### PR DESCRIPTION
Allow optional `max_metrics` parameter to be passed into `gather_trajectory_groups`, which should prevent the progress bar from wrapping when tracking many metrics.