### PR TITLE
`LocalBackend._monitor_openai_server` improvement

### DIFF
--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -315,11 +315,11 @@ class LocalBackend(Backend):
                 if running_requests == 0 and pending_requests == 0:
                     try:
                         # Send a health check with a 5 second timeout
-                        await openai_client.completions.create(
+                        timeout = float(os.environ.get("ART_SERVER_MONITOR_TIMEOUT", 5.0))
+                        # Send a health check with a 5 second timeout
+                        await openai_client.models.retrieve(
                             model=model_name,
-                            prompt="Hi",
-                            max_tokens=1,
-                            timeout=5,
+                            timeout=timeout,
                         )
                     except Exception as e:
                         # If the server is sleeping, a failed health check is okay

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -315,7 +315,9 @@ class LocalBackend(Backend):
                 if running_requests == 0 and pending_requests == 0:
                     try:
                         # Send a health check with a 5 second timeout
-                        timeout = float(os.environ.get("ART_SERVER_MONITOR_TIMEOUT", 5.0))
+                        timeout = float(
+                            os.environ.get("ART_SERVER_MONITOR_TIMEOUT", 5.0)
+                        )
                         # Send a health check with a 5 second timeout
                         await openai_client.models.retrieve(
                             model=model_name,


### PR DESCRIPTION
- Do not add additional load the server while performing health-check by sending inference requests; rather check if the actual model is loaded on the server via `openai_client.models.retrieve`
- added configurable timeout for the health check via env variable `"ART_SERVER_MONITOR_TIMEOUT"`