### PR TITLE
feat: Add placeholder _log() implementation for ServerlessBackend

### DIFF
--- a/src/art/serverless/backend.py
+++ b/src/art/serverless/backend.py
@@ -84,7 +84,27 @@ class ServerlessBackend(Backend):
         trajectory_groups: list[TrajectoryGroup],
         split: str = "val",
     ) -> None:
-        raise NotImplementedError
+        # TODO: Implement proper serverless logging via API
+        # For now, write to local jsonl file as a placeholder
+        import os
+        from pathlib import Path
+
+        from ..utils.trajectory_logging import serialize_trajectory_groups
+
+        # Create log directory (configurable via env var)
+        log_base = os.getenv("ART_SERVERLESS_LOG_DIR", "/tmp/serverless-training-logs")
+        log_dir = Path(log_base) / model.name / split
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Get current step
+        step = await model.get_step()
+        file_path = log_dir / f"{step:04d}.jsonl"
+
+        # Write trajectory groups to jsonl
+        with open(file_path, "w") as f:
+            f.write(serialize_trajectory_groups(trajectory_groups))
+
+        print(f"[ServerlessBackend] Logged {len(trajectory_groups)} groups to {file_path}")
 
     async def _train_model(
         self,


### PR DESCRIPTION
Implements a local file-based placeholder for ServerlessBackend._log() to unblock usage of ServerlessBackend with code that calls model.log().

Changes:
- Writes trajectory groups to local JSONL files using same format as LocalBackend
- Uses /tmp/serverless-training-logs by default (configurable via ART_SERVERLESS_LOG_DIR)
- Organizes logs by model name, split, and step number
- Marked with TODO for future proper serverless API implementation

This allows ServerlessBackend to be used immediately while proper remote logging is being developed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)