### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 <a href="https://art.openpipe.ai"><picture>
 <img alt="ART logo" src="https://github.com/openpipe/art/raw/main/assets/ART_logo.png" width="160px">
 </picture></a>
+  <a href="https://gitcgr.com/openpipe/ART">
+    <img src="https://gitcgr.com/badge/openpipe/ART.svg" alt="gitcgr" />
+  </a>
 
 <p align="center">
   <h1>Agent Reinforcement Trainer</h1>


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/openpipe/ART.svg)](https://gitcgr.com/openpipe/ART)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).