### PR TITLE
 Refactor: Simplify TrajectoryGroup and remove monkey-patching

### DIFF
--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -35,15 +35,7 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
         )
         return
 
-    # Reset the custom __new__ and __init__ methods for TrajectoryGroup
-    def __new__(cls, *args: Any, **kwargs: Any) -> TrajectoryGroup:
-        return pydantic.BaseModel.__new__(cls)
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        return pydantic.BaseModel.__init__(self, *args, **kwargs)
-
-    TrajectoryGroup.__new__ = __new__  # type: ignore
-    TrajectoryGroup.__init__ = __init__
+    
 
     backend = LocalBackend()
     app = FastAPI()

--- a/src/art/trajectories.py
+++ b/src/art/trajectories.py
@@ -118,9 +118,7 @@ class TrajectoryGroup(pydantic.BaseModel):
 
     def __init__(
         self,
-        trajectories: (
-            Iterable[Trajectory | BaseException] | Iterable[Awaitable[Trajectory]]
-        ),
+        trajectories: Iterable[Trajectory | BaseException],
         *,
         exceptions: list[BaseException] = [],
     ) -> None:
@@ -173,56 +171,50 @@ class TrajectoryGroup(pydantic.BaseModel):
         *,
         exceptions: list[BaseException] = [],
     ) -> Awaitable["TrajectoryGroup"]: ...
+        cls,
+        trajectories: Iterable[Awaitable[Trajectory]],
+        *,
+        exceptions: list[BaseException] = [],
+    ) -> Awaitable["TrajectoryGroup"]:
+        ts = list(trajectories)
+
+        async def _(exceptions: list[BaseException]):
+            from .gather import get_gather_context, record_metrics
+
+            context = get_gather_context()
+            trajectories = []
+            for future in asyncio.as_completed(cast(list[Awaitable[Trajectory]], ts)):
+                try:
+                    trajectory = await future
+                    trajectories.append(trajectory)
+                    record_metrics(context, trajectory)
+                    context.update_pbar(n=1)
+                except BaseException as e:
+                    exceptions.append(e)
+                    context.metric_sums["exceptions"] += 1
+                    context.update_pbar(n=0)
+                    if context.too_many_exceptions():
+                        raise
+            return TrajectoryGroup(
+                trajectories=trajectories,
+                exceptions=exceptions,
+            )
+
+        class CoroutineWithMetadata:
+            def __init__(self, coro, num_trajectories):
+                self.coro = coro
+                self._num_trajectories = num_trajectories
+
+            def __await__(self):
+                return self.coro.__await__()
+
+        coro = _(exceptions.copy())
+        return CoroutineWithMetadata(coro, len(ts))
 
     def __new__(
         cls,
-        trajectories: (
-            Iterable[Trajectory | BaseException] | Iterable[Awaitable[Trajectory]]
-        ),
+        trajectories: Iterable[Trajectory | BaseException],
         *,
         exceptions: list[BaseException] = [],
-    ) -> "TrajectoryGroup | Awaitable[TrajectoryGroup]":
-        ts = list(trajectories)
-        if any(hasattr(t, "__await__") for t in ts):
-
-            async def _(exceptions: list[BaseException]):
-                from .gather import get_gather_context, record_metrics
-
-                context = get_gather_context()
-                trajectories = []
-                for future in asyncio.as_completed(
-                    cast(list[Awaitable[Trajectory]], ts)
-                ):
-                    try:
-                        trajectory = await future
-                        trajectories.append(trajectory)
-                        record_metrics(context, trajectory)
-                        context.update_pbar(n=1)
-                    except BaseException as e:
-                        exceptions.append(e)
-                        context.metric_sums["exceptions"] += 1
-                        context.update_pbar(n=0)
-                        if context.too_many_exceptions():
-                            raise
-                return TrajectoryGroup(
-                    trajectories=trajectories,
-                    exceptions=exceptions,
-                )
-
-            class CoroutineWithMetadata:
-                def __init__(self, coro, num_trajectories):
-                    self.coro = coro
-                    self._num_trajectories = num_trajectories
-
-                def __await__(self):
-                    return self.coro.__await__()
-
-            coro = _(exceptions.copy())
-            return CoroutineWithMetadata(coro, len(ts))
-        else:
-            group = super().__new__(cls)
-            group.__init__(
-                trajectories=cast(list[Trajectory | BaseException], ts),
-                exceptions=exceptions,
-            )
-            return group
+    ) -> "TrajectoryGroup":
+        return super().__new__(cls)


### PR DESCRIPTION
This pull request refactors the TrajectoryGroup class to simplify its initialization and remove the need for monkey-patching in the ART CLI. Previously, the TrajectoryGroup class had a complex __new__ method to handle both synchronous and asynchronous creation, which required monkey-patching in the server environment to function correctly. This approach made the code harder to understand and maintain. This refactoring addresses the issue by: - Moving the asynchronous instantiation logic to a new from_awaitables class method. This separates the asynchronous and synchronous creation paths, making the code more explicit and easier to follow. - Simplifying the __new__ and __init__ methods to handle only the standard, synchronous case. - Removing the monkey-patching code from src/art/cli.py, as it is no longer necessary. These changes improve code clarity, maintainability, and eliminate the potential side effects of modifying a class at runtime. The TrajectoryGroup class is now more robust and easier to use in different contexts without workarounds.