### PR TITLE
Remove `group_aggregate` from utils/__init__.py

### DIFF
--- a/src/art/unsloth/train.py
+++ b/src/art/unsloth/train.py
@@ -9,7 +9,7 @@ from typing import cast, Callable, TYPE_CHECKING
 
 from .. import dev
 from ..types import TrainConfig
-from ..utils import group_aggregate
+from ..utils.group_aggregate import group_aggregate
 
 if TYPE_CHECKING:
     from .service import TrainInputs

--- a/src/art/utils/__init__.py
+++ b/src/art/utils/__init__.py
@@ -1,6 +1,5 @@
 # Import all utilities to maintain the same interface
 from .format_message import format_message
-from .group_aggregate import group_aggregate
 from .retry import retry
 from .iterate_dataset import iterate_dataset
 from .limit_concurrency import limit_concurrency
@@ -9,7 +8,6 @@ from .get_model_step import get_model_step
 
 __all__ = [
     "format_message",
-    "group_aggregate",
     "retry",
     "iterate_dataset",
     "limit_concurrency",


### PR DESCRIPTION
Fixes https://github.com/OpenPipe/ART/issues/291

### Changes
* Remove `group_aggregate` from utils/__init__.py
* Update import of `group_aggregate` in unsloth/train.py 