### PR TITLE
Launch H100-SXM by default

### DIFF
--- a/skypilot-config.yaml
+++ b/skypilot-config.yaml
@@ -382,7 +382,7 @@
 
 workdir: .
 resources:
-  accelerators: ["H100:1", "A100-80GB:1"]
+  accelerators: ["H100-SXM:1", "A100-80GB:1"]
   ports:
     - 7999 # main ART server
     - 8000 # vLLM server


### PR DESCRIPTION
### Changes
* Launch `H100-SXM` by default when running `./scripts/launch-cluster.sh`