### PR TITLE
Improve release workflow with human-curated notes

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -1,0 +1,115 @@
+name: Create Draft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+        - patch
+        - minor
+        - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install -e .
+
+      - name: Bump version
+        id: bump
+        run: |
+          python scripts/bump_version.py ${{ github.event.inputs.version_type }}
+          NEW_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Generate release notes template
+        id: release_notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get the previous tag
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          
+          # Get merged PRs since last release
+          if [ -z "$PREVIOUS_TAG" ]; then
+            PRS=$(gh pr list --state merged --limit 100 --json number,title,url | jq -r '.[] | "- \(.title) ([#\(.number)](\(.url)))"')
+          else
+            LAST_TAG_DATE=$(git log -1 --format=%aI $PREVIOUS_TAG)
+            PRS=$(gh pr list --state merged --limit 100 --json number,title,url,mergedAt | jq -r --arg date "$LAST_TAG_DATE" '.[] | select(.mergedAt > $date) | "- \(.title) ([#\(.number)](\(.url)))"')
+          fi
+          
+          # Create release notes template
+          cat << EOF > release_notes_template.md
+          ## Release Highlights
+          
+          <!-- Add key features, improvements, and breaking changes here -->
+          
+          ## What's Changed
+          
+          $PRS
+          
+          **Full Changelog**: https://github.com/OpenPipe/ART/compare/$PREVIOUS_TAG...v${{ steps.bump.outputs.NEW_VERSION }}
+          EOF
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create v${{ steps.bump.outputs.NEW_VERSION }} \
+            --title "v${{ steps.bump.outputs.NEW_VERSION }}" \
+            --notes-file release_notes_template.md \
+            --draft
+
+      - name: Create PR with version bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git checkout -b release/v${{ steps.bump.outputs.NEW_VERSION }}
+          git add pyproject.toml uv.lock
+          git commit -m "Bump version to ${{ steps.bump.outputs.NEW_VERSION }}"
+          git push origin release/v${{ steps.bump.outputs.NEW_VERSION }}
+          
+          gh pr create \
+            --title "Release v${{ steps.bump.outputs.NEW_VERSION }}" \
+            --body "This PR bumps the version to ${{ steps.bump.outputs.NEW_VERSION }}. 
+
+          **Next steps:**
+          1. Review and edit the [draft release](https://github.com/OpenPipe/ART/releases) 
+          2. Add release highlights and curate the changelog
+          3. Merge this PR to publish the release automatically" \
+            --base main \
+            --head release/v${{ steps.bump.outputs.NEW_VERSION }}
+
+      - name: Output instructions
+        run: |
+          echo "::notice::Draft release created! Next steps:"
+          echo "::notice::1. Go to https://github.com/OpenPipe/ART/releases and edit the draft"
+          echo "::notice::2. Add release highlights and curate the auto-generated PR list"  
+          echo "::notice::3. Merge the PR to publish the release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -12,6 +12,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,42 +37,37 @@ jobs:
       - name: Build package
         run: uv run hatch build
 
-      - name: Generate release notes
-        id: release_notes
+      - name: Get version from pyproject.toml
+        id: get_version
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create git tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag v${{ steps.get_version.outputs.VERSION }}
+          git push origin v${{ steps.get_version.outputs.VERSION }}
+
+      - name: Publish draft release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get the previous tag
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          
-          # Get merged PRs since last release
-          if [ -z "$PREVIOUS_TAG" ]; then
-            # If no previous tag, get all PRs
-            PRS=$(gh pr list --state merged --limit 100 --json number,title,url | jq -r '.[] | "- \(.title) ([#\(.number)](\(.url)))"')
+          # Find and publish the draft release
+          DRAFT_ID=$(gh release list --json id,isDraft,tagName | jq -r '.[] | select(.isDraft == true and .tagName == "v${{ steps.get_version.outputs.VERSION }}") | .id')
+          if [ -n "$DRAFT_ID" ]; then
+            gh release edit v${{ steps.get_version.outputs.VERSION }} --draft=false
           else
-            # Get PRs merged since the last tag
-            LAST_TAG_DATE=$(git log -1 --format=%aI $PREVIOUS_TAG)
-            PRS=$(gh pr list --state merged --limit 100 --json number,title,url,mergedAt | jq -r --arg date "$LAST_TAG_DATE" '.[] | select(.mergedAt > $date) | "- \(.title) ([#\(.number)](\(.url)))"')
+            echo "::error::No draft release found for v${{ steps.get_version.outputs.VERSION }}"
+            exit 1
           fi
-          
-          # Create release notes
-          cat << EOF > release_notes.md
-          ## What's Changed
-          
-          $PRS
-          
-          **Full Changelog**: https://github.com/OpenPipe/ART/compare/$PREVIOUS_TAG...${{ github.ref_name }}
-          EOF
-          
-          # Output for GitHub Actions
-          echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          body_path: release_notes.md
-          files: dist/*
-          generate_release_notes: false
+      - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload v${{ steps.get_version.outputs.VERSION }} dist/*
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/AGENT.md
+++ b/AGENT.md
@@ -12,7 +12,7 @@ This project uses the `uv` package manager.
 
 ## Releases
 
-- If asked to help with a release, refer to the checklist in CONTRIBUTING.md
+- If asked to help with a release, refer to the checklist in CONTRIBUTING.md. Be sure to first share a draft of the release notes with the user before actually publishing the release to GitHub.
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,44 +37,31 @@ These checks are automatically run in CI for all pull requests. If your PR fails
 
 To create a new release:
 
-1. **Ensure you're on the main branch with latest changes**:
+1. **Review merged PRs since the last release**:
+   - Go to the [pull requests page](https://github.com/OpenPipe/ART/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc)
+   - Review PRs merged since the last release to understand what changed
+   - Note any breaking changes, new features, or important bug fixes
 
-   ```bash
-   git checkout main
-   git pull origin main
-   ```
+2. **Create a draft release**:
+   - Go to [Actions](https://github.com/OpenPipe/ART/actions/workflows/create-draft-release.yml)
+   - Click "Run workflow"
+   - Select the version bump type:
+     - `patch`: Bug fixes and minor changes (0.3.13 → 0.3.14)
+     - `minor`: New features and non-breaking changes (0.3.13 → 0.4.0)  
+     - `major`: Breaking changes (0.3.13 → 1.0.0)
 
-2. **Decide on version bump type**:
-
-   - `patch`: Bug fixes and minor changes (0.3.13 → 0.3.14)
-   - `minor`: New features and non-breaking changes (0.3.13 → 0.4.0)
-   - `major`: Breaking changes (0.3.13 → 1.0.0)
-
-3. **Run the version bump script**:
-
-   ```bash
-   python scripts/bump_version.py patch  # or minor/major
-   ```
-
-4. **Commit and tag the version**:
-
-   ```bash
-   git add pyproject.toml uv.lock
-   git commit -m "Bump version to X.Y.Z"
-   git tag vX.Y.Z
-   git push origin main vX.Y.Z
-   ```
-
-5. **GitHub Actions will automatically**:
-
-   - Create a GitHub release with auto-generated notes listing all merged PRs
-   - Build and publish the package to PyPI
-
-6. **Update release notes** (recommended):
+3. **Edit the draft release notes**:
    - Go to the [releases page](https://github.com/OpenPipe/ART/releases)
-   - Click "Edit" on the latest release
-   - Add highlights, breaking changes, or other important information
-   - The auto-generated PR list provides a good starting point, but manual curation improves clarity
+   - Click "Edit" on the draft release
+   - Add release highlights, breaking changes, and curated changelog
+   - The auto-generated PR list provides a starting point, but manual curation improves clarity
+
+4. **Finalize the release**:
+   - Review and merge the automatically created release PR
+   - This will automatically:
+     - Create the git tag
+     - Publish the curated release notes
+     - Build and publish the package to PyPI
 
 Then follow the SkyPilot or Local Training instructions below.
 


### PR DESCRIPTION
## Problem
Currently, releases are automatically published with auto-generated notes, then manually updated afterward. This means release notification emails go out with placeholder content before the curated notes are ready.

## Solution
This PR introduces a two-stage release process:

1. **Draft Creation**: Manual workflow creates a draft release with editable notes template
2. **Publication**: Merging a version bump PR publishes the curated release

## Changes
- **New workflow** (): Creates draft releases with PR list template
- **Updated workflow** (): Publishes draft releases when version PR is merged  
- **Updated docs** (): New process includes reviewing merged PRs since last release

## New Workflow
1. Review merged PRs since last release
2. Run "Create Draft Release" workflow action
3. Edit draft release notes with highlights and curated changelog
4. Merge the auto-created version bump PR to publish

## Benefits
- ✅ Curated release notes published from the start
- ✅ No more placeholder emails to users
- ✅ Explicit step to review PRs since last release
- ✅ Draft-first approach prevents premature publishing