### PR TITLE
feat: Add dedicated lora mode to Megatron backend

### DIFF
--- a/src/art/megatron/backend.py
+++ b/src/art/megatron/backend.py
@@ -1,3 +1,5 @@
+import os
+
 from mp_actors import move_to_child_process
 
 from ..local.backend import LocalBackend
@@ -19,6 +21,7 @@ class MegatronBackend(LocalBackend):
 
     async def _get_service(self, model: TrainableModel) -> ModelService:
         from ..dev.get_model_config import get_model_config
+        from ..dev.validate import is_dedicated_mode, validate_dedicated_config
         from .service import MegatronService
 
         if model.name not in self._services:
@@ -27,13 +30,19 @@ class MegatronBackend(LocalBackend):
                 output_dir=get_model_dir(model=model, art_path=self._path),
                 config=model._internal_config,
             )
+            validate_dedicated_config(config)
+            dedicated = is_dedicated_mode(config)
+            if dedicated:
+                os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(
+                    str(gpu_id) for gpu_id in config["trainer_gpu_ids"]
+                )
             self._services[model.name] = MegatronService(
                 model_name=model.name,
                 base_model=model.base_model,
                 config=config,
                 output_dir=get_model_dir(model=model, art_path=self._path),
             )
-            if not self._in_process:
+            if not dedicated and not self._in_process:
                 self._services[model.name] = move_to_child_process(
                     self._services[model.name],
                     process_name="megatron-service",

--- a/src/art/megatron/service.py
+++ b/src/art/megatron/service.py
@@ -1,13 +1,16 @@
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 import importlib
+import json
+import logging
 import os
 from pathlib import Path
 import shlex
 import shutil
 import socket
 import subprocess
+import sys
 from typing import Any, AsyncIterator, Literal, cast
 
 from peft.tuners.lora.config import LoraConfig
@@ -18,6 +21,7 @@ from vllm.v1.engine.async_llm import AsyncLLM
 
 from .. import dev, types
 from ..dev.get_model_config import default_target_modules
+from ..dev.validate import is_dedicated_mode
 from ..local.checkpoints import get_last_checkpoint_dir
 from ..preprocessing.pack import DiskPackedTensors
 from ..preprocessing.tokenize import SFTBatch
@@ -127,6 +131,9 @@ def create_identity_lora(
         torch.cuda.empty_cache()
 
 
+logger = logging.getLogger(__name__)
+
+
 @dataclass
 class MegatronService:
     model_name: str
@@ -137,6 +144,24 @@ class MegatronService:
     _latest_step: int = 0
     _lora_id_counter: int = 1
     _megatron_process: asyncio.subprocess.Process | None = None
+    _vllm_process: subprocess.Popen | None = field(default=None, repr=False)  # type: ignore[type-arg]
+    _vllm_log_file: Any = field(default=None, repr=False)
+    _vllm_host: str = "127.0.0.1"
+    _vllm_port: int = 0
+
+    @property
+    def is_dedicated(self) -> bool:
+        return is_dedicated_mode(self.config)
+
+    @property
+    def rollout_weights_mode(self) -> Literal["lora", "merged"]:
+        mode = self.config.get("rollout_weights_mode", "lora")
+        assert mode in {"lora", "merged"}
+        return mode
+
+    @property
+    def _vllm_base_url(self) -> str:
+        return f"http://{self._vllm_host}:{self._vllm_port}"
 
     def _megatron_random_state(self) -> int | None:
         for config_key in ("peft_args", "init_args"):
@@ -222,6 +247,145 @@ class MegatronService:
                 return
         self._default_lora_adapter_config().save_pretrained(lora_path)
 
+    def _resolve_active_lora_path(self) -> str:
+        lora_path = get_last_checkpoint_dir(self.output_dir)
+        if lora_path is None:
+            lora_path = get_step_checkpoint_dir(self.output_dir, 0)
+            self._latest_step = 0
+        else:
+            self._latest_step = get_step_from_dir(self.output_dir)
+        self._ensure_identity_lora(lora_path)
+        self._ensure_lora_adapter_config(lora_path)
+        return lora_path
+
+    async def _start_vllm_subprocess(
+        self,
+        lora_path: str,
+        port: int,
+        config: dev.OpenAIServerConfig | None,
+    ) -> tuple[str, int]:
+        import atexit
+
+        import httpx
+
+        inference_gpu_ids = self.config["inference_gpu_ids"]
+        cuda_devices = ",".join(str(gpu_id) for gpu_id in inference_gpu_ids)
+
+        server_args: dict[str, object] = {
+            "return_tokens_as_token_ids": True,
+            "enable_auto_tool_choice": True,
+            "tool_call_parser": "hermes",
+        }
+        if config and "server_args" in config:
+            server_args.update(dict(config["server_args"]))
+        for key in ("port", "host", "lora_modules", "api_key"):
+            server_args.pop(key, None)
+
+        engine_args = dict(self.config.get("engine_args", {}))
+        if config and "engine_args" in config:
+            engine_args.update(dict(config["engine_args"]))
+        engine_args.setdefault("generation_config", "vllm")
+        engine_args["enable_lora"] = True
+        engine_args.setdefault("max_loras", 2)
+        for key in ("model", "served_model_name", "enable_sleep_mode"):
+            engine_args.pop(key, None)
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "art.vllm.dedicated_server",
+            f"--model={self.base_model}",
+            f"--port={port}",
+            f"--host={self._vllm_host}",
+            f"--cuda-visible-devices={cuda_devices}",
+            f"--lora-path={lora_path}",
+            f"--served-model-name={self.model_name}@{self._latest_step}",
+            f"--rollout-weights-mode={self.rollout_weights_mode}",
+            f"--engine-args-json={json.dumps(engine_args)}",
+            f"--server-args-json={json.dumps(server_args)}",
+        ]
+
+        log_dir = os.path.join(self.output_dir, "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        self._vllm_log_file = open(
+            os.path.join(log_dir, "vllm-dedicated.log"), "w", buffering=1
+        )
+        self._vllm_process = subprocess.Popen(
+            cmd,
+            stdout=self._vllm_log_file,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
+        )
+        self._vllm_port = port
+
+        timeout = float(os.environ.get("ART_DEDICATED_VLLM_TIMEOUT", 600))
+        elapsed = 0.0
+        async with httpx.AsyncClient() as client:
+            while elapsed < timeout:
+                if self._vllm_process.poll() is not None:
+                    raise RuntimeError(
+                        "vLLM subprocess exited with code "
+                        f"{self._vllm_process.returncode}. "
+                        f"Check logs at {log_dir}/vllm-dedicated.log"
+                    )
+                try:
+                    response = await client.get(
+                        f"{self._vllm_base_url}/v1/models",
+                        timeout=5.0,
+                    )
+                    if response.status_code == 200:
+                        break
+                except (httpx.ConnectError, httpx.ReadTimeout):
+                    pass
+                await asyncio.sleep(1.0)
+                elapsed += 1.0
+            else:
+                self._stop_vllm_subprocess()
+                raise TimeoutError(
+                    f"vLLM subprocess did not become ready within {timeout}s. "
+                    f"Check logs at {log_dir}/vllm-dedicated.log"
+                )
+
+        atexit.register(self.close)
+        logger.info("vLLM subprocess ready on port %d (GPUs: %s)", port, cuda_devices)
+        return self._vllm_host, self._vllm_port
+
+    async def _reload_adapter(self, checkpoint_path: str, step: int) -> None:
+        import httpx
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self._vllm_base_url}/v1/load_lora_adapter",
+                json={
+                    "lora_name": f"{self.model_name}@{step}",
+                    "lora_path": checkpoint_path,
+                    "load_inplace": True,
+                },
+                timeout=60.0,
+            )
+            response.raise_for_status()
+        self._latest_step = step
+
+    def _stop_vllm_subprocess(self) -> None:
+        if self._vllm_process is not None:
+            self._vllm_process.terminate()
+            try:
+                self._vllm_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._vllm_process.kill()
+                self._vllm_process.wait()
+            self._vllm_process = None
+        if self._vllm_log_file is not None:
+            self._vllm_log_file.close()
+            self._vllm_log_file = None
+
+    def _stop_megatron_process(self) -> None:
+        if self._megatron_process is None:
+            return
+        if self._megatron_process.returncode is None:
+            self._megatron_process.terminate()
+        self._megatron_process = None
+
     async def _add_lora_aliases(
         self, llm: AsyncLLM, step: int, checkpoint_dir: str
     ) -> None:
@@ -237,6 +401,10 @@ class MegatronService:
         self._latest_step = step
 
     async def register_lora_for_step(self, step: int, checkpoint_dir: str) -> None:
+        if self.is_dedicated:
+            assert self.rollout_weights_mode == "lora"
+            await self._reload_adapter(checkpoint_dir, step)
+            return
         llm = await self.llm
         await llm.pause_generation()
         await self._add_lora_aliases(llm, step, checkpoint_dir)
@@ -259,19 +427,26 @@ class MegatronService:
 
         train_script = Path(__file__).parent / "train.py"
         project_root = Path(__file__).resolve().parents[3]
-        num_gpus = torch.cuda.device_count()
         jobs_dir, _training_log_dir, wake_lock_path = self._megatron_runtime_paths()
-        env = os.environ.copy()
-        env["MODEL_IDENTIFIER"] = self.base_model
-        env["ART_MEGATRON_JOBS_DIR"] = jobs_dir
-        env["ART_MEGATRON_WAKE_LOCK_PATH"] = wake_lock_path
-        master_addr = env.get("MASTER_ADDR", "127.0.0.1")
+        launch_env = os.environ.copy()
+        if self.is_dedicated:
+            trainer_gpu_ids = self.config["trainer_gpu_ids"]
+            num_gpus = len(trainer_gpu_ids)
+            launch_env["CUDA_VISIBLE_DEVICES"] = ",".join(
+                str(gpu_id) for gpu_id in trainer_gpu_ids
+            )
+        else:
+            num_gpus = torch.cuda.device_count()
+        launch_env["MODEL_IDENTIFIER"] = self.base_model
+        launch_env["ART_MEGATRON_JOBS_DIR"] = jobs_dir
+        launch_env["ART_MEGATRON_WAKE_LOCK_PATH"] = wake_lock_path
+        master_addr = launch_env.get("MASTER_ADDR", "127.0.0.1")
         master_port = str(self._allocate_master_port())
-        env["MASTER_ADDR"] = master_addr
-        env["MASTER_PORT"] = master_port
+        launch_env["MASTER_ADDR"] = master_addr
+        launch_env["MASTER_PORT"] = master_port
         random_state = self._megatron_random_state()
         if random_state is not None:
-            env["ART_MEGATRON_RANDOM_STATE"] = str(random_state)
+            launch_env["ART_MEGATRON_RANDOM_STATE"] = str(random_state)
 
         command = (
             f"{setup_cmd}uv run --project {shlex.quote(str(project_root))} "
@@ -282,7 +457,7 @@ class MegatronService:
         self._megatron_process = await asyncio.create_subprocess_shell(
             command,
             cwd=str(project_root),
-            env=env,
+            env=launch_env,
         )
 
     def _clear_pending_jobs(self) -> None:
@@ -300,13 +475,7 @@ class MegatronService:
         )
 
     def _resolve_training_lora_path(self) -> str:
-        lora_path = get_last_checkpoint_dir(self.output_dir)
-        if lora_path is None:
-            lora_path = get_step_checkpoint_dir(self.output_dir, 0)
-            self._latest_step = 0
-        self._ensure_identity_lora(lora_path)
-        self._ensure_lora_adapter_config(lora_path)
-        return lora_path
+        return self._resolve_active_lora_path()
 
     async def _prepare_for_training(self) -> tuple[AsyncLLM, str]:
         llm = await self.llm
@@ -349,17 +518,26 @@ class MegatronService:
         await self._add_lora_aliases(llm, next_step, new_checkpoint_dir)
         await llm.resume_generation()
 
+    async def _publish_dedicated_training_checkpoint(self, *, lora_path: str) -> None:
+        next_step = self._latest_step + 1
+        new_checkpoint_dir = get_step_checkpoint_dir(self.output_dir, next_step)
+        os.makedirs(new_checkpoint_dir, exist_ok=True)
+        shutil.copy(
+            f"{lora_path}/adapter_model.safetensors",
+            f"{new_checkpoint_dir}/adapter_model.safetensors",
+        )
+        self._ensure_lora_adapter_config(new_checkpoint_dir, source_path=lora_path)
+        await self._reload_adapter(new_checkpoint_dir, next_step)
+
     async def start_openai_server(
         self, config: dev.OpenAIServerConfig | None
     ) -> tuple[str, int]:
-        lora_path = get_last_checkpoint_dir(self.output_dir)
-        if lora_path is None:
-            lora_path = get_step_checkpoint_dir(self.output_dir, 0)
-            self._latest_step = 0
-        else:
-            self._latest_step = get_step_from_dir(self.output_dir)
-        self._ensure_identity_lora(lora_path)
-        self._ensure_lora_adapter_config(lora_path)
+        lora_path = self._resolve_active_lora_path()
+
+        if self.is_dedicated:
+            assert self.rollout_weights_mode == "lora"
+            port = (config or {}).get("server_args", {}).get("port", 8000)
+            return await self._start_vllm_subprocess(lora_path, port, config)
 
         lora_path_for_server = (
             lora_path if self._adapter_has_weights(lora_path) else None
@@ -378,7 +556,16 @@ class MegatronService:
         )
 
     async def vllm_engine_is_sleeping(self) -> bool:
+        if self.is_dedicated:
+            return False
         return self._is_sleeping
+
+    async def aclose(self) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._stop_vllm_subprocess()
+        self._stop_megatron_process()
 
     async def train(
         self,
@@ -387,6 +574,37 @@ class MegatronService:
         _config: dev.TrainConfig,
         verbose: bool = False,
     ) -> AsyncIterator[dict[str, float]]:
+        if self.is_dedicated:
+            assert self.rollout_weights_mode == "lora"
+            await self._ensure_megatron_running()
+
+            lora_path = self._resolve_active_lora_path()
+            self._clear_pending_jobs()
+            if _config.get("moe_routing_replay_bundle") is not None:
+                raise RuntimeError(
+                    "moe_routing_replay_bundle is only supported for in-process/runtime APIs; "
+                    "MegatronService subprocess jobs must use moe_routing_replay_path."
+                )
+            job_path, log_path = self._create_megatron_job_paths()
+            job = MegatronTrainingJob(
+                lora_path=lora_path,
+                optimizer_state_path=self._get_optimizer_state_path("rl"),
+                disk_packed_tensors=disk_packed_tensors,
+                config=config,
+                experimental_config=cast(dict[str, Any], _config),
+                moe_routing_replay_path=_config.get("moe_routing_replay_path"),
+                moe_routing_replay_strict=_config.get(
+                    "moe_routing_replay_strict", True
+                ),
+                log_path=log_path,
+            )
+            write_megatron_job(job, job_path=job_path)
+
+            async for result in stream_megatron_job(job, job_path=job_path):
+                yield {key: float(value) for key, value in result.items()}
+
+            await self._publish_dedicated_training_checkpoint(lora_path=lora_path)
+            return
         llm, lora_path = await self._prepare_for_training()
         if _config.get("moe_routing_replay_bundle") is not None:
             raise RuntimeError(
@@ -417,6 +635,10 @@ class MegatronService:
         config: types.TrainSFTConfig,
         verbose: bool = False,
     ) -> AsyncIterator[dict[str, float]]:
+        if self.is_dedicated:
+            raise NotImplementedError(
+                "SFT training is not supported for dedicated MegatronService"
+            )
         llm, lora_path = await self._prepare_for_training()
         serialized_batches = materialize_sft_batches(batches)
         job_path, log_path = self._create_megatron_job_paths()

--- a/tests/unit/test_megatron_dedicated.py
+++ b/tests/unit/test_megatron_dedicated.py
@@ -61,7 +61,9 @@ async def test_megatron_backend_dedicated_uses_trainer_gpus_without_child_proces
     monkeypatch.setattr(
         "art.megatron.backend.move_to_child_process",
         lambda *args, **kwargs: (_ for _ in ()).throw(
-            AssertionError("Dedicated Megatron service should not move to a child process")
+            AssertionError(
+                "Dedicated Megatron service should not move to a child process"
+            )
         ),
     )
     monkeypatch.setattr("art.megatron.service.MegatronService", FakeService)
@@ -95,7 +97,9 @@ async def test_megatron_service_ensure_megatron_running_uses_trainer_gpus(
 
     seen: dict[str, Any] = {}
 
-    monkeypatch.setattr("art.megatron.service.subprocess.run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "art.megatron.service.subprocess.run", lambda *args, **kwargs: None
+    )
 
     async def fake_create_subprocess_shell(
         command: str,
@@ -145,7 +149,9 @@ async def test_megatron_service_start_openai_server_dedicated_starts_subprocess(
         lambda _output_dir: str(checkpoint_dir),
     )
     monkeypatch.setattr(service, "_ensure_identity_lora", lambda _path: None)
-    monkeypatch.setattr(service, "_ensure_lora_adapter_config", lambda _path, source_path=None: None)
+    monkeypatch.setattr(
+        service, "_ensure_lora_adapter_config", lambda _path, source_path=None: None
+    )
 
     async def fake_start_vllm_subprocess(
         lora_path: str,
@@ -186,7 +192,9 @@ async def test_megatron_service_register_lora_for_step_dedicated_reloads_adapter
     monkeypatch.setattr(
         service,
         "_reload_adapter",
-        lambda checkpoint_dir, step: seen.append((checkpoint_dir, step)) or asyncio.sleep(0),
+        lambda checkpoint_dir, step: (
+            seen.append((checkpoint_dir, step)) or asyncio.sleep(0)
+        ),
     )
 
     await service.register_lora_for_step(3, "/tmp/checkpoints/3")

--- a/tests/unit/test_megatron_dedicated.py
+++ b/tests/unit/test_megatron_dedicated.py
@@ -1,0 +1,194 @@
+import asyncio
+import os
+from pathlib import Path
+import shlex
+import sys
+import types as pytypes
+from typing import Any
+
+import pytest
+
+pytest.importorskip("vllm")
+
+from art import TrainableModel, types
+from art.dev.model import InternalModelConfig
+from art.megatron.backend import MegatronBackend
+from art.megatron.service import MegatronService
+
+
+@pytest.mark.asyncio
+async def test_megatron_backend_dedicated_uses_trainer_gpus_without_child_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = InternalModelConfig(
+        trainer_gpu_ids=[0],
+        inference_gpu_ids=[1],
+        rollout_weights_mode="lora",
+    )
+    model = TrainableModel(
+        name="megatron-dedicated",
+        project="unit-tests",
+        base_model="Qwen/Qwen3-30B-A3B-Instruct-2507",
+        base_path=str(tmp_path),
+        _internal_config=config,
+    )
+    backend = MegatronBackend(path=str(tmp_path))
+    validated: dict[str, Any] = {}
+
+    class FakeService:
+        def __init__(
+            self,
+            *,
+            model_name: str,
+            base_model: str,
+            config: InternalModelConfig,
+            output_dir: str,
+        ) -> None:
+            self.model_name = model_name
+            self.base_model = base_model
+            self.config = config
+            self.output_dir = output_dir
+
+    monkeypatch.setattr(
+        "art.dev.get_model_config.get_model_config",
+        lambda *args, **kwargs: config,
+    )
+    monkeypatch.setattr(
+        "art.dev.validate.validate_dedicated_config",
+        lambda cfg: validated.setdefault("config", cfg),
+    )
+    monkeypatch.setattr(
+        "art.megatron.backend.move_to_child_process",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("Dedicated Megatron service should not move to a child process")
+        ),
+    )
+    monkeypatch.setattr("art.megatron.service.MegatronService", FakeService)
+
+    service = await backend._get_service(model)
+
+    assert isinstance(service, FakeService)
+    assert validated["config"] is config
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_megatron_service_ensure_megatron_running_uses_trainer_gpus(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = MegatronService(
+        model_name="megatron-dedicated",
+        base_model="Qwen/Qwen3-30B-A3B-Instruct-2507",
+        config=InternalModelConfig(
+            trainer_gpu_ids=[0, 1],
+            inference_gpu_ids=[2],
+            rollout_weights_mode="lora",
+        ),
+        output_dir=str(tmp_path),
+    )
+    megatron_module = pytypes.ModuleType("megatron")
+    megatron_bridge_module = pytypes.ModuleType("megatron.bridge")
+    monkeypatch.setitem(sys.modules, "megatron", megatron_module)
+    monkeypatch.setitem(sys.modules, "megatron.bridge", megatron_bridge_module)
+
+    seen: dict[str, Any] = {}
+
+    monkeypatch.setattr("art.megatron.service.subprocess.run", lambda *args, **kwargs: None)
+
+    async def fake_create_subprocess_shell(
+        command: str,
+        cwd: str,
+        env: dict[str, str],
+    ) -> Any:
+        seen["command"] = command
+        seen["cwd"] = cwd
+        seen["env"] = env
+        return pytypes.SimpleNamespace(returncode=None)
+
+    monkeypatch.setattr(
+        "art.megatron.service.asyncio.create_subprocess_shell",
+        fake_create_subprocess_shell,
+    )
+
+    await service._ensure_megatron_running()
+
+    assert shlex.quote(sys.executable) in seen["command"]
+    assert "torch.distributed.run" in seen["command"]
+    assert "--nproc_per_node 2" in seen["command"]
+    assert seen["env"]["CUDA_VISIBLE_DEVICES"] == "0,1"
+    assert seen["env"]["MODEL_IDENTIFIER"] == "Qwen/Qwen3-30B-A3B-Instruct-2507"
+
+
+@pytest.mark.asyncio
+async def test_megatron_service_start_openai_server_dedicated_starts_subprocess(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint_dir = tmp_path / "checkpoints" / "0000"
+    checkpoint_dir.mkdir(parents=True)
+    service = MegatronService(
+        model_name="megatron-dedicated",
+        base_model="Qwen/Qwen3-30B-A3B-Instruct-2507",
+        config=InternalModelConfig(
+            trainer_gpu_ids=[0],
+            inference_gpu_ids=[1],
+            rollout_weights_mode="lora",
+        ),
+        output_dir=str(tmp_path),
+    )
+    seen: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        "art.megatron.service.get_last_checkpoint_dir",
+        lambda _output_dir: str(checkpoint_dir),
+    )
+    monkeypatch.setattr(service, "_ensure_identity_lora", lambda _path: None)
+    monkeypatch.setattr(service, "_ensure_lora_adapter_config", lambda _path, source_path=None: None)
+
+    async def fake_start_vllm_subprocess(
+        lora_path: str,
+        port: int,
+        config: dict[str, Any] | None,
+    ) -> tuple[str, int]:
+        seen["lora_path"] = lora_path
+        seen["port"] = port
+        seen["config"] = config
+        return ("127.0.0.1", port)
+
+    monkeypatch.setattr(service, "_start_vllm_subprocess", fake_start_vllm_subprocess)
+
+    location = await service.start_openai_server({"server_args": {"port": 8123}})
+
+    assert location == ("127.0.0.1", 8123)
+    assert seen["lora_path"] == str(checkpoint_dir)
+    assert seen["port"] == 8123
+
+
+@pytest.mark.asyncio
+async def test_megatron_service_register_lora_for_step_dedicated_reloads_adapter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = MegatronService(
+        model_name="megatron-dedicated",
+        base_model="Qwen/Qwen3-30B-A3B-Instruct-2507",
+        config=InternalModelConfig(
+            trainer_gpu_ids=[0],
+            inference_gpu_ids=[1],
+            rollout_weights_mode="lora",
+        ),
+        output_dir=str(tmp_path),
+    )
+    seen: list[tuple[str, int]] = []
+
+    monkeypatch.setattr(
+        service,
+        "_reload_adapter",
+        lambda checkpoint_dir, step: seen.append((checkpoint_dir, step)) or asyncio.sleep(0),
+    )
+
+    await service.register_lora_for_step(3, "/tmp/checkpoints/3")
+
+    assert seen == [("/tmp/checkpoints/3", 3)]


### PR DESCRIPTION
## Summary

This adds dedicated `lora` mode to the Megatron backend so inference and training can run on separate GPUs in parallel.

In dedicated mode, ART now keeps a dedicated vLLM server on the inference GPU and updates LoRA adapters in place after training steps. That makes the Megatron flow match the dedicated-serving model we already use elsewhere instead of treating training as a blocking operation.

## What this enables

- Use Megatron with separate trainer and inference GPUs in dedicated mode
- Keep rollout serving on the inference GPU while Megatron trains on the trainer GPU
- Advance served model steps by reloading the next adapter into the running vLLM server

## Validation

- Unit coverage:
  - `tests/unit/test_megatron_dedicated.py`
- 2-GPU smoke on a fresh H200 machine:
  - trainer on GPU `0`
  - inference on GPU `1`
  - base model `Qwen/Qwen3-30B-A3B-Instruct-2507`
  - dedicated `lora` mode completed two real train steps and advanced the served model from `@0` to `@2`
