### PR TITLE
Upgrade SkyPilot to 0.10.3.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ backend = [
 
 skypilot = [
     "semver>=3.0.4",
-    "skypilot[cudo,do,fluidstack,gcp,lambda,kubernetes,paperspace,runpod]==0.10.2",
+    "skypilot[cudo,do,fluidstack,gcp,lambda,kubernetes,paperspace,runpod]==0.10.3.post1",
 ]
 
 langgraph = [

--- a/uv.lock
+++ b/uv.lock
@@ -179,6 +179,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload-time = "2025-02-03T07:30:13.6Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.16.5"
 source = { registry = "https://pypi.org/simple" }
@@ -4218,7 +4230,7 @@ requires-dist = [
     { name = "semver", marker = "extra == 'skypilot'", specifier = ">=3.0.4" },
     { name = "setproctitle", marker = "extra == 'backend'", specifier = ">=1.3.6" },
     { name = "setuptools", marker = "extra == 'backend'", specifier = ">=78.1.0" },
-    { name = "skypilot", extras = ["cudo", "do", "fluidstack", "gcp", "lambda", "kubernetes", "paperspace", "runpod"], marker = "extra == 'skypilot'", specifier = "==0.10.2" },
+    { name = "skypilot", extras = ["cudo", "do", "fluidstack", "gcp", "lambda", "kubernetes", "paperspace", "runpod"], marker = "extra == 'skypilot'", specifier = "==0.10.3.post1" },
     { name = "tblib", marker = "extra == 'backend'", specifier = ">=3.0.0" },
     { name = "torch", marker = "extra == 'backend'", specifier = ">=2.7.0" },
     { name = "torchao", marker = "extra == 'backend'", specifier = ">=0.9.0" },
@@ -4716,6 +4728,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170, upload-time = "2025-07-01T09:16:23.762Z" },
     { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505, upload-time = "2025-07-01T09:16:25.593Z" },
     { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598, upload-time = "2025-07-01T09:16:27.732Z" },
+]
+
+[[package]]
+name = "pip"
+version = "25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/16/650289cd3f43d5a2fadfd98c68bd1e1e7f2550a1a5326768cddfbcedb2c5/pip-25.2.tar.gz", hash = "sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2", size = 1840021, upload-time = "2025-07-30T21:50:15.401Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/3f/945ef7ab14dc4f9d7f40288d2df998d1837ee0888ec3659c813487572faa/pip-25.2-py3-none-any.whl", hash = "sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717", size = 1752557, upload-time = "2025-07-30T21:50:13.323Z" },
 ]
 
 [[package]]
@@ -6805,12 +6826,15 @@ wheels = [
 
 [[package]]
 name = "skypilot"
-version = "0.10.2"
+version = "0.10.3.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
+    { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "anyio" },
+    { name = "bcrypt" },
     { name = "cachetools" },
     { name = "casbin" },
     { name = "click" },
@@ -6828,6 +6852,7 @@ dependencies = [
     { name = "pandas" },
     { name = "passlib" },
     { name = "pendulum" },
+    { name = "pip" },
     { name = "prettytable" },
     { name = "prometheus-client" },
     { name = "psutil" },
@@ -6841,6 +6866,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "setproctitle" },
+    { name = "setuptools" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-adapter" },
     { name = "tabulate" },
@@ -6849,9 +6875,9 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
     { name = "wheel" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/91/f1e4a34653c2403c5c3190b5e23cc63f04767973817997f073ae5800cd83/skypilot-0.10.2.tar.gz", hash = "sha256:d881fab16b8c49f80299198de06744f8c881a4555e136dd9b676a9f00aa445b9", size = 2452110, upload-time = "2025-08-27T07:54:15.297Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/93/d57715ae5da799daaf9a6ff17536ad21d5bb8aba78ce83ab3de78de782da/skypilot-0.10.3.post1.tar.gz", hash = "sha256:49ac2bc69c024e52bc47bd1247211b19dd305f0b7d5f576dedd6fe67f90d6905", size = 2482952, upload-time = "2025-09-22T19:53:56.144Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/48/83a41abebeab0d15fe2535926c9d0d9edc3ffe04b1691c98fc11f62d26e6/skypilot-0.10.2-py3-none-any.whl", hash = "sha256:74d4177f65b78404ddae206fd374003d51d8b322ecc7a41fee85931a88be5311", size = 2687022, upload-time = "2025-08-27T07:54:13.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/69/7fd4d35e88a67fa8a521927909907fcaf8ebda5c2812837778e549bddb20/skypilot-0.10.3.post1-py3-none-any.whl", hash = "sha256:902b7387ad202c9d88b6553f768f075a066c9391b488b32e4efd0405b6971c15", size = 2714888, upload-time = "2025-09-22T19:53:54.602Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Upgrades SkyPilot from 0.10.2 to 0.10.3.post1

## Testing
- ✅ Tested with SkyPilot API for launching training jobs on Kubernetes
- ⚠️ SkypilotBackend not tested, but no breaking changes listed in the 0.10.x changelog that would affect ART

## Notes
No breaking changes affecting ART according to the [0.10.x release notes](https://github.com/skypilot-org/skypilot/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)