### PR TITLE
Update ART•E notebook ART version

### DIFF
--- a/examples/art-e/art-e.ipynb
+++ b/examples/art-e/art-e.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!uv pip install openpipe-art==0.3.11.post3 langchain-core tenacity datasets \"gql<4\" --prerelease allow --no-cache-dir"
+    "!uv pip install openpipe-art==0.3.11.post5 langchain-core tenacity datasets \"gql<4\" --prerelease allow --no-cache-dir"
    ]
   },
   {


### PR DESCRIPTION
The code was referencing a non-existent `items` attribute on batches, which was added after the previous version was released.

### Changes
* Update version of `openpipe-art` in ART•E notebook