### PR TITLE
Deploy to model name + " (deployment)"

### DIFF
--- a/src/art/utils/deployment/wandb.py
+++ b/src/art/utils/deployment/wandb.py
@@ -68,6 +68,7 @@ def deploy_wandb(
         print(f"Uploading checkpoint from {checkpoint_path} to W&B...")
 
     run = wandb.init(
+        name=model.name + " (deployment)",
         entity=model.entity,
         project=model.project,
         settings=wandb.Settings(api_key=os.environ["WANDB_API_KEY"]),


### PR DESCRIPTION
Instead of a random name being associated with the run that a W&B model is deployed to, we're now naming these ephemeral runs `model.name + (deployment)`.

It would be even better if we could somehow deploy the artifact as part of the run that recorded its metrics, but not the highest priority.