### PR TITLE
Fix trajectory group duplication in gather_trajectory_groups

### DIFF
--- a/src/art/gather.py
+++ b/src/art/gather.py
@@ -48,6 +48,7 @@ async def gather_trajectory_groups(
         ae_processed_groups = await asyncio.gather(
             *(after_each(g) for g in processed_groups)
         )
+        processed_groups = []
         for g in ae_processed_groups:
             if g is None:
                 continue


### PR DESCRIPTION
Fixes a bug where the `after_each` callback in `gather_trajectory_groups` was causing group duplication by appending returned groups to the existing processed_groups list.

## Problem
When using `gather_trajectory_groups` with an `after_each` callback, the function was duplicating trajectory groups. The callback would return the same groups it received (possibly after processing), but these returned groups were being appended to the existing `processed_groups` list rather than replacing it.

This resulted in:
- Original groups: 12 (as configured by `groups_per_step`)
- Final groups: 24 (original + callback returned groups)

## Solution
Reset `processed_groups` to an empty list before collecting the `after_each` callback results, ensuring only the callback-returned groups are included in the final output.

## Testing
Verified that model 237 in art-e now correctly shows 12 groups submitted instead of the previous 20-24.