### PR TITLE
Fix link to SkyPilotBackend

### DIFF
--- a/docs/fundamentals/art-client.mdx
+++ b/docs/fundamentals/art-client.mdx
@@ -24,7 +24,7 @@ If you're curious about how ART allows you to run training and inference either 
     <Card
       title="SkyPilotBackend"
       icon="cloud"
-      href="/fundamentals/art-backend#skypilot-backend"
+      href="/fundamentals/art-backend#skypilotbackend"
       horizontal={true}
       arrow={true}
     >


### PR DESCRIPTION
### Changes
* `#skypilot-backend` -> `#skypilotbackend`