### PR TITLE
Fix OpenAI temperature handling

### DIFF
--- a/src/art/tinker/service.py
+++ b/src/art/tinker/service.py
@@ -339,7 +339,9 @@ class TinkerService:
                     max_tokens=body.get("max_completion_tokens")
                     or body.get("max_tokens"),
                     seed=body.get("seed"),
-                    temperature=body.get("temperature", 1.0),
+                    temperature=t
+                    if (t := body.get("temperature")) is not None
+                    else 1.0,
                     top_k=body.get("top_k") or -1,
                     top_p=body.get("top_p") or 1.0,
                 ),


### PR DESCRIPTION
Allow temperature=0.0 to pass through to Tinker sampling params by only defaulting to 1.0 when unset.