### PR TITLE
Add client-side error capturing

### DIFF
--- a/src/art/client.py
+++ b/src/art/client.py
@@ -291,7 +291,7 @@ class TrainingJobs(AsyncAPIResource):
 
 class TrainingJobEvent(BaseModel):
     id: str
-    type: Literal["training_started", "gradient_step", "training_ended"]
+    type: Literal["training_started", "gradient_step", "training_ended", "training_failed"]
     data: dict[str, Any]
 
 

--- a/src/art/serverless/backend.py
+++ b/src/art/serverless/backend.py
@@ -156,6 +156,9 @@ class ServerlessBackend(Backend):
                     continue
                 elif event.type == "training_ended":
                     return
+                elif event.type == "training_failed":
+                    error_message = event.data.get("error_message", "Training failed with an unknown error")
+                    raise RuntimeError(f"Training job failed: {error_message}")
                 after = event.id
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Fixed an issue where failed serverless training jobs would never report a failure to the client.
Errors are now thrown and logged to the console.