### PR TITLE
fix: add --system flag to uv pip install for SkyPilot backend

### DIFF
--- a/src/art/skypilot/backend.py
+++ b/src/art/skypilot/backend.py
@@ -192,7 +192,7 @@ class SkyPilotBackend(Backend):
 
         if art_version_is_semver:
             art_installation_command = (
-                f"uv pip install openpipe-art[backend]=={art_version}"
+                f"uv pip install --system openpipe-art[backend]=={art_version}"
             )
         elif os.path.exists(art_version):
             # copy the contents of the art_path onto the new machine


### PR DESCRIPTION
Fixes setup failure on SkyPilot clusters with uv >= 0.8.18.

Root cause:
- uv 0.8.18+ changed behavior to require either a virtual environment or explicit --system flag for pip install operations
- SkyPilot backend setup runs: uv pip install openpipe-art[backend]
- This fails with: "error: No virtual environment found; run \`uv venv\`"

Solution:
Add --system flag to install into system Python (miniconda3 on cluster).

Related issue: https://github.com/OpenPipe/ART/issues/416
- User reported same error after uv 0.8.18 release
- Workarounds discussed: pin uv to 0.8.17 or use --system flag
- This implements the --system flag approach

Testing:
- Tested on GCP
- openpipe-art==0.5.2
- 233 packages installed successfully

Alternative considered: Pinning uv version in install script, but --system is cleaner and works with any uv version.