### PR TITLE
Add GitHub Action to prevent manual version bumps in PRs

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -1,0 +1,44 @@
+name: Check Version Bump
+
+on:
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Check if version was changed
+        run: |
+          # Get the version from main branch
+          git checkout origin/main -- pyproject.toml
+          MAIN_VERSION=$(grep '^version = ' pyproject.toml | cut -d '"' -f 2)
+          
+          # Get the version from PR branch  
+          git checkout HEAD -- pyproject.toml
+          PR_VERSION=$(grep '^version = ' pyproject.toml | cut -d '"' -f 2)
+          
+          echo "Main branch version: $MAIN_VERSION"
+          echo "PR branch version: $PR_VERSION"
+          
+          if [ "$MAIN_VERSION" != "$PR_VERSION" ]; then
+            echo "❌ Version change detected in PR!"
+            echo ""
+            echo "Please do not manually bump the version in pull requests."
+            echo ""
+            echo "To create a release:"
+            echo "1. Use the GitHub workflow: gh workflow run create-draft-release.yml --field version_type=patch"
+            echo "2. Or go to: https://github.com/OpenPipe/ART/actions/workflows/create-draft-release.yml"
+            echo "3. Choose the version bump type (patch/minor/major)"
+            echo ""
+            echo "This will create a proper release PR with updated changelog."
+            exit 1
+          fi
+          
+          echo "✅ No version changes detected - check passed!"


### PR DESCRIPTION
This PR adds a GitHub Action workflow that prevents contributors from manually bumping the version in regular pull requests.

## What it does:
- ✅ Runs on PRs that modify `pyproject.toml`
- ✅ Skips release PRs (branches starting with `release/`)
- ✅ Fails with clear instructions if version was manually changed
- ✅ Guides contributors to use the proper release workflow

## Benefits:
- Enforces consistent release process
- Prevents accidental version conflicts  
- Educates contributors on proper release workflow
- Reduces maintenance overhead

The workflow provides clear instructions to use:
```bash
gh workflow run create-draft-release.yml --field version_type=patch
```

Or the GitHub Actions web interface at: https://github.com/OpenPipe/ART/actions/workflows/create-draft-release.yml