### PR TITLE
Remove metadata from TrajectoryGroup, keep only on Trajectory

### DIFF
--- a/src/art/trajectories.py
+++ b/src/art/trajectories.py
@@ -114,7 +114,6 @@ def get_messages(messages_and_choices: MessagesAndChoices) -> Messages:
 
 class TrajectoryGroup(pydantic.BaseModel):
     trajectories: list[Trajectory]
-    metadata: dict[str, MetadataValue] = {}
     exceptions: list[PydanticException] = []
 
     def __init__(
@@ -123,7 +122,6 @@ class TrajectoryGroup(pydantic.BaseModel):
             Iterable[Trajectory | BaseException] | Iterable[Awaitable[Trajectory]]
         ),
         *,
-        metadata: dict[str, MetadataValue] = {},
         exceptions: list[BaseException] = [],
     ) -> None:
         super().__init__(
@@ -133,7 +131,6 @@ class TrajectoryGroup(pydantic.BaseModel):
                 if isinstance(trajectory, Trajectory)
             ]
             or getattr(self, "trajectories", []),
-            metadata=metadata,
             exceptions=[
                 PydanticException(
                     type=str(type(exception)),
@@ -166,7 +163,6 @@ class TrajectoryGroup(pydantic.BaseModel):
         cls,
         trajectories: Iterable[Trajectory | BaseException],
         *,
-        metadata: dict[str, MetadataValue] = {},
         exceptions: list[BaseException] = [],
     ) -> "TrajectoryGroup": ...
 
@@ -175,7 +171,6 @@ class TrajectoryGroup(pydantic.BaseModel):
         cls,
         trajectories: Iterable[Awaitable[Trajectory]],
         *,
-        metadata: dict[str, MetadataValue] = {},
         exceptions: list[BaseException] = [],
     ) -> Awaitable["TrajectoryGroup"]: ...
 
@@ -185,7 +180,6 @@ class TrajectoryGroup(pydantic.BaseModel):
             Iterable[Trajectory | BaseException] | Iterable[Awaitable[Trajectory]]
         ),
         *,
-        metadata: dict[str, MetadataValue] = {},
         exceptions: list[BaseException] = [],
     ) -> "TrajectoryGroup | Awaitable[TrajectoryGroup]":
         ts = list(trajectories)
@@ -213,7 +207,6 @@ class TrajectoryGroup(pydantic.BaseModel):
                 return TrajectoryGroup(
                     trajectories=trajectories,
                     exceptions=exceptions,
-                    metadata=metadata,
                 )
 
             class CoroutineWithMetadata:
@@ -230,7 +223,6 @@ class TrajectoryGroup(pydantic.BaseModel):
             group = super().__new__(cls)
             group.__init__(
                 trajectories=cast(list[Trajectory | BaseException], ts),
-                metadata=metadata,
                 exceptions=exceptions,
             )
             return group

--- a/src/art/utils/trajectory_logging.py
+++ b/src/art/utils/trajectory_logging.py
@@ -30,7 +30,6 @@ def trajectory_group_to_dict(trajectory_group: TrajectoryGroup) -> dict[str, Any
 
     return {
         "trajectories": trajectory_dicts,
-        "metadata": trajectory_group.metadata,
     }
 
 
@@ -76,7 +75,6 @@ def dict_to_trajectory_group(dict: dict[str, Any]) -> TrajectoryGroup:
         trajectories=[
             dict_to_trajectory(trajectory) for trajectory in dict["trajectories"]
         ],
-        metadata=dict["metadata"],
         exceptions=[],
     )
 


### PR DESCRIPTION
## Summary
- Removed metadata field from TrajectoryGroup class
- Updated all constructors and methods to remove metadata parameter
- Updated serialization/deserialization in trajectory_logging.py

## Rationale
We're not aware of anyone using group-level metadata, and this change provides several benefits:
- **Simpler schema** for ingesting into experiment tracking tools
- **Clearer mental model** of where to store metadata (only on individual trajectories)
- **Reduced complexity** in the data model

Users who need group-level metadata can still achieve this by setting the same metadata on each trajectory in the group.

## Changes
- Removed `metadata: dict[str, MetadataValue] = {}` field from TrajectoryGroup
- Removed `metadata` parameter from all TrajectoryGroup constructors and overloads
- Updated trajectory_logging.py to no longer serialize/deserialize group metadata
- No existing tests needed updating (no tests existed for this functionality)

We can add this functionality back later if it proves necessary.

🤖 Generated with [Claude Code](https://claude.ai/code)