### PR TITLE
fix: move _internal_config assignment back into TrainableModel.__init__

### DIFF
--- a/src/art/model.py
+++ b/src/art/model.py
@@ -706,6 +706,9 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
             report_metrics=report_metrics,
             **kwargs,
         )
+        if _internal_config is not None:
+            # Bypass BaseModel __setattr__ to allow setting private attr
+            object.__setattr__(self, "_internal_config", _internal_config)
         object.__setattr__(self, "_costs_lock", asyncio.Lock())
         object.__setattr__(self, "_cost_calculator", self._noop_cost_calculator)
 
@@ -725,9 +728,6 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
         _prompt_tokens: int | None, _completion_tokens: int | None
     ) -> dict[str, float]:
         return {}
-        if _internal_config is not None:
-            # Bypass BaseModel __setattr__ to allow setting private attr
-            object.__setattr__(self, "_internal_config", _internal_config)
 
     @overload
     def __new__(


### PR DESCRIPTION
## Summary

The `_internal_config` assignment in `TrainableModel` was accidentally placed after a `return {}` statement inside `_noop_cost_calculator`, making it dead code. This means `_internal_config` was never actually set on `TrainableModel` instances.

This PR moves the 3 lines back into `__init__` where they belong.

### Files changed
- `src/art/model.py` — move `_internal_config` assignment from dead code in `_noop_cost_calculator` back into `__init__`