### PR TITLE
Pin openpipe-art and accelerate versions in notebooks

### DIFF
--- a/examples/2048/2048.ipynb
+++ b/examples/2048/2048.ipynb
@@ -102,7 +102,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!uv pip install openpipe-art openpipe --prerelease allow --no-cache-dir"
+    "!uv pip install openpipe-art==0.3.11 openpipe accelerate==1.7.0 --prerelease allow --no-cache-dir"
    ]
   },
   {

--- a/examples/codenames/Codenames_RL.ipynb
+++ b/examples/codenames/Codenames_RL.ipynb
@@ -144,7 +144,7 @@
       "outputs": [],
       "source": [
         "%%capture\n",
-        "!uv pip install openpipe-art openpipe --prerelease allow --no-cache-dir"
+        "!uv pip install openpipe-art==0.3.11 openpipe accelerate==1.7.0 --prerelease allow --no-cache-dir"
       ]
     },
     {

--- a/examples/temporal_clue/temporal-clue.ipynb
+++ b/examples/temporal_clue/temporal-clue.ipynb
@@ -103,7 +103,7 @@
       "outputs": [],
       "source": [
         "%%capture\n",
-        "!uv pip install openpipe-art openpipe --prerelease allow --no-cache-dir"
+        "!uv pip install openpipe-art==0.3.11 openpipe accelerate==1.7.0 --prerelease allow --no-cache-dir"
       ]
     },
     {

--- a/examples/tic_tac_toe/tic-tac-toe.ipynb
+++ b/examples/tic_tac_toe/tic-tac-toe.ipynb
@@ -102,7 +102,7 @@
       "outputs": [],
       "source": [
         "%%capture\n",
-        "!uv pip install openpipe-art openpipe --prerelease allow --no-cache-dir"
+        "!uv pip install openpipe-art==0.3.11 openpipe accelerate==1.7.0 --prerelease allow --no-cache-dir"
       ]
     },
     {


### PR DESCRIPTION
Version `0.3.12` of `openpipe-art` has trouble running on T4s in Google Colab, so let's use `0.3.11`. However, `0.3.11` doesn't pin `accelerate` to `1.7.0`, so let's just pin it manually within the notebook.

### Changes
* Update Google Colab notebooks to pin `openpipe-art==0.3.11` and `accelerate==1.7.0`