### PR TITLE
feat: add persistent state methods to Model

### DIFF
--- a/src/art/model.py
+++ b/src/art/model.py
@@ -148,12 +148,12 @@ class Model(
         report_metrics: list[str] | None = None,
     ) -> "Model[ModelConfig, dict[str, Any]]": ...
 
-    def __new__(
+    def __new__(  # pyright: ignore[reportInconsistentOverload]
         cls,
         *args,
         **kwargs,
     ) -> "Model[ModelConfig, StateType]":
-        return super().__new__(cls)
+        return super().__new__(cls)  # type: ignore[return-value]
 
     def safe_model_dump(self, *args, **kwargs) -> dict:
         """
@@ -539,7 +539,7 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
         _internal_config: dev.InternalModelConfig | None = None,
     ) -> "TrainableModel[ModelConfig, dict[str, Any]]": ...
 
-    def __new__(
+    def __new__(  # pyright: ignore[reportInconsistentOverload]
         cls,
         *args,
         **kwargs,


### PR DESCRIPTION
## Summary

Add `write_state()` and `read_state()` methods to `art.Model` that persist arbitrary JSON state to the model's output directory (`state.json`).

## Features

- **`StateType` type parameter** with default `dict[str, Any]` for backward compatibility
- **`write_state(state: StateType)`** - persists state as JSON to `{output_dir}/state.json`
- **`read_state() -> StateType | None`** - reads state, returns `None` if not found
- Full backward compatibility: existing `Model[MyConfig]` syntax still works
- Optional type safety: `Model[MyConfig, MyState]` enforces state type with type checkers

## Use Case

This enables filesystem-based state tracking for training resumption, dataset position, and other metadata. For the Tinker RL training migration, this replaces wandb-based state tracking with filesystem-based persistence for better compatibility.

## Usage Examples

```python
# Without type parameter (backward compatible)
model = art.TrainableModel(name="my-model", project="my-project", base_model="...")
model.write_state({"step": 5, "dataset_offset": 100})
state = model.read_state()  # Returns dict[str, Any] | None

# With type parameter for type safety
class TrainingState(TypedDict):
    step: int
    dataset_offset: int
    policy_version: int

model = art.TrainableModel[TinkerConfig, TrainingState](...)
model.write_state({"step": 5, "dataset_offset": 100, "policy_version": 3})
state = model.read_state()  # Returns TrainingState | None
```

## File Storage

State is stored at: `.art/{project}/models/{model_name}/state.json`