### PR TITLE
Add support for model name appendix

### DIFF
--- a/src/art/utils/benchmarking/log_constant_metrics_wandb.py
+++ b/src/art/utils/benchmarking/log_constant_metrics_wandb.py
@@ -9,6 +9,7 @@ async def log_constant_metrics_wandb(
     model: art.Model,
     num_steps: int,
     split_metrics: dict[str, dict[str, float]],
+    model_name_appendix: str | None = None,
 ) -> None:
     """
     Log constant metrics to W&B as horizontal lines across all training steps.
@@ -31,7 +32,7 @@ async def log_constant_metrics_wandb(
     """
     run = wandb.init(
         project=model.project,
-        name=model.name,
+        name=model.name + f" {model_name_appendix}" if model_name_appendix else "",
         reinit="create_new",
     )
 


### PR DESCRIPTION
### Changes
* Allow caller of `log_constant_metrics_wandb` to add an appendix to the model's name in wandb run name