### PR TITLE
Expose LocalBackend from top-level package

### DIFF
--- a/src/art/__init__.py
+++ b/src/art/__init__.py
@@ -17,8 +17,12 @@ command above and they will appear in the project directory.
 """
 
 import os
+from typing import Any, TYPE_CHECKING
 
 from dotenv import load_dotenv
+
+if TYPE_CHECKING:
+    from .local import LocalBackend
 
 load_dotenv()
 
@@ -87,6 +91,17 @@ from .types import (
 )
 from .utils import retry
 from .yield_trajectory import capture_yielded_trajectory, yield_trajectory
+
+
+def __getattr__(name: str) -> Any:
+    if name == "LocalBackend":
+        # Keep backend-only dependencies optional until the symbol is requested.
+        from .local import LocalBackend
+
+        globals()[name] = LocalBackend
+        return LocalBackend
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "dev",

--- a/tests/unit/test_package_exports.py
+++ b/tests/unit/test_package_exports.py
@@ -1,0 +1,7 @@
+import art
+
+
+def test_art_localbackend_top_level_export():
+    from art.local import LocalBackend
+
+    assert art.LocalBackend is LocalBackend


### PR DESCRIPTION
## Summary
- expose `art.LocalBackend` via lazy top-level export
- keep backend-only dependencies optional during `import art`
- add a regression test for the top-level export

## Notes
- no runtime behavior change beyond restoring the documented top-level API