### PR TITLE
fix: lazy-import heavy deps in CLI so lightweight commands work without extras

### DIFF
--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -1,26 +1,10 @@
 import json
 from pathlib import Path
 import socket
-from typing import Any, AsyncIterator, Optional
+from typing import Any, AsyncIterator
 
 from dotenv import load_dotenv
-from fastapi import Body, FastAPI, Request
-from fastapi.responses import JSONResponse, StreamingResponse
-import pydantic
 import typer
-import uvicorn
-
-from . import dev
-from .errors import ARTError
-from .local import LocalBackend
-from .model import Model, TrainableModel
-from .trajectories import TrajectoryGroup
-from .types import TrainConfig
-from .utils.deployment import (
-    Provider,
-    TogetherDeploymentConfig,
-    WandbDeploymentConfig,
-)
 
 load_dotenv()
 
@@ -301,6 +285,18 @@ def migrate(
 @app.command()
 def run(host: str = "0.0.0.0", port: int = 7999) -> None:
     """Run the ART CLI."""
+
+    from fastapi import Body, FastAPI, Request
+    from fastapi.responses import JSONResponse, StreamingResponse
+    import pydantic
+    import uvicorn
+
+    from . import dev
+    from .errors import ARTError
+    from .local import LocalBackend
+    from .model import Model, TrainableModel
+    from .trajectories import TrajectoryGroup
+    from .types import TrainConfig
 
     # check if port is available
     def is_port_available(port: int) -> bool:

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -15,7 +15,6 @@ from . import dev
 from .costs import CostCalculator
 from .trajectories import Trajectory, TrajectoryGroup
 from .types import TrainConfig, TrainSFTConfig
-from .utils.old_benchmarking.calculate_step_metrics import calculate_step_std_dev
 from .utils.trajectory_logging import write_trajectory_groups_parquet
 
 if TYPE_CHECKING:
@@ -638,6 +637,10 @@ class Model(
                 averages[f"group_metric_{metric}"] = sum(values) / len(values)
 
         # Calculate average standard deviation of rewards within groups
+        from .utils.old_benchmarking.calculate_step_metrics import (
+            calculate_step_std_dev,
+        )
+
         averages["reward_std_dev"] = calculate_step_std_dev(trajectory_groups)
 
         # Merge in any additional metrics passed directly


### PR DESCRIPTION
## Summary

- CLI commands (`art install-skills`, `art train-sft`, `art train-rl`, `art migrate`) crash with `ModuleNotFoundError` when only base dependencies are installed, because `cli.py` eagerly imports `fastapi`, `uvicorn`, `torch` (via `LocalBackend`), and `numpy` (via `model.py` → `calculate_step_metrics`) at module load time — even though only the `run` command needs them.

- Moved all `run`-only imports (`fastapi`, `uvicorn`, `pydantic`, `LocalBackend`, `dev`, `ARTError`, `Model`, `TrainableModel`, `TrajectoryGroup`, `TrainConfig`) from top-level into the `run()` function body.

- Made the `calculate_step_std_dev` import in `model.py` lazy (moved into the method that calls it), breaking the `__init__` → `utils` → `output_dirs` → `model` → `numpy` eager import chain.

- Removed unused imports: `Optional`, `Provider`, `TogetherDeploymentConfig`, `WandbDeploymentConfig`.

## Reproduction

```
pip install openpipe-art
art install-skills
# ModuleNotFoundError: No module named 'numpy'
# (after installing numpy) ModuleNotFoundError: No module named 'fastapi'
# (after installing fastapi) ModuleNotFoundError: No module named 'torch'
```

## Test plan

- [ ] `pip install openpipe-art && art install-skills` works with base deps only
- [ ] `art run` still works when backend extras are installed
- [ ] `ruff check` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)