### PR TITLE
Match default SkyPilotBackend version to client

### DIFF
--- a/src/art/skypilot/backend.py
+++ b/src/art/skypilot/backend.py
@@ -4,6 +4,7 @@ import sky
 import os
 import semver
 from dotenv import dotenv_values
+from importlib.metadata import version, PackageNotFoundError
 
 from .utils import (
     is_task_created,
@@ -40,7 +41,9 @@ class SkyPilotBackend(Backend):
         self._envs = {}
 
         if env_path is not None:
-            self._envs = {k: v for k, v in dotenv_values(env_path).items() if v is not None}
+            self._envs = {
+                k: v for k, v in dotenv_values(env_path).items() if v is not None
+            }
             print(f"Loading envs from {env_path}")
             print(f"{len(self._envs)} environment variables found")
 
@@ -140,28 +143,32 @@ class SkyPilotBackend(Backend):
         task.set_resources(resources)
         task.update_envs(self._envs)
 
-        # default to installing latest version of art
-        art_installation_command = "uv pip install openpipe-art"
-        if art_version is not None:
-            art_version_is_semver = False
-            # check if art_version is valid semver
-            if art_version is not None:
-                try:
-                    semver.Version.parse(art_version)
-                    art_version_is_semver = True
-                except Exception:
-                    pass
+        # default to installing the version of art that is used by the client
+        if art_version is None:
+            try:
+                art_version = version("openpipe-art")
+            except PackageNotFoundError:
+                art_version = None
 
-            if art_version_is_semver:
-                art_installation_command = f"uv pip install openpipe-art=={art_version}"
-            elif os.path.exists(art_version):
-                # copy the contents of the art_path onto the new machine
-                task.workdir = art_version
-                art_installation_command = "uv sync"
-            else:
-                raise ValueError(
-                    f"Invalid art_version: {art_version}. Must be a semver or a path to a local directory."
-                )
+        art_version_is_semver = False
+        # check if art_version is valid semver
+        if art_version is not None:
+            try:
+                semver.Version.parse(art_version)
+                art_version_is_semver = True
+            except Exception:
+                pass
+
+        if art_version_is_semver:
+            art_installation_command = f"uv pip install openpipe-art=={art_version}"
+        elif os.path.exists(art_version):
+            # copy the contents of the art_path onto the new machine
+            task.workdir = art_version
+            art_installation_command = "uv sync"
+        else:
+            raise ValueError(
+                f"Invalid art_version: {art_version}. Must be a semver or a path to a local directory."
+            )
 
         setup_script = f"""
     curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/src/art/skypilot/backend.py
+++ b/src/art/skypilot/backend.py
@@ -148,7 +148,9 @@ class SkyPilotBackend(Backend):
             try:
                 art_version = version("openpipe-art")
             except PackageNotFoundError:
-                art_version = None
+                raise ValueError(
+                    "No version of openpipe-art installed in project. Please provide an art_version."
+                )
 
         art_version_is_semver = False
         # check if art_version is valid semver


### PR DESCRIPTION
Resolves #172 

### Changes
* During SkyPilotBackend initialization, default ART server to whatever version of `openpipe-art` is specified in client
* Throw error if `openpipe-art` not installed and no art_version provided