### PR TITLE
Fix s3 utils typo

### DIFF
--- a/src/art/utils/s3.py
+++ b/src/art/utils/s3.py
@@ -92,7 +92,7 @@ async def s3_sync(
         cmd += ["--profile", profile]
 
     cmd += ["s3"]
-    # us cp for files, sync for directories
+    # use cp for files, sync for directories
     if os.path.isfile(source):
         cmd += ["cp"]
     else:


### PR DESCRIPTION
## Summary
- fix small typo in `s3.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f56c91070832bafe0e65a8bd0f2a2