### PR TITLE
fix: set openai library upperbound to 1.99.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "The OpenPipe Agent Reinforcement Training (ART) library"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "openai>=1.65.5",
+    "openai>=1.65.5,<=1.99.1",
     "typer>=0.15.2",
     "litellm>=1.63.0",
     "weave>=0.51.51",

--- a/uv.lock
+++ b/uv.lock
@@ -3547,7 +3547,7 @@ requires-dist = [
     { name = "hf-xet", marker = "extra == 'backend'", specifier = ">=1.1.0" },
     { name = "litellm", specifier = ">=1.63.0" },
     { name = "matplotlib", marker = "extra == 'plotting'", specifier = ">=3.10.1" },
-    { name = "openai", specifier = ">=1.65.5" },
+    { name = "openai", specifier = ">=1.65.5,<=1.99.1" },
     { name = "peft", marker = "extra == 'backend'", specifier = ">=0.14.0" },
     { name = "polars", marker = "extra == 'backend'", specifier = ">=1.26.0" },
     { name = "seaborn", marker = "extra == 'plotting'", specifier = ">=0.13.2" },


### PR DESCRIPTION
With the release of GPT-5, OpenAI seemed to have introduced breaking changes to their oai library. For instance, doing 

`from art.model import Model` 

will lead to 

`cannot import name 'Function' from 'openai.types.chat.chat_completion_message_tool_call'`. 

Setting the upper bound to 1.99.1 fixes the above issue. 