### PR TITLE
ENH: Improve assertion error message for content type

### DIFF
--- a/src/art/preprocessing/tokenize.py
+++ b/src/art/preprocessing/tokenize.py
@@ -192,7 +192,9 @@ def tokenize_trajectory(
         end = start + 1
         if isinstance(message, dict):
             content = message.get("content")
-            assert isinstance(content, str)
+            assert isinstance(content, str), (
+                "Trajectories must have a 'content' field of type str"
+            )
             content_token_ids = tokenizer.encode(
                 content,
                 add_special_tokens=False,


### PR DESCRIPTION
Enhance assertion for content type in message dictionary.

Came across this when testing this out with a tool-call and the assertion / why it was failing was not obvious