### PR TITLE
fix: Bump minimum openai version to 2.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "The OpenPipe Agent Reinforcement Training (ART) library"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "openai>=1.65.5",
+    "openai>=2.14.0",
     "typer>=0.15.2",
     "litellm==1.74.1",
     "weave>=0.51.51",


### PR DESCRIPTION
The `ChatCompletionMessageFunctionToolCall` type used in `src/art/openai.py` was introduced in openai 1.99.2. Without this constraint, users may get openai 1.99.1 or earlier which lacks this module, causing an ImportError on import.