### PR TITLE
Update wandb and weave

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openpipe-art"
-version = "0.5.7"
+version = "0.5.8"
 description = "The OpenPipe Agent Reinforcement Training (ART) library"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -5083,7 +5083,7 @@ wheels = [
 
 [[package]]
 name = "openpipe-art"
-version = "0.5.7"
+version = "0.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
This PR fixes [Wandb SDK version compatibility](https://github.com/wandb/docs/blob/8ad5cc08e389dd17d9706288900cedea82f480a8/snippets/en/_includes/api-key-security.mdx#sdk-version-compatibility):

New API keys are longer than legacy keys. When authenticating with older versions of the wandb or weave SDKs, users may encounter an API key length error.

Solution: Update to a newer SDK version:
wandb SDK v0.22.3+
weave SDK v0.52.17+

