### PR TITLE
fix: Pin vLLM to 0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ backend = [
     "bitsandbytes>=0.45.2",
     "unsloth==2025.12.9",
     "unsloth-zoo==2025.12.7",
-    "vllm>=0.11.0",
+    "vllm==0.13.0",
     "torchtune",
     "torch>=2.8.0",
     "torchao==0.14.1",


### PR DESCRIPTION
Pin vLLM to `0.13.0` (was `>=0.11.0`)

With `vllm>=0.11.0`, `uv` dependency resolution can install vLLM 0.11.0 which causes an import error:

`ModuleNotFoundError: No module named 'vllm.utils.argparse_utils'`. This error happens because the module is only present in vLLM 0.12.0 and above.