### PR TITLE
feat: add multi-GPU–friendly default for vLLM/Unsloth engine setup

### DIFF
--- a/src/art/dev/get_model_config.py
+++ b/src/art/dev/get_model_config.py
@@ -38,6 +38,10 @@ def get_model_config(
         disable_log_requests=True,
         enable_sleep_mode=enable_sleep_mode,
         generation_config="vllm",
+        # Default tensor parallel to visible GPU count (respects CUDA_VISIBLE_DEVICES)
+        tensor_parallel_size=(
+            torch.cuda.device_count() if torch.cuda.is_available() else 1
+        ),
     )
     engine_args.update(config.get("engine_args", {}))
     init_args.update(config.get("init_args", {}))


### PR DESCRIPTION
• Summary

- Default vLLM/Unsloth tensor_parallel_size to the number of visible GPUs (respects CUDA_VISIBLE_DEVICES) so multi-GPU setups don’t start with an unset/invalid TP world size.
- Still allows explicit overrides via _internal_config["engine_args"].

  Motivation

- On multi-GPU H100 machines, vLLM was crashing during init when TP wasn’t configured; setting a sensible default prevents a TP=0/None startup.

  Details

- In get_model_config, set engine_args["tensor_parallel_size"] = torch.cuda.device_count() (or 1 if CUDA unavailable) before merging user overrides.