### PR TITLE
fix: truncate excess scenarios instead of raising error in MCP generation

### DIFF
--- a/src/art/mcp/generate_scenarios.py
+++ b/src/art/mcp/generate_scenarios.py
@@ -201,9 +201,14 @@ You must respond with a JSON object containing a "scenarios" array of exactly {n
         scenarios = result if isinstance(result, list) else list(result.values())[0]
 
     # Validate count
-    if len(scenarios) != num_scenarios:
+    if len(scenarios) < num_scenarios:
         err(f"Expected {num_scenarios} scenarios, got {len(scenarios)}.")
         raise ValueError(f"Expected {num_scenarios} scenarios, got {len(scenarios)}")
+    elif len(scenarios) > num_scenarios:
+        ok(
+            f"Expected {num_scenarios} scenarios, got {len(scenarios)}. Truncating to {num_scenarios}."
+        )
+        scenarios = scenarios[:num_scenarios]
 
     ok(f"Parsed {len(scenarios)} scenario(s) successfully.")
 


### PR DESCRIPTION
## Summary

When using `generate_scenarios()`, the LLM occasionally generates more scenarios than the requested `num_scenarios` count. Previously this raised a `ValueError`, forcing a retry. This PR changes the behavior to:

- **Too few scenarios**: Still raises `ValueError` (generation failed)
- **Too many scenarios**: Truncates to the requested count and logs an info message

This makes scenario generation more robust, especially with models that don't strictly respect JSON schema `maxItems` constraints.

### Files changed
- `src/art/mcp/generate_scenarios.py` — split the `!=` check into `<` (error) and `>` (truncate with log)