### PR TITLE
fix(ruler): Add explicit JSON schema format for Ollama models in RULER

### DIFF
--- a/src/art/rewards/ruler.py
+++ b/src/art/rewards/ruler.py
@@ -50,6 +50,26 @@ DEFAULT_RUBRIC = dedent(
 as RULER extracts task understanding from the system prompts in the trajectories."""
 
 
+def _is_ollama_model(model: str) -> bool:
+    """Check if the model is an Ollama model."""
+    return model.startswith("ollama/") or model.startswith("ollama_chat/")
+
+
+def _get_response_format_for_ollama(pydantic_model: type[BaseModel]) -> dict:
+    """Convert Pydantic model to explicit JSON schema format for Ollama.
+
+    LiteLLM requires an explicit JSON schema format for Ollama models to
+    produce structured output via the /api/chat endpoint.
+    """
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": pydantic_model.__name__,
+            "schema": pydantic_model.model_json_schema(),
+        },
+    }
+
+
 async def ruler(
     message_lists: list[list[ChatCompletionMessageParam]],
     judge_model: str = "openai/o3",
@@ -172,13 +192,21 @@ async def ruler(
         {"role": "user", "content": user_text},
     ]
 
+    # Prepare response_format based on model type
+    # Ollama models require explicit JSON schema format for structured output
+    if _is_ollama_model(judge_model):
+        response_format = _get_response_format_for_ollama(Response)
+    else:
+        response_format = Response
+
     response = await acompletion(
         model=judge_model,
         messages=messages,
-        response_format=Response,
+        response_format=response_format,
         caching=False,
         **extra_litellm_params if extra_litellm_params else {},
     )
+
     assert isinstance(response, ModelResponse)
 
     if len(response.choices) == 0:

--- a/tests/unit/test_ruler.py
+++ b/tests/unit/test_ruler.py
@@ -1,0 +1,58 @@
+"""Unit tests for RULER Ollama JSON schema support (Issue #476)."""
+
+import pytest
+
+from art.rewards.ruler import (
+    Response,
+    _get_response_format_for_ollama,
+    _is_ollama_model,
+)
+
+
+class TestIsOllamaModel:
+    """Tests for _is_ollama_model helper function."""
+
+    def test_ollama_prefix(self):
+        """Test detection of ollama/ prefix."""
+        assert _is_ollama_model("ollama/qwen2.5:7b") is True
+
+    def test_ollama_chat_prefix(self):
+        """Test detection of ollama_chat/ prefix."""
+        assert _is_ollama_model("ollama_chat/qwen2.5:7b") is True
+
+    def test_non_ollama_models(self):
+        """Test that non-Ollama models return False."""
+        assert _is_ollama_model("openai/gpt-4o") is False
+        assert _is_ollama_model("openai/o3") is False
+
+
+class TestGetResponseFormatForOllama:
+    """Tests for _get_response_format_for_ollama helper function."""
+
+    def test_returns_correct_structure(self):
+        """Test that the function returns the correct JSON schema structure."""
+        result = _get_response_format_for_ollama(Response)
+
+        assert result["type"] == "json_schema"
+        assert "json_schema" in result
+        assert result["json_schema"]["name"] == "Response"
+        assert "schema" in result["json_schema"]
+
+    def test_schema_contains_expected_properties(self):
+        """Test that the schema contains the expected properties from Response model."""
+        result = _get_response_format_for_ollama(Response)
+        schema = result["json_schema"]["schema"]
+
+        # Response model should have 'scores' property
+        assert "properties" in schema
+        assert "scores" in schema["properties"]
+
+    def test_schema_is_valid_json_schema(self):
+        """Test that the generated schema is a valid structure."""
+        result = _get_response_format_for_ollama(Response)
+
+        # Verify it has the structure LiteLLM expects for Ollama
+        assert isinstance(result, dict)
+        assert result["type"] == "json_schema"
+        assert isinstance(result["json_schema"], dict)
+        assert isinstance(result["json_schema"]["schema"], dict)


### PR DESCRIPTION
## Summary
Fixes #476

Adds support for [ollama_chat/](cci:1://file:///e:/Sahil/open-source/ART/tests/unit/test_ruler.py:18:4-20:65) and [ollama/](cci:1://file:///e:/Sahil/open-source/ART/src/art/rewards/ruler.py:52:0-54:74) models in RULER by converting the Pydantic [response_format](cci:1://file:///e:/Sahil/open-source/ART/src/art/rewards/ruler.py:57:0-69:5) to the explicit JSON schema format that LiteLLM requires for Ollama's `/api/chat` endpoint.

## Changes
- Added helper to detect Ollama models
- Added helper to convert Pydantic schema to explicit JSON schema dict
- Updated [ruler()](cci:1://file:///e:/Sahil/open-source/ART/src/art/rewards/ruler.py:72:0-244:28) to use correct format based on model type
- Added unit tests

## Testing
- ✅ All unit tests pass
- ✅ Verified manually with `ollama_chat/qwen2.5:7b`