### PR TITLE
fix: Handle RULER rewards when all trajectories are identical

### DIFF
--- a/src/art/rewards/ruler.py
+++ b/src/art/rewards/ruler.py
@@ -39,7 +39,7 @@ class Response(BaseModel):
 
 
 DEFAULT_RUBRIC = dedent(
-    """         
+    """
         - A trajectory that achieves its goal should always get a significantly higher score than a trajectory that does not achieve its goal.
         - A trajectory that achieves its goal more efficiently (eg. by avoiding unproductive detours) should get a higher score than a trajectory that achieves its goal less efficiently.
         - If one trajectory is only slightly better than another, the difference in scores should be small. If it is significantly better, the difference in scores should be large.


### PR DESCRIPTION
Due to the way we efficiently deal with common substring, there is an edge case where RULER would send empty trajectories to the judge when all trajectories in a group were identical. This caused scores of 0 for that group, which while it doesn't affect the advantage, might be alarming. 

This PR detects this edge case and sends only 1 trajectory to the judge and duplicates the result to all trajectories. We still end up having the same score across all trajectories, just now it's a number chosen between 0-1 by the judge.

To test this case:
```python
    message_lists = [
        [
            {"role": "system", "content": "You are helpful."},
            {"role": "user", "content": "What is 2+2?"},
            {"role": "assistant", "content": "4"},
        ],
        [
            {"role": "system", "content": "You are helpful."},
            {"role": "user", "content": "What is 2+2?"},
            {"role": "assistant", "content": "4"},
        ],
    ]
    scores = await ruler(message_lists, debug=True)
```