### PR TITLE
Fix busy wait in vllm test client

### DIFF
--- a/src/art/local/vllm.py
+++ b/src/art/local/vllm.py
@@ -68,7 +68,7 @@ async def openai_server_task(
                 async for _ in client.models.list():
                     return
             except:
-                pass
+                await asyncio.sleep(0.1)
 
     test_client_task = asyncio.create_task(test_client())
     try:


### PR DESCRIPTION
## Summary
- avoid high CPU usage in `test_client` by sleeping when server is unreachable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f56c119f4832b8731c6db6fa962eb