### PR TITLE
feat: set vLLM engine_args defaults for gpu_memory_utilization

### DIFF
--- a/src/art/dev/get_model_config.py
+++ b/src/art/dev/get_model_config.py
@@ -38,6 +38,11 @@ def get_model_config(
         disable_log_requests=True,
         enable_sleep_mode=enable_sleep_mode,
         generation_config="vllm",
+        # Tie vLLM context/gpu utilization defaults to Unsloth init args to avoid
+        # zeroed KV cache calculations on large cards (e.g., H100) when defaults
+        # are missing.
+        gpu_memory_utilization=init_args["gpu_memory_utilization"],  # type: ignore
+        max_model_len=init_args["max_seq_length"],  # type: ignore
     )
     engine_args.update(config.get("engine_args", {}))
     init_args.update(config.get("init_args", {}))


### PR DESCRIPTION
• Summary

Issue: #472 
- Prevent vLLM from computing a zero KV-cache budget by aligning engine defaults with Unsloth init defaults.
- Set gpu_memory_utilization and max_model_len in engine_args to the corresponding Unsloth init_args values so large-GPU setups don’t stall.

Motivation

- Training with Qwen2.5-14B + Unsloth/vLLM on H100 was stalling at 0/steps; logs showed “vLLM’s KV Cache can use up to 0.0 GB” despite ample VRAM. Missing engine defaults led vLLM to size the cache to zero.

Details

- In get_model_config, initialize vLLM engine_args with:
    - gpu_memory_utilization = init_args["gpu_memory_utilization"]
    - max_model_len = init_args["max_seq_length"]
- Still allow user overrides via _internal_config["engine_args"].