### PR TITLE
Improve SkyPilotBackend

### DIFF
--- a/dev/test_skypilot/launch.py
+++ b/dev/test_skypilot/launch.py
@@ -1,0 +1,24 @@
+"""Training example for MCP agent using rollout with AlphaMcpServer in scenarios."""
+
+import asyncio
+
+from art.skypilot.backend import SkyPilotBackend
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+async def launch():
+    backend = await SkyPilotBackend().initialize_cluster(
+        cluster_name="test_launch",
+        gpu="H100-SXM",
+        env_path=".env",
+        force_restart=True,
+    )
+
+    print("successfully initialized skypilot server")
+
+
+if __name__ == "__main__":
+    asyncio.run(launch())

--- a/dev/test_skypilot/launch.py
+++ b/dev/test_skypilot/launch.py
@@ -2,16 +2,16 @@
 
 import asyncio
 
-from art.skypilot.backend import SkyPilotBackend
 from dotenv import load_dotenv
 
+from art.skypilot.backend import SkyPilotBackend
 
 load_dotenv()
 
 
 async def launch():
     backend = await SkyPilotBackend().initialize_cluster(
-        cluster_name="test_launch",
+        cluster_name="test-skypilot",
         gpu="H100-SXM",
         env_path=".env",
         force_restart=True,

--- a/dev/test_skypilot/launch_tail.py
+++ b/dev/test_skypilot/launch_tail.py
@@ -2,16 +2,16 @@
 
 import asyncio
 
-from art.skypilot.backend import SkyPilotBackend
 from dotenv import load_dotenv
 
+from art.skypilot.backend import SkyPilotBackend
 
 load_dotenv()
 
 
 async def launch_tail():
     backend = await SkyPilotBackend().initialize_cluster(
-        cluster_name="test_launch",
+        cluster_name="test-skypilot",
         gpu="H100-SXM",
         env_path=".env",
         force_restart=True,

--- a/dev/test_skypilot/launch_tail.py
+++ b/dev/test_skypilot/launch_tail.py
@@ -1,0 +1,27 @@
+"""Training example for MCP agent using rollout with AlphaMcpServer in scenarios."""
+
+import asyncio
+
+from art.skypilot.backend import SkyPilotBackend
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+async def launch_tail():
+    backend = await SkyPilotBackend().initialize_cluster(
+        cluster_name="test_launch",
+        gpu="H100-SXM",
+        env_path=".env",
+        force_restart=True,
+        tail_logs=True,
+    )
+    print("successfully initialized skypilot server")
+
+    # unforunately, we can't cancel the task programmatically, so we have to ctrl+c
+    # to exit
+
+
+if __name__ == "__main__":
+    asyncio.run(launch_tail())

--- a/dev/test_skypilot/register_model.py
+++ b/dev/test_skypilot/register_model.py
@@ -2,42 +2,22 @@
 
 import asyncio
 
+from dotenv import load_dotenv
+from pydantic import BaseModel
+
 import art
 from art.skypilot.backend import SkyPilotBackend
-from pydantic import BaseModel
-from dotenv import load_dotenv
-
 
 load_dotenv()
 
 
-class McpPolicyConfig(BaseModel):
+class ComplexModelConfig(BaseModel):
     max_turns: int = 5
     max_tokens: int = 2048
 
     base_model: str = "Qwen/Qwen2.5-14B-Instruct"
-
-    # MCP server configuration
-    smithery_mcp_url: str = "asdf"
-
-    # Training configuration fields
-    trajectories_per_group: int = 7
-    groups_per_step: int = 4
-    learning_rate: float = 1e-6
-    eval_steps: int = 1
-    val_set_size: int = 8
-    training_dataset_size: int = 16
-    num_epochs: int = 80
-    # Model name to use for RULER rescoring (LLM-as-a-judge)
-    ruler_judge_model: str = "openrouter/openai/o4-mini"
-    minimum_reward_std_dev: float = 0.0
     # Random seed to control which subset of the training data is sampled
     training_dataset_seed: int | None = None
-
-    # Fork configuration
-    fork_from_model: str | None = None
-    fork_from_project: str | None = None
-    fork_not_after_step: int | None = None
 
     # Training configuration
     scale_rewards: bool = True
@@ -45,26 +25,18 @@ class McpPolicyConfig(BaseModel):
 
 async def register_model():
     backend = await SkyPilotBackend().initialize_cluster(
-        cluster_name="test_launch",
+        cluster_name="test-skypilot",
         gpu="H100-SXM",
         env_path=".env",
         # force_restart=True,
     )
 
     model = art.TrainableModel(
-        name="mcp-nws-14b-001",
-        project="mcp-smithery",
+        name="complex-model",
+        project="test-skypilot",
         base_model="Qwen/Qwen2.5-14B-Instruct",
-        # _internal_config=art.dev.InternalModelConfig(
-        #     init_args=art.dev.InitArgs(
-        #         max_seq_length=16384,
-        #     ),
-        # ),
-        config=McpPolicyConfig(
+        config=ComplexModelConfig(
             num_epochs=160,
-            smithery_mcp_url="asdf",
-            # trajectories_per_group=2,
-            # groups_per_step=1,
         ),
     )
 

--- a/dev/test_skypilot/register_model.py
+++ b/dev/test_skypilot/register_model.py
@@ -1,0 +1,77 @@
+"""Training example for MCP agent using rollout with AlphaMcpServer in scenarios."""
+
+import asyncio
+
+import art
+from art.skypilot.backend import SkyPilotBackend
+from pydantic import BaseModel
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+class McpPolicyConfig(BaseModel):
+    max_turns: int = 5
+    max_tokens: int = 2048
+
+    base_model: str = "Qwen/Qwen2.5-14B-Instruct"
+
+    # MCP server configuration
+    smithery_mcp_url: str = "asdf"
+
+    # Training configuration fields
+    trajectories_per_group: int = 7
+    groups_per_step: int = 4
+    learning_rate: float = 1e-6
+    eval_steps: int = 1
+    val_set_size: int = 8
+    training_dataset_size: int = 16
+    num_epochs: int = 80
+    # Model name to use for RULER rescoring (LLM-as-a-judge)
+    ruler_judge_model: str = "openrouter/openai/o4-mini"
+    minimum_reward_std_dev: float = 0.0
+    # Random seed to control which subset of the training data is sampled
+    training_dataset_seed: int | None = None
+
+    # Fork configuration
+    fork_from_model: str | None = None
+    fork_from_project: str | None = None
+    fork_not_after_step: int | None = None
+
+    # Training configuration
+    scale_rewards: bool = True
+
+
+async def register_model():
+    backend = await SkyPilotBackend().initialize_cluster(
+        cluster_name="test_launch",
+        gpu="H100-SXM",
+        env_path=".env",
+        # force_restart=True,
+    )
+
+    model = art.TrainableModel(
+        name="mcp-nws-14b-001",
+        project="mcp-smithery",
+        base_model="Qwen/Qwen2.5-14B-Instruct",
+        # _internal_config=art.dev.InternalModelConfig(
+        #     init_args=art.dev.InitArgs(
+        #         max_seq_length=16384,
+        #     ),
+        # ),
+        config=McpPolicyConfig(
+            num_epochs=160,
+            smithery_mcp_url="asdf",
+            # trajectories_per_group=2,
+            # groups_per_step=1,
+        ),
+    )
+
+    await backend.register(model)
+
+    print("model registered")
+
+
+if __name__ == "__main__":
+    asyncio.run(register_model())

--- a/src/art/backend.py
+++ b/src/art/backend.py
@@ -41,11 +41,11 @@ class Backend:
         Args:
             model: An art.Model instance.
         """
-        response = await self._client.post("/register", json=model.model_dump())
+        response = await self._client.post("/register", json=model.safe_model_dump())
         response.raise_for_status()
 
     async def _get_step(self, model: "TrainableModel") -> int:
-        response = await self._client.post("/_get_step", json=model.model_dump())
+        response = await self._client.post("/_get_step", json=model.safe_model_dump())
         response.raise_for_status()
         return response.json()
 
@@ -57,7 +57,7 @@ class Backend:
     ) -> None:
         response = await self._client.post(
             "/_delete_checkpoints",
-            json=model.model_dump(),
+            json=model.safe_model_dump(),
             params={"benchmark": benchmark, "benchmark_smoothing": benchmark_smoothing},
         )
         response.raise_for_status()
@@ -69,7 +69,7 @@ class Backend:
     ) -> tuple[str, str]:
         response = await self._client.post(
             "/_prepare_backend_for_training",
-            json={"model": model.model_dump(), "config": config},
+            json={"model": model.safe_model_dump(), "config": config},
             timeout=600,
         )
         response.raise_for_status()
@@ -85,7 +85,7 @@ class Backend:
         response = await self._client.post(
             "/_log",
             json={
-                "model": model.model_dump(),
+                "model": model.safe_model_dump(),
                 "trajectory_groups": [tg.model_dump() for tg in trajectory_groups],
                 "split": split,
             },
@@ -105,7 +105,7 @@ class Backend:
             "POST",
             "/_train_model",
             json={
-                "model": model.model_dump(),
+                "model": model.safe_model_dump(),
                 "trajectory_groups": [tg.model_dump() for tg in trajectory_groups],
                 "config": config.model_dump(),
                 "dev_config": dev_config,
@@ -150,7 +150,7 @@ class Backend:
         response = await self._client.post(
             "/_experimental_pull_from_s3",
             json={
-                "model": model.model_dump(),
+                "model": model.safe_model_dump(),
                 "s3_bucket": s3_bucket,
                 "prefix": prefix,
                 "verbose": verbose,
@@ -175,7 +175,7 @@ class Backend:
         response = await self._client.post(
             "/_experimental_push_to_s3",
             json={
-                "model": model.model_dump(),
+                "model": model.safe_model_dump(),
                 "s3_bucket": s3_bucket,
                 "prefix": prefix,
                 "verbose": verbose,
@@ -212,7 +212,7 @@ class Backend:
         response = await self._client.post(
             "/_experimental_fork_checkpoint",
             json={
-                "model": model.model_dump(),
+                "model": model.safe_model_dump(),
                 "from_model": from_model,
                 "from_project": from_project,
                 "from_s3_bucket": from_s3_bucket,
@@ -246,7 +246,7 @@ class Backend:
             "/_experimental_deploy",
             json={
                 "deploy_to": deploy_to,
-                "model": model.model_dump(),
+                "model": model.safe_model_dump(),
                 "step": step,
                 "s3_bucket": s3_bucket,
                 "prefix": prefix,

--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -1,6 +1,6 @@
 import json
 import socket
-from typing import Any, AsyncIterator, Union
+from typing import Any, AsyncIterator
 
 import pydantic
 import typer
@@ -13,6 +13,7 @@ from . import dev
 from .errors import ARTError
 from .local import LocalBackend
 from .model import Model, TrainableModel
+
 from .trajectories import TrajectoryGroup
 from .types import TrainConfig
 from .utils.deploy_model import LoRADeploymentProvider
@@ -62,8 +63,7 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
 
     @app.post("/register")
     async def register(
-        # Ensure that trainable models are serialzed as TrainableModel, not Model
-        model: Union[TrainableModel, Model] = Body(...),
+        model: Model = Body(...),
     ):
         await backend.register(model)
 
@@ -76,7 +76,7 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
 
     @app.post("/_log")
     async def _log(
-        model: Union[TrainableModel, Model],
+        model: Model,
         trajectory_groups: list[TrajectoryGroup],
         split: str = Body("val"),
     ):
@@ -102,7 +102,7 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
     # all parameters as body parameters
     @app.post("/_experimental_pull_from_s3")
     async def _experimental_pull_from_s3(
-        model: Union[TrainableModel, Model] = Body(...),
+        model: Model = Body(...),
         s3_bucket: str | None = Body(None),
         prefix: str | None = Body(None),
         verbose: bool = Body(False),
@@ -118,7 +118,7 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
 
     @app.post("/_experimental_push_to_s3")
     async def _experimental_push_to_s3(
-        model: Union[TrainableModel, Model] = Body(...),
+        model: Model = Body(...),
         s3_bucket: str | None = Body(None),
         prefix: str | None = Body(None),
         verbose: bool = Body(False),

--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncIterator
 import pydantic
 import typer
 import uvicorn
+from dotenv import load_dotenv
 from fastapi import Body, FastAPI, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
@@ -15,6 +16,8 @@ from .model import Model, TrainableModel
 from .trajectories import TrajectoryGroup
 from .types import TrainConfig
 from .utils.deploy_model import LoRADeploymentProvider
+
+load_dotenv()
 
 app = typer.Typer()
 

--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -13,7 +13,6 @@ from . import dev
 from .errors import ARTError
 from .local import LocalBackend
 from .model import Model, TrainableModel
-
 from .trajectories import TrajectoryGroup
 from .types import TrainConfig
 from .utils.deploy_model import LoRADeploymentProvider

--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -57,14 +57,9 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
 
     app.get("/healthcheck")(lambda: {"status": "ok"})
     app.post("/close")(backend.close)
+    app.post("/register")(backend.register)
     app.post("/_get_step")(backend._get_step)
     app.post("/_delete_checkpoints")(backend._delete_checkpoints)
-
-    @app.post("/register")
-    async def register(
-        model: Model = Body(...),
-    ):
-        await backend.register(model)
 
     @app.post("/_prepare_backend_for_training")
     async def _prepare_backend_for_training(

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -121,7 +121,7 @@ class LocalBackend(Backend):
             json.dump(model.model_dump(), f)
 
         # Initialize wandb and weave early if this is a trainable model
-        if isinstance(model, TrainableModel) and "WANDB_API_KEY" in os.environ:
+        if model.trainable and "WANDB_API_KEY" in os.environ:
             _ = self._get_wandb_run(model)
 
     async def _get_service(self, model: TrainableModel) -> ModelService:
@@ -230,7 +230,8 @@ class LocalBackend(Backend):
         return self.__get_step(model)
 
     def __get_step(self, model: Model) -> int:
-        if isinstance(model, TrainableModel):
+        if model.trainable:
+            model = cast(TrainableModel, model)
             return get_model_step(model, self._path)
         # Non-trainable models do not have checkpoints/steps; default to 0
         return 0

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -128,7 +128,7 @@ class Model(
         """
         data = super().model_dump(*args, **kwargs)
         # remove config from dumped_model to prevent serialization errors
-        data.pop("config")
+        data["config"] = None
         return data
 
     @property
@@ -310,7 +310,7 @@ class TrainableModel(Model[ModelConfig], Generic[ModelConfig]):
         """
         data = self.model_dump(*args, **kwargs)
         # remove config from dumped_model to prevent serialization errors
-        data.pop("config")
+        data["config"] = None
         return data
 
     @property

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -122,6 +122,15 @@ class Model(
     ) -> "Model[ModelConfig] | Model[None]":
         return super().__new__(cls)
 
+    def safe_model_dump(self, *args, **kwargs) -> dict:
+        """
+        Dump the model, but remove the config field to prevent serialization errors in the backend.
+        """
+        data = super().model_dump(*args, **kwargs)
+        # remove config from dumped_model to prevent serialization errors
+        data.pop("config")
+        return data
+
     @property
     def trainable(self) -> bool:
         return False

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -295,6 +295,15 @@ class TrainableModel(Model[ModelConfig], Generic[ModelConfig]):
         data["_internal_config"] = self._internal_config
         return data
 
+    def safe_model_dump(self, *args, **kwargs) -> dict:
+        """
+        Dump the model, but remove the config field to prevent serialization errors in the backend.
+        """
+        data = self.model_dump(*args, **kwargs)
+        # remove config from dumped_model to prevent serialization errors
+        data.pop("config")
+        return data
+
     @property
     def trainable(self) -> bool:
         return True

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -56,6 +56,8 @@ class Model(
     name: str
     project: str
     config: ModelConfig
+    # Discriminator field for FastAPI serialization
+    trainable: bool = False
 
     # --- Inference connection information (populated automatically for
     #     TrainableModel or set manually for prompted / comparison models) ---
@@ -131,9 +133,6 @@ class Model(
         data["config"] = None
         return data
 
-    @property
-    def trainable(self) -> bool:
-        return False
 
     def backend(self) -> "Backend":
         if self._backend is None:
@@ -244,6 +243,8 @@ class Model(
 
 class TrainableModel(Model[ModelConfig], Generic[ModelConfig]):
     base_model: str
+    # Override discriminator field for FastAPI serialization
+    trainable: bool = True
 
     # The fields within `_internal_config` are unstable and subject to change.
     # Use at your own risk.
@@ -313,9 +314,6 @@ class TrainableModel(Model[ModelConfig], Generic[ModelConfig]):
         data["config"] = None
         return data
 
-    @property
-    def trainable(self) -> bool:
-        return True
 
     async def register(
         self,

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -133,7 +133,6 @@ class Model(
         data["config"] = None
         return data
 
-
     def backend(self) -> "Backend":
         if self._backend is None:
             raise ValueError(
@@ -313,7 +312,6 @@ class TrainableModel(Model[ModelConfig], Generic[ModelConfig]):
         # remove config from dumped_model to prevent serialization errors
         data["config"] = None
         return data
-
 
     async def register(
         self,

--- a/src/art/skypilot/backend.py
+++ b/src/art/skypilot/backend.py
@@ -37,6 +37,7 @@ class SkyPilotBackend(Backend):
         art_version: str | None = None,
         env_path: str | None = None,
         force_restart: bool = False,
+        tail_logs: bool = True,
     ) -> "SkyPilotBackend":
         self = cls.__new__(cls)
         self._cluster_name = cluster_name
@@ -146,14 +147,15 @@ class SkyPilotBackend(Backend):
         # Manually call the real __init__ now that base_url is ready
         super(cls, self).__init__(base_url=base_url)
 
-        if self._art_server_job_id is not None:
-            asyncio.create_task(
-                asyncio.to_thread(
-                    sky.tail_logs,
-                    cluster_name=self._cluster_name,
-                    job_id=self._art_server_job_id,
-                    follow=True,
-                )
+        if self._art_server_job_id is not None and tail_logs:
+            await asyncio.to_thread(
+                sky.tail_logs,
+                cluster_name=self._cluster_name,
+                job_id=self._art_server_job_id,
+                follow=True,
+            )
+            print(
+                "Tailing logs. This process will only automatically exit after the backend is down. To exit before then, you'll have to manually close the process (e.g. ctrl+C)."
             )
         return self
 


### PR DESCRIPTION
### Changes
* Add skypilot test functions in `dev/test_skypilot`
* Add `safe_model_dump` function without `config` object, use when sending model to backend (avoid serialization issue for complex configs)
* Make log tailing optional to avoid client-side error swallowing
* Add `trainable` field to Model and use it to determine if model is trainable
  * Previous model property was not serialized and passed from SkyPilotBackend to LocalBackend, so `isinstance(model, TrainableModel)` returned false for trainable models when using SkyPilotBackend