### PR TITLE
Remove failing step checks

### DIFF
--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -446,7 +446,9 @@ class LocalBackend(Backend):
         metrics = {f"{split}/{metric}": value for metric, value in metrics.items()}
         step = step if step is not None else self.__get_step(model)
 
-        with open(f"{get_model_dir(model=model, art_path=self._path)}/history.jsonl", "a") as f:
+        with open(
+            f"{get_model_dir(model=model, art_path=self._path)}/history.jsonl", "a"
+        ) as f:
             f.write(
                 json.dumps(
                     {

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -443,11 +443,7 @@ class LocalBackend(Backend):
         step: int | None = None,
     ) -> None:
         metrics = {f"{split}/{metric}": value for metric, value in metrics.items()}
-        step = (
-            step
-            if step is not None
-            else self.__get_step(model)
-        )
+        step = step if step is not None else self.__get_step(model)
 
         # If we have a W&B run, log the data there
         if run := self._get_wandb_run(model):

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -273,7 +273,7 @@ class LocalBackend(Backend):
         os.makedirs(parent_dir, exist_ok=True)
 
         # Get the file name for the current iteration, or default to 0 for non-trainable models
-        iteration = self.__get_step(model) if isinstance(model, TrainableModel) else 0
+        iteration = self.__get_step(model)
         file_name = f"{iteration:04d}.jsonl"
 
         # Write the logs to the file
@@ -446,7 +446,7 @@ class LocalBackend(Backend):
         step = (
             step
             if step is not None
-            else (self.__get_step(model) if isinstance(model, TrainableModel) else 0)
+            else self.__get_step(model)
         )
 
         # If we have a W&B run, log the data there


### PR DESCRIPTION
When serialize we don't include that the model is a trainable one, causing these checks to fail. However, get step works fine even when it's not a trainable model.