### PR TITLE
Flex Attention for Local Megatron Backend

### DIFF
--- a/src/art/megatron/flex_attention.py
+++ b/src/art/megatron/flex_attention.py
@@ -1,0 +1,209 @@
+"""Flex attention plumbing for ART's Megatron backend."""
+
+import math
+from typing import Any, ClassVar, cast
+
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.utils import divide
+from pydantic import BaseModel, ConfigDict
+import torch
+from torch import Tensor
+import torch._inductor.config as inductor_config
+from torch.nn.attention.flex_attention import (
+    BlockMask,
+    create_block_mask,
+    flex_attention,
+)
+
+
+class SharedPrefixAttentionState(BaseModel):
+    """Shared-prefix sparsity metadata for one packed ART training sample."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    block_mask: BlockMask
+
+
+class FlexAttentionWrapper(torch.nn.Module):
+    """Compiled `flex_attention` wrapper with Torchtitan-style inductor options."""
+
+    _requested_compile_options = {
+        "wrap_inductor_compiled_regions": True,
+        "max_autotune": True,
+        "coordinate_descent_tuning": True,
+        "triton.cudagraphs": False,
+    }
+    _supported_compile_options = {
+        key: value
+        for key, value in _requested_compile_options.items()
+        if key in inductor_config.get_config_copy()
+    }
+    _compiled_flex_attention: ClassVar = torch.compile(
+        flex_attention,
+        options=_supported_compile_options,
+    )
+
+    def forward(
+        self,
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        *,
+        block_mask: BlockMask,
+        scale: float,
+        enable_gqa: bool,
+    ) -> Tensor:
+        # q, k, v are [B, H, S, D] tensors expected by torch.flex_attention.
+        return cast(
+            Tensor,
+            FlexAttentionWrapper._compiled_flex_attention(
+                q,
+                k,
+                v,
+                block_mask=block_mask,
+                scale=scale,
+                enable_gqa=enable_gqa,
+            ),
+        )
+
+
+_compiled_create_block_mask = torch.compile(create_block_mask)
+
+
+def create_shared_prefix_attention_state(
+    group_ids: Tensor,
+    parent_ids: Tensor,
+) -> SharedPrefixAttentionState:
+    """Build a compiled block mask for ART shared-prefix packing.
+
+    Args:
+        group_ids: `[B, S]` group id for each token in a packed sequence.
+        parent_ids: `[B, S]` parent group id for each token in a packed sequence.
+    """
+
+    def _shared_prefix_mask(
+        batch_idx: Tensor,
+        head_idx: Tensor,
+        query_idx: Tensor,
+        kv_idx: Tensor,
+    ) -> Tensor:
+        del head_idx
+        # Token q can attend token k if k is causal and either from the same
+        # group or from q's parent-prefix group.
+        same_group = group_ids[batch_idx, query_idx] == group_ids[batch_idx, kv_idx]
+        parent_prefix = parent_ids[batch_idx, query_idx] == group_ids[batch_idx, kv_idx]
+        return (query_idx >= kv_idx) & (same_group | parent_prefix)
+
+    block_mask = _compiled_create_block_mask(
+        _shared_prefix_mask,
+        group_ids.shape[0],
+        None,
+        group_ids.shape[1],
+        group_ids.shape[1],
+        device=group_ids.device,
+    )
+    return SharedPrefixAttentionState(block_mask=block_mask)
+
+
+class FlexDotProductAttention(torch.nn.Module):
+    """Megatron core-attention module backed by compiled torch flex attention."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        layer_number: int,
+        attn_mask_type: AttnMaskType,
+        attention_type: str,
+        attention_dropout: float | None = None,
+        softmax_scale: float | None = None,
+        cp_comm_type: str | None = None,
+        pg_collection: ProcessGroupCollection | None = None,
+    ):
+        super().__init__()
+        del (
+            layer_number,
+            attn_mask_type,
+            attention_type,
+            attention_dropout,
+            cp_comm_type,
+        )
+        self.config = config
+        self.flex_attention = FlexAttentionWrapper()
+
+        if pg_collection is None:
+            tp_world_size = self.config.tensor_model_parallel_size
+        else:
+            tp_world_size = pg_collection.tp.size()
+
+        kv_channels = self.config.kv_channels
+        assert kv_channels is not None, "Megatron config must provide kv_channels."
+        projection_size = kv_channels * self.config.num_attention_heads
+        self.hidden_size_per_partition = divide(projection_size, tp_world_size)
+        num_query_groups = (
+            self.config.num_query_groups or self.config.num_attention_heads
+        )
+        self.num_attention_heads_per_partition = divide(
+            self.config.num_attention_heads, tp_world_size
+        )
+        self.num_query_groups_per_partition = divide(num_query_groups, tp_world_size)
+
+        if softmax_scale is None:
+            head_dim = divide(projection_size, self.config.num_attention_heads)
+            self.softmax_scale = 1.0 / math.sqrt(head_dim)
+        else:
+            self.softmax_scale = softmax_scale
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask: Tensor,
+        attn_mask_type: AttnMaskType | None = None,
+        attention_bias: Any = None,
+        packed_seq_params: PackedSeqParams | None = None,
+    ) -> Tensor:
+        """Compute self attention with compiled flex kernels.
+
+        Args:
+            query: `[S, B, Hq, D]`
+            key: `[S, B, Hkv, D]`
+            value: `[S, B, Hkv, D]`
+            attention_mask: unused placeholder tensor kept for Megatron checkpoint API.
+            attention_bias: `SharedPrefixAttentionState` or `BlockMask`.
+        """
+
+        del attention_mask, attn_mask_type
+        assert packed_seq_params is None, (
+            "PackedSeqParams is not used in ART Megatron flex path."
+        )
+
+        if isinstance(attention_bias, SharedPrefixAttentionState):
+            block_mask = attention_bias.block_mask
+        else:
+            assert isinstance(attention_bias, BlockMask), (
+                "Expected a flex BlockMask in attention_bias."
+            )
+            block_mask = attention_bias
+
+        # Megatron uses [S, B, H, D], while flex attention expects [B, H, S, D].
+        q = query.permute(1, 2, 0, 3)
+        k = key.permute(1, 2, 0, 3)
+        v = value.permute(1, 2, 0, 3)
+
+        out = self.flex_attention(
+            q,
+            k,
+            v,
+            block_mask=block_mask,
+            scale=self.softmax_scale,
+            enable_gqa=self.num_attention_heads_per_partition
+            != self.num_query_groups_per_partition,
+        )
+
+        # Return to Megatron's expected layout [S, B, Hq*D].
+        out = out.permute(2, 0, 1, 3).contiguous()
+        out = out.view(out.size(0), out.size(1), self.hidden_size_per_partition)
+        return out

--- a/src/art/megatron/flex_attention.py
+++ b/src/art/megatron/flex_attention.py
@@ -11,7 +11,6 @@ from megatron.core.utils import divide
 from pydantic import BaseModel, ConfigDict
 import torch
 from torch import Tensor
-import torch._inductor.config as inductor_config
 from torch.nn.attention.flex_attention import (
     BlockMask,
     create_block_mask,
@@ -29,20 +28,15 @@ class SharedPrefixAttentionState(BaseModel):
 class FlexAttentionWrapper(torch.nn.Module):
     """Compiled `flex_attention` wrapper with Torchtitan-style inductor options."""
 
-    _requested_compile_options = {
-        "wrap_inductor_compiled_regions": True,
+    # Torchtitan inductor options for compiling flex attention.
+    _compile_options = {
         "max_autotune": True,
         "coordinate_descent_tuning": True,
         "triton.cudagraphs": False,
     }
-    _supported_compile_options = {
-        key: value
-        for key, value in _requested_compile_options.items()
-        if key in inductor_config.get_config_copy()
-    }
     _compiled_flex_attention: ClassVar = torch.compile(
         flex_attention,
-        options=_supported_compile_options,
+        options=_compile_options,
     )
 
     def forward(
@@ -78,6 +72,8 @@ def create_shared_prefix_attention_state(
 ) -> SharedPrefixAttentionState:
     """Build a compiled block mask for ART shared-prefix packing.
 
+    Initialized on the device of the group_ids tensor.
+
     Args:
         group_ids: `[B, S]` group id for each token in a packed sequence.
         parent_ids: `[B, S]` parent group id for each token in a packed sequence.
@@ -91,7 +87,8 @@ def create_shared_prefix_attention_state(
     ) -> Tensor:
         del head_idx
         # Token q can attend token k if k is causal and either from the same
-        # group or from q's parent-prefix group.
+        # traj (traj -> traj)/within the shared prefix (prefix -> prefix) (same_group)
+        # or from the prefix which q uses (traj -> prefix) (parent_prefix).
         same_group = group_ids[batch_idx, query_idx] == group_ids[batch_idx, kv_idx]
         parent_prefix = parent_ids[batch_idx, query_idx] == group_ids[batch_idx, kv_idx]
         return (query_idx >= kv_idx) & (same_group | parent_prefix)
@@ -108,7 +105,10 @@ def create_shared_prefix_attention_state(
 
 
 class FlexDotProductAttention(torch.nn.Module):
-    """Megatron core-attention module backed by compiled torch flex attention."""
+    """Megatron core-attention module backed by compiled torch flex attention.
+
+    The current implementation lacks support for fp8 and context parallelism (which are available in TEDotProductAttention)
+    """
 
     def __init__(
         self,

--- a/src/art/megatron/provider.py
+++ b/src/art/megatron/provider.py
@@ -1,5 +1,7 @@
 import copy
+from functools import partial
 import inspect
+from typing import Callable
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.gpt_provider import GPTModelProvider
@@ -9,6 +11,21 @@ from megatron.core.transformer.spec_utils import ModuleSpec
 import torch
 
 from art.megatron.flex_attention import FlexDotProductAttention
+
+
+def _resolve_layer_spec(
+    base_layer_spec: ModuleSpec | Callable[[GPTModelProvider], ModuleSpec],
+    config: GPTModelProvider,
+    vp_stage: int | None = None,
+) -> ModuleSpec:
+    if isinstance(base_layer_spec, ModuleSpec):
+        return copy.deepcopy(base_layer_spec)
+    kwargs = (
+        {"vp_stage": vp_stage}
+        if vp_stage in inspect.signature(base_layer_spec).parameters
+        else {}
+    )
+    return base_layer_spec(config, **kwargs)
 
 
 def get_provider(model: str) -> GPTModelProvider:
@@ -26,16 +43,9 @@ def get_provider(model: str) -> GPTModelProvider:
     def _flex_attention_layer_spec(
         config: GPTModelProvider, vp_stage: int | None = None
     ) -> ModuleSpec:
-        if isinstance(base_layer_spec, ModuleSpec):
-            layer_spec = copy.deepcopy(base_layer_spec)
-        elif "vp_stage" in inspect.signature(base_layer_spec).parameters:
-            layer_spec = base_layer_spec(config, vp_stage=vp_stage)
-        else:
-            layer_spec = base_layer_spec(config)
-
+        layer_spec = _resolve_layer_spec(base_layer_spec, config, vp_stage)
         # Keep Megatron's standard layer stack and replace only core attention.
-        layer_spec = copy.deepcopy(layer_spec)
-        layer_spec.submodules.self_attention.submodules.core_attention = (  # type: ignore[union-attr]
+        layer_spec.submodules.self_attention.submodules.core_attention = (  # ty: ignore[unresolved-attribute]
             FlexDotProductAttention
         )
         return layer_spec

--- a/src/art/megatron/provider.py
+++ b/src/art/megatron/provider.py
@@ -1,8 +1,14 @@
+import copy
+import inspect
+
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.qwen.qwen3_moe_bridge import Qwen3MoEBridge
 from megatron.core.transformer.enums import AttnBackend
+from megatron.core.transformer.spec_utils import ModuleSpec
 import torch
+
+from art.megatron.flex_attention import FlexDotProductAttention
 
 
 def get_provider(model: str) -> GPTModelProvider:
@@ -15,7 +21,27 @@ def get_provider(model: str) -> GPTModelProvider:
         "Only Qwen3 MoE models are supported"
     )
     provider = bridge.to_megatron_provider()
-    provider.attention_backend = AttnBackend.fused
+    base_layer_spec = provider.transformer_layer_spec
+
+    def _flex_attention_layer_spec(
+        config: GPTModelProvider, vp_stage: int | None = None
+    ) -> ModuleSpec:
+        if isinstance(base_layer_spec, ModuleSpec):
+            layer_spec = copy.deepcopy(base_layer_spec)
+        elif "vp_stage" in inspect.signature(base_layer_spec).parameters:
+            layer_spec = base_layer_spec(config, vp_stage=vp_stage)
+        else:
+            layer_spec = base_layer_spec(config)
+
+        # Keep Megatron's standard layer stack and replace only core attention.
+        layer_spec = copy.deepcopy(layer_spec)
+        layer_spec.submodules.self_attention.submodules.core_attention = (  # type: ignore[union-attr]
+            FlexDotProductAttention
+        )
+        return layer_spec
+
+    provider.transformer_layer_spec = _flex_attention_layer_spec
+    provider.attention_backend = AttnBackend.auto
     provider.recompute_granularity = "full"
     provider.recompute_method = "uniform"
     provider.recompute_num_layers = 1

--- a/src/art/megatron/train.py
+++ b/src/art/megatron/train.py
@@ -1,9 +1,18 @@
 # isort: off
 import os
 
+
+def _set_cache_dir(env_var: str, default_path: str) -> None:
+    if not os.environ.get(env_var):
+        os.environ[env_var] = os.path.expanduser(default_path)
+    os.makedirs(os.environ[env_var], exist_ok=True)
+
+
 os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 os.environ["TORCH_CUDA_ARCH_LIST"] = "9.0"
+_set_cache_dir("TORCHINDUCTOR_CACHE_DIR", "~/.cache/torchinductor")
+_set_cache_dir("TRITON_CACHE_DIR", "~/.triton/cache")
 # isort: on
 
 import gc
@@ -21,6 +30,7 @@ from megatron.core.transformer.module import MegatronModule
 from pydantic import BaseModel
 from safetensors.torch import load_file, save_file
 import torch
+from torch._inductor.runtime.cache_dir_utils import cache_dir as inductor_cache_dir
 
 from art import dev, types
 from art.loss import loss_fn, shift_tensor
@@ -55,6 +65,11 @@ model = provider.provide_distributed_model(
 
 rank = torch.distributed.get_rank()
 world_size = torch.distributed.get_world_size()
+
+if rank == 0:
+    print("TORCHINDUCTOR_CACHE_DIR:", os.environ["TORCHINDUCTOR_CACHE_DIR"])
+    print("Resolved inductor cache_dir():", inductor_cache_dir())
+    print("TRITON_CACHE_DIR:", os.environ["TRITON_CACHE_DIR"])
 
 for module in model:
     while not isinstance(module, GPTModel) and hasattr(module, "module"):
@@ -301,9 +316,11 @@ while True:
     offload_to_cpu(model, optimizer, rank, offload_state)
     # Release mmap-backed packed tensor references on all ranks before rank0 cleanup.
     del packed_tensors
+    del adapter_model
     if "inputs" in locals():
         del inputs
     gc.collect()
+    torch.cuda.empty_cache()
     # Ensure all ranks have finished saving before signaling completion
     torch.distributed.barrier()
     if rank == 0:

--- a/src/art/megatron/train.py
+++ b/src/art/megatron/train.py
@@ -24,6 +24,7 @@ import torch
 
 from art import dev, types
 from art.loss import loss_fn, shift_tensor
+from art.megatron.flex_attention import create_shared_prefix_attention_state
 from art.megatron.lora import apply_lora_adapters
 from art.megatron.offload import OffloadState, offload_to_cpu, reload_to_gpu
 from art.megatron.provider import get_provider
@@ -122,31 +123,6 @@ def print0(*values: Any) -> None:
 offload_state = OffloadState()
 
 
-def calculate_mask(
-    batch_size: int,
-    seq_len: int,
-    device: torch.device,
-    group_ids: torch.Tensor,
-    parent_ids: torch.Tensor,
-) -> torch.Tensor:
-    causal_mask = (
-        torch.tril(
-            torch.ones(
-                seq_len,
-                seq_len,
-                dtype=torch.bool,
-                device=device,
-            )
-        )
-        .unsqueeze(0)
-        .expand(batch_size, seq_len, seq_len)
-    )
-    group_mask = group_ids.unsqueeze(2) == group_ids.unsqueeze(1)
-    parent_mask = parent_ids.unsqueeze(2) == group_ids.unsqueeze(1)
-    mask = causal_mask & (group_mask | parent_mask)
-    return mask
-
-
 offload_to_cpu(model, optimizer, rank, offload_state)
 
 while True:
@@ -236,26 +212,19 @@ while True:
         for key, value in inputs.items():
             if isinstance(value, torch.Tensor):
                 inputs[key] = value.to(device)  # type: ignore
-        attention_mask = ~calculate_mask(
-            batch_size=inputs["tokens"].shape[0],
-            seq_len=inputs["tokens"].shape[1],
-            device=device,
+        attention_state = create_shared_prefix_attention_state(
             group_ids=inputs["group_ids"],
             parent_ids=inputs["parent_ids"],
-        ).unsqueeze(1)  # add head dimension [B, H=1, S, S]
-        attention_bias = torch.where(
-            attention_mask,
-            torch.tensor(
-                float("-inf"), dtype=next(model[0].parameters()).dtype, device=device
-            ),
-            torch.tensor(0.0, dtype=next(model[0].parameters()).dtype, device=device),
         )
+        # Megatron full-layer recompute saves positional tensor args, so keep a tiny
+        # placeholder Tensor here and pass flex BlockMask state via attention_bias.
+        attention_mask = torch.zeros((1, 1, 1, 1), dtype=torch.bool, device=device)
         new_logprobs: torch.Tensor = -model[0](
             input_ids=inputs["tokens"],
             position_ids=inputs["input_pos"],
             attention_mask=attention_mask,
             labels=shift_tensor(inputs["tokens"], 0),
-            extra_block_kwargs={"attention_bias": attention_bias},
+            extra_block_kwargs={"attention_bias": attention_state},
         )
         loss = loss_fn(
             inputs,  # type: ignore

--- a/src/art/megatron/train.py
+++ b/src/art/megatron/train.py
@@ -212,7 +212,7 @@ while True:
         for key, value in inputs.items():
             if isinstance(value, torch.Tensor):
                 inputs[key] = value.to(device)  # type: ignore
-        attention_state = create_shared_prefix_attention_state(
+        attention_state = create_shared_prefix_attention_state(  # should happen after group_ids is moved to device
             group_ids=inputs["group_ids"],
             parent_ids=inputs["parent_ids"],
         )


### PR DESCRIPTION
# Flex Attn
## Motivation and Choice
- Megatron fused attn is very slow, after comparing flex attn and flash attn, I have elected to go with flex attn which has the following benefits compared to fused attn and flash attn:
  - Much faster than fused attn
  - Benefits from the shared prefix packing `pack.py`
  - Matches flash attn without shared prefix. Outperforms with.
  - Makes it easy to use SWA or other attn modifications in the future

## Benchmarks (Short Version)
Fwd and Bwd Pass (these speedups are generally pretty close for both)
- ~10-15x faster than fused attn
- Roughly same speed as flash attn with no shared prefix. If you then compare flex attn with the shared prefix (@ 6% of the trajectory length) to flash attn varlen with prefix duplicated, ~1.2x faster than flash attn.

Training wall clock time (just training, no rollouts):
- ~1.87x faster than fused attn @ 64K sequence length with 8K shared prefix and 8K completions.

## Correctness
Verified that when starting from the same LoRA checkpoint, main branch training and flex attn branch training produce near identical checkpoints for 10 steps. 
```python
max_abs_diff = 0.0008
mean_abs_diff = 7e-6
relative_l2 = 0.001   # ||diff||_2 / ||W_main||_2
```

Also verified the ART loop by training for 10 steps on temporal clue.

## Additional Bug Fixed
- Free the adapter in Megatron `train.py` at the end of the loop because holding the mmapped tensors prevents deleting the checkpoint on disk

## Benchmark Results (More Specific Version)
### Kernel Comparison
Terms:
- `prefix_ratio`: ratio of the total seq len that is the shared prefix for the rest of the completions
- `avg_traj_ratio`: ratio of the total seq len for each completion (note there is some randomness, centered on this marker)
- `flash_token_multiplier`: ratio of seq len when the prefix is duplicated for each trajectory (so flash attn and flex attn compute the same result)
- `art_pair_sparsity`: `1 - (art_allowed_pairs / dense_causal_pairs)` where `art_allowed_pairs` is the number of QK pairs computed and `dense_causal_pairs` is the number of pairs in a full causal mask. Effectively, the percent of QK pairs skipped by the mask (due to masking out intra-trajectory pairs).
- `packed_tok/s`: tokens per s, but with the seq len fixed to `seq` (i.e. does not count `flash_token_multiplier`).

The input sequences are randomized, so there's some variance.

```txt
=== Attention Backend Benchmark Summary ===
Device=cuda:0 dtype=bf16 heads=32 head_dim=128 warmup=3 bench=10 block_size=128 flex_compile_mode=default refresh_inputs_per_iter=True

[seq=16,384 prefix_ratio=0.0000 avg_traj_ratio=0.1200] flash_token_multiplier=1.00x art_pair_sparsity=0.719
  - fused: fwd=14.891ms bwd=40.584ms packed_tok/s(fwd)=1,100,289 packed_tok/s(bwd)=403,705
  - flex: fwd=1.486ms bwd=4.426ms packed_tok/s(fwd)=11,027,852 packed_tok/s(bwd)=3,701,578
  - flash_varlen: fwd=1.404ms bwd=5.098ms packed_tok/s(fwd)=11,666,856 packed_tok/s(bwd)=3,213,791

[seq=16,384 prefix_ratio=0.0100 avg_traj_ratio=0.1200] flash_token_multiplier=1.07x art_pair_sparsity=0.721
  - fused: fwd=14.848ms bwd=40.560ms packed_tok/s(fwd)=1,103,478 packed_tok/s(bwd)=403,942
  - flex: fwd=1.574ms bwd=4.989ms packed_tok/s(fwd)=10,408,620 packed_tok/s(bwd)=3,283,843
  - flash_varlen: fwd=1.468ms bwd=6.168ms packed_tok/s(fwd)=11,163,245 packed_tok/s(bwd)=2,656,167

[seq=16,384 prefix_ratio=0.0300 avg_traj_ratio=0.1200] flash_token_multiplier=1.24x art_pair_sparsity=0.744
  - fused: fwd=14.842ms bwd=40.571ms packed_tok/s(fwd)=1,103,865 packed_tok/s(bwd)=403,837
  - flex: fwd=1.549ms bwd=4.947ms packed_tok/s(fwd)=10,573,859 packed_tok/s(bwd)=3,312,036
  - flash_varlen: fwd=1.548ms bwd=6.098ms packed_tok/s(fwd)=10,584,570 packed_tok/s(bwd)=2,686,883

[seq=16,384 prefix_ratio=0.0600 avg_traj_ratio=0.1200] flash_token_multiplier=1.96x art_pair_sparsity=0.819
  - fused: fwd=14.800ms bwd=40.570ms packed_tok/s(fwd)=1,107,055 packed_tok/s(bwd)=403,850
  - flex: fwd=1.578ms bwd=5.026ms packed_tok/s(fwd)=10,383,184 packed_tok/s(bwd)=3,260,162
  - flash_varlen: fwd=1.922ms bwd=7.662ms packed_tok/s(fwd)=8,523,929 packed_tok/s(bwd)=2,138,436

[seq=32,768 prefix_ratio=0.0000 avg_traj_ratio=0.1200] flash_token_multiplier=1.00x art_pair_sparsity=0.718
  - fused: fwd=57.713ms bwd=165.148ms packed_tok/s(fwd)=567,775 packed_tok/s(bwd)=198,416
  - flex: fwd=4.999ms bwd=14.568ms packed_tok/s(fwd)=6,554,699 packed_tok/s(bwd)=2,249,260
  - flash_varlen: fwd=4.998ms bwd=17.075ms packed_tok/s(fwd)=6,556,323 packed_tok/s(bwd)=1,919,052

[seq=32,768 prefix_ratio=0.0100 avg_traj_ratio=0.1200] flash_token_multiplier=1.04x art_pair_sparsity=0.679
  - fused: fwd=57.711ms bwd=165.626ms packed_tok/s(fwd)=567,793 packed_tok/s(bwd)=197,843
  - flex: fwd=5.225ms bwd=15.677ms packed_tok/s(fwd)=6,271,324 packed_tok/s(bwd)=2,090,259
  - flash_varlen: fwd=5.209ms bwd=17.903ms packed_tok/s(fwd)=6,290,262 packed_tok/s(bwd)=1,830,316

[seq=32,768 prefix_ratio=0.0300 avg_traj_ratio=0.1200] flash_token_multiplier=1.32x art_pair_sparsity=0.787
  - fused: fwd=57.940ms bwd=165.695ms packed_tok/s(fwd)=565,548 packed_tok/s(bwd)=197,761
  - flex: fwd=5.383ms bwd=16.016ms packed_tok/s(fwd)=6,087,527 packed_tok/s(bwd)=2,045,954
  - flash_varlen: fwd=5.695ms bwd=19.731ms packed_tok/s(fwd)=5,754,286 packed_tok/s(bwd)=1,660,735

[seq=32,768 prefix_ratio=0.0600 avg_traj_ratio=0.1200] flash_token_multiplier=2.01x art_pair_sparsity=0.818
  - fused: fwd=58.030ms bwd=165.725ms packed_tok/s(fwd)=564,676 packed_tok/s(bwd)=197,726
  - flex: fwd=5.492ms bwd=16.395ms packed_tok/s(fwd)=5,966,573 packed_tok/s(bwd)=1,998,692
  - flash_varlen: fwd=6.953ms bwd=25.080ms packed_tok/s(fwd)=4,712,761 packed_tok/s(bwd)=1,306,542

[seq=131,072 prefix_ratio=0.0000 avg_traj_ratio=0.1200] flash_token_multiplier=1.00x art_pair_sparsity=0.857
  - fused: fwd=1002.016ms bwd=2935.834ms packed_tok/s(fwd)=130,808 packed_tok/s(bwd)=44,646
  - flex: fwd=66.963ms bwd=190.072ms packed_tok/s(fwd)=1,957,371 packed_tok/s(bwd)=689,590
  - flash_varlen: fwd=76.088ms bwd=225.348ms packed_tok/s(fwd)=1,722,627 packed_tok/s(bwd)=581,642

[seq=131,072 prefix_ratio=0.0100 avg_traj_ratio=0.1200] flash_token_multiplier=1.11x art_pair_sparsity=0.811
  - fused: fwd=1007.115ms bwd=2950.165ms packed_tok/s(fwd)=130,146 packed_tok/s(bwd)=44,429
  - flex: fwd=68.471ms bwd=195.230ms packed_tok/s(fwd)=1,914,258 packed_tok/s(bwd)=671,373
  - flash_varlen: fwd=77.845ms bwd=231.205ms packed_tok/s(fwd)=1,683,758 packed_tok/s(bwd)=566,908

[seq=131,072 prefix_ratio=0.0300 avg_traj_ratio=0.1200] flash_token_multiplier=1.27x art_pair_sparsity=0.793
  - fused: fwd=1007.242ms bwd=2946.386ms packed_tok/s(fwd)=130,130 packed_tok/s(bwd)=44,486
  - flex: fwd=66.313ms bwd=189.177ms packed_tok/s(fwd)=1,976,574 packed_tok/s(bwd)=692,853
  - flash_varlen: fwd=79.444ms bwd=237.077ms packed_tok/s(fwd)=1,649,874 packed_tok/s(bwd)=552,867

[seq=131,072 prefix_ratio=0.0600 avg_traj_ratio=0.1200] flash_token_multiplier=1.58x art_pair_sparsity=0.690
  - fused: fwd=1005.248ms bwd=2937.606ms packed_tok/s(fwd)=130,388 packed_tok/s(bwd)=44,619
  - flex: fwd=71.921ms bwd=205.016ms packed_tok/s(fwd)=1,822,442 packed_tok/s(bwd)=639,325
  - flash_varlen: fwd=105.047ms bwd=316.233ms packed_tok/s(fwd)=1,247,747 packed_tok/s(bwd)=414,479
```

### Training Loop
```json
{
  "throughput": {
    "comparison_seq_len": 65536,
    "main": {
      "seq_len": 65536,
      "num_sequences": 32,
      "steps": 1,
      "tokens_per_step": 2097152,
      "step_durations_s": [
        844.541773557663
      ],
      "wall_clock_s": 844.541773557663,
      "tokens_per_second": 2483.183266548996
    },
    "flex": {
      "seq_len": 65536,
      "num_sequences": 32,
      "steps": 1,
      "tokens_per_step": 2097152,
      "step_durations_s": [
        452.29875659942627
      ],
      "wall_clock_s": 452.29875659942627,
      "tokens_per_second": 4636.652145071716
    },
    "trajectory_mix": {
      "prefill_tokens": 8192,
      "completion_tokens": 8192,
      "note": "Synthetic ART shared-prefix packing: one prefill region plus repeated completion branches per packed sequence."
    }
  }
}
```