### PR TITLE
feat(backend): add exclude option to pull_from_s3 for selective directory sync

### DIFF
--- a/src/art/backend.py
+++ b/src/art/backend.py
@@ -140,12 +140,14 @@ class Backend:
         verbose: bool = False,
         delete: bool = False,
         only_step: int | Literal["latest"] | None = None,
+        exclude: list[Literal["checkpoints", "logs", "trajectories"]] | None = None,
     ) -> None:
         """Download the model directory from S3 into file system where the LocalBackend is running. Right now this can be used to pull trajectory logs for processing or model checkpoints.
 
         Args:
             only_step: If specified, only pull this specific step. Can be an int for a specific step,
                       or "latest" to pull only the latest checkpoint. If None, pulls all steps.
+            exclude: List of directories to exclude from sync. Valid options: "checkpoints", "logs", "trajectories".
         """
         response = await self._client.post(
             "/_experimental_pull_from_s3",
@@ -156,6 +158,7 @@ class Backend:
                 "verbose": verbose,
                 "delete": delete,
                 "only_step": only_step,
+                "exclude": exclude,
             },
             timeout=600,
         )

--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -1,6 +1,6 @@
 import json
 import socket
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Literal
 
 import pydantic
 import typer
@@ -101,6 +101,8 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
         prefix: str | None = Body(None),
         verbose: bool = Body(False),
         delete: bool = Body(False),
+        only_step: int | Literal["latest"] | None = Body(None),
+        exclude: list[Literal["checkpoints", "logs", "trajectories"]] | None = Body(None),
     ):
         await backend._experimental_pull_from_s3(
             model=model,
@@ -108,6 +110,8 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
             prefix=prefix,
             verbose=verbose,
             delete=delete,
+            only_step=only_step,
+            exclude=exclude,
         )
 
     @app.post("/_experimental_push_to_s3")


### PR DESCRIPTION
- Add exclude parameter to Backend._experimental_pull_from_s3 to skip specified dirs
- Supported exclude values: checkpoints, logs, trajectories
- Update API to accept exclude list and forward it to backend method
- Enhance CLI endpoint to pass exclude option when pulling from S3
- Document exclude usage in method docstring with valid options listed
- Maintain backward compatibility with default None exclude behavior

solves #350 