### PR TITLE
Add exclude parameter to S3 pull functionality

### DIFF
--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -48,6 +48,7 @@ from .checkpoints import (
 from art.utils.s3 import (
     pull_model_from_s3,
     push_model_to_s3,
+    ExcludableOption,
 )
 
 
@@ -443,6 +444,7 @@ class LocalBackend(Backend):
         prefix: str | None = None,
         verbose: bool = False,
         delete: bool = False,
+        exclude: list[ExcludableOption] | None = None,
     ) -> None:
         """Download the model directory from S3 into local Backend storage. Right now this can be used to pull trajectory logs for processing or model checkpoints.
         Args:
@@ -452,7 +454,9 @@ class LocalBackend(Backend):
             prefix: The prefix to pull from S3. If None, the model name will be used.
             verbose: Whether to print verbose output.
             delete: Whether to delete the local model directory.
+            exclude: List of directories to exclude from sync. Valid options: "checkpoints", "logs", "trajectories".
         """
+
         await pull_model_from_s3(
             model_name=model.name,
             project=model.project,
@@ -462,6 +466,7 @@ class LocalBackend(Backend):
             verbose=verbose,
             delete=delete,
             art_path=self._path,
+            exclude=exclude,
         )
 
     async def _experimental_push_to_s3(

--- a/src/art/utils/benchmarking/load_trajectories.py
+++ b/src/art/utils/benchmarking/load_trajectories.py
@@ -238,6 +238,7 @@ async def pull_model_trajectories(model: ArtModel) -> None:
             model,
             s3_bucket=bucket,
             verbose=True,
+            exclude=["checkpoints", "logs"],
         )
 
         print("Finished pulling trajectories.", flush=True)


### PR DESCRIPTION
## Summary
- Added typesafe `exclude` parameter to S3 pull functionality to filter out directories during sync
- Updated `pull_model_trajectories` helper to automatically exclude checkpoints and logs
- Enables pulling only trajectories for local analysis without downloading large model weights

## Motivation
Often when analyzing trajectory data, we only need the trajectory files themselves, not the model checkpoints or logs. Model checkpoints can be very large (gigabytes), and downloading them consumes significant bandwidth and storage space. This is especially important when working on mobile connections or with limited bandwidth.

## Changes
1. Added `ExcludableOption` type with valid options: `"checkpoints"`, `"logs"`, `"trajectories"`
2. Modified `s3_sync()` to accept and use exclude patterns with AWS CLI's `--exclude` flag
3. Updated `pull_model_from_s3()` and `_experimental_pull_from_s3()` to accept and pass through exclude parameter
4. Modified `pull_model_trajectories()` helper to automatically exclude checkpoints and logs

## Test plan
Created and ran `test_s3_exclude.py` to verify:
- [x] Helper function correctly excludes checkpoints and logs
- [x] Direct backend call with exclude parameter works
- [x] Only trajectory files are downloaded, excluded directories remain empty
- [x] Tested with model `email-agent-216-4` in project `email_agent`

🤖 Generated with [Claude Code](https://claude.ai/code)