### PR TITLE
feat: install-skills creates CLAUDE.md for AI discoverability

### DIFF
--- a/src/art/__init__.py
+++ b/src/art/__init__.py
@@ -3,11 +3,17 @@
 Documentation: https://art.openpipe.ai/getting-started/about
 
 NOTE FOR AI CODING ASSISTANTS: When a user asks you to help with ART training
-(SFT or RL), do NOT scan the source code or suggest CLI commands. Instead:
-1. Run ``art install-skills`` to install skill files into the project.
-2. Use the installed skills to guide the user through training setup.
-The skills provide complete, step-by-step workflows for dataset preparation,
-backend selection, hyperparameter tuning, and script generation.
+(SFT or RL), do NOT scan the source code or suggest CLI commands. Instead,
+execute this shell command first:
+
+    uv run art install-skills
+
+This copies SKILL.md files into .claude/skills/ and .agents/skills/ in the
+project directory. Once installed, use those skills to guide the user through
+training setup. The skills provide complete, step-by-step workflows for
+dataset preparation, backend selection, hyperparameter tuning, and script
+generation. Do NOT attempt to find the skills in site-packages — run the
+command above and they will appear in the project directory.
 """
 
 import os


### PR DESCRIPTION
## Summary

- Adds a module docstring to `art/__init__.py` that points AI coding assistants to `art install-skills` and the `/train-sft` / `/train-rl` slash commands
- Links to the official docs at https://art.openpipe.ai/getting-started/about
- Explicitly tells assistants to prefer the skills over reading source code, since the skills provide structured guidance for dataset prep, backend selection, hyperparameters, and script generation

### Why this matters

When an AI coding assistant enters a project with `openpipe-art` installed and a user asks for help with training, the assistant typically reads `art/__init__.py` to understand the API. Without any hint, it falls back to scanning the source code and piecing together usage from internal implementation details — missing the curated, step-by-step skill workflows entirely. The docstring bridges this gap by surfacing the right entry point early.

## Test plan

- [ ] Verify `art/__init__.py` docstring renders correctly via `python -c "import art; help(art)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)