### PR TITLE
DeepEP, `torch.compile` and Fix Megatron Training Bug

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install CI dependencies
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends ca-certificates curl git zstd
+          apt-get install -y --no-install-recommends ca-certificates curl git zstd libibverbs-dev
           rm -rf /var/lib/apt/lists/*
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "/root/.local/bin" >> "${GITHUB_PATH}"
@@ -130,7 +130,7 @@ jobs:
       - name: Install CI dependencies
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends ca-certificates curl git zstd
+          apt-get install -y --no-install-recommends ca-certificates curl git zstd libibverbs-dev
           rm -rf /var/lib/apt/lists/*
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "/root/.local/bin" >> "${GITHUB_PATH}"

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -18,7 +18,7 @@ env:
   CI_UV_BUILD_SLOTS: "2"
   UV_CACHE_DIR: "/root/.cache/uv"
   UV_LINK_MODE: "copy"
-  TORCH_CUDA_ARCH_LIST: "8.0"
+  TORCH_CUDA_ARCH_LIST: "9.0"
 
 jobs:
   cache-status:
@@ -38,6 +38,7 @@ jobs:
             --uv-lock uv.lock \
             --base-image "${CI_BASE_IMAGE}" \
             --python-mm "${CI_PYTHON_MM}" \
+            --torch-cuda-arch-list "${TORCH_CUDA_ARCH_LIST}" \
             --ci-apex-parallel-build "${CI_APEX_PARALLEL_BUILD}" \
             --ci-apex-nvcc-threads "${CI_APEX_NVCC_THREADS}")"
           echo "fingerprint=${fp}" >> "${GITHUB_OUTPUT}"

--- a/dev/yes_no_maybe_trainability.py
+++ b/dev/yes_no_maybe_trainability.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import asyncio
+from itertools import permutations
+import json
+import os
+from pathlib import Path
+import re
+import time
+from typing import cast
+
+from dotenv import load_dotenv
+import openai
+
+try:
+    import unsloth  # noqa: F401
+except ImportError:
+    pass
+
+import art
+from art.local import LocalBackend
+from art.megatron import MegatronBackend
+
+
+def _disable_wandb() -> None:
+    os.environ["WANDB_DISABLED"] = "true"
+    os.environ["WANDB_MODE"] = "disabled"
+    os.environ["WANDB_SILENT"] = "true"
+    os.environ.pop("WANDB_API_KEY", None)
+
+
+def _get_env_bool(name: str, default: bool | None = None) -> bool | None:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Invalid boolean value for {name}: {value!r}")
+
+
+def _get_env_int_list(name: str) -> list[int] | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    parts = [part.strip() for part in value.split(",") if part.strip()]
+    if not parts:
+        raise ValueError(f"Invalid GPU ID list for {name}: {value!r}")
+    return [int(part) for part in parts]
+
+
+def _with_quotes(word: str) -> str:
+    return f"'{word}'"
+
+
+def build_prompts() -> list[str]:
+    prompts: list[str] = []
+    for prefix in ["respond", "just respond"]:
+        for use_quotes in [True, False]:
+            for length in [3, 2]:
+                for words in permutations(["yes", "no", "maybe"], length):
+                    rendered_words = (
+                        [_with_quotes(word) for word in words]
+                        if use_quotes
+                        else list(words)
+                    )
+                    suffix = (
+                        ", ".join(rendered_words)
+                        if length == 3
+                        else f"{rendered_words[0]} or {rendered_words[1]}"
+                    )
+                    prompts.append(f"{prefix} with {suffix}")
+    return prompts
+
+
+def reward_for_answer(answer: str) -> float:
+    if answer == "yes":
+        return 0.5
+    if answer == "no":
+        return 0.75
+    if answer == "maybe":
+        return 1.0
+    return 0.0
+
+
+def first_word_for_answer(content: str | None) -> str:
+    if not content:
+        return ""
+    content = re.sub(
+        r"<think>.*?</think>\s*",
+        "",
+        content,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    words = content.strip().lower().split(maxsplit=1)
+    if not words:
+        return ""
+    return words[0].strip(".,!?:;\"'()[]{}")
+
+
+def scenario_id_for_prompt(prompt: str) -> str:
+    return prompt.replace(" ", "_").replace("'", "")
+
+
+def response_total_tokens(
+    response: openai.types.chat.chat_completion.ChatCompletion,
+) -> int:
+    usage = response.usage
+    if usage is None:
+        return 0
+    return int(usage.prompt_tokens or 0) + int(usage.completion_tokens or 0)
+
+
+def total_actor_tokens(groups: list[art.TrajectoryGroup]) -> int:
+    return sum(
+        int(trajectory.metadata.get("actor_total_tokens", 0) or 0)
+        for group in groups
+        for trajectory in group.trajectories
+    )
+
+
+def mean_reward(groups: list[art.TrajectoryGroup]) -> float:
+    rewards = [
+        trajectory.reward for group in groups for trajectory in group.trajectories
+    ]
+    if not rewards:
+        return 0.0
+    return sum(rewards) / len(rewards)
+
+
+async def rollout(
+    client: openai.AsyncOpenAI,
+    model: art.TrainableModel,
+    prompt: str,
+    *,
+    max_tokens: int,
+    timeout: float,
+    enable_thinking: bool,
+) -> art.Trajectory:
+    messages: art.Messages = [{"role": "user", "content": prompt}]
+    chat_completion = await client.chat.completions.create(
+        messages=messages,
+        model=model.get_inference_name(),
+        max_tokens=max_tokens,
+        timeout=timeout,
+        extra_body={"chat_template_kwargs": {"enable_thinking": enable_thinking}},
+    )
+    choice = chat_completion.choices[0]
+    answer = first_word_for_answer(choice.message.content)
+    return art.Trajectory(
+        messages_and_choices=[*messages, choice],
+        reward=reward_for_answer(answer),
+        metadata={
+            "scenario_id": scenario_id_for_prompt(prompt),
+            "actor_total_tokens": response_total_tokens(chat_completion),
+        },
+        metrics={
+            "valid_answer": answer in {"yes", "no", "maybe"},
+            "answer_is_yes": answer == "yes",
+            "answer_is_no": answer == "no",
+            "answer_is_maybe": answer == "maybe",
+        },
+    )
+
+
+async def gather_groups(
+    client: openai.AsyncOpenAI,
+    model: art.TrainableModel,
+    prompts: list[str],
+    *,
+    rollouts_per_prompt: int,
+    max_tokens: int,
+    timeout: float,
+    enable_thinking: bool,
+) -> list[art.TrajectoryGroup]:
+    return await art.gather_trajectory_groups(
+        (
+            art.TrajectoryGroup(
+                rollout(
+                    client,
+                    model,
+                    prompt,
+                    max_tokens=max_tokens,
+                    timeout=timeout,
+                    enable_thinking=enable_thinking,
+                )
+                for _ in range(rollouts_per_prompt)
+            )
+            for prompt in prompts
+        )
+    )
+
+
+def build_internal_config() -> art.dev.InternalModelConfig:
+    visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    visible_gpu_count = (
+        len([device for device in visible_devices.split(",") if device.strip()])
+        if visible_devices
+        else 1
+    )
+    init_args: art.dev.InitArgs = {
+        "max_seq_length": int(os.environ.get("MAX_SEQ_LENGTH", "4096"))
+    }
+    load_in_4bit = _get_env_bool("LOAD_IN_4BIT")
+    if load_in_4bit is not None:
+        init_args["load_in_4bit"] = load_in_4bit
+    load_in_16bit = _get_env_bool("LOAD_IN_16BIT")
+    if load_in_16bit is not None:
+        init_args["load_in_16bit"] = load_in_16bit
+
+    config = art.dev.InternalModelConfig(
+        engine_args=art.dev.EngineArgs(
+            gpu_memory_utilization=float(
+                os.environ.get("GPU_MEMORY_UTILIZATION", "0.85")
+            ),
+            max_model_len=int(os.environ.get("MAX_MODEL_LEN", "4096")),
+            max_num_seqs=int(os.environ.get("MAX_NUM_SEQS", "8")),
+            enforce_eager=_get_env_bool("ENFORCE_EAGER", True),
+            tensor_parallel_size=int(
+                os.environ.get("TENSOR_PARALLEL_SIZE", str(max(1, visible_gpu_count)))
+            ),
+        ),
+        init_args=init_args,
+    )
+
+    trainer_gpu_ids = _get_env_int_list("TRAINER_GPU_IDS")
+    inference_gpu_ids = _get_env_int_list("INFERENCE_GPU_IDS")
+    if (trainer_gpu_ids is None) != (inference_gpu_ids is None):
+        raise ValueError(
+            "TRAINER_GPU_IDS and INFERENCE_GPU_IDS must both be set or both unset"
+        )
+    if trainer_gpu_ids is not None and inference_gpu_ids is not None:
+        config["trainer_gpu_ids"] = trainer_gpu_ids
+        config["inference_gpu_ids"] = inference_gpu_ids
+
+    rollout_weights_mode = os.environ.get("ROLLOUT_WEIGHTS_MODE")
+    if rollout_weights_mode is not None:
+        config["rollout_weights_mode"] = rollout_weights_mode
+    return config
+
+
+def make_backend(
+    backend_name: str, art_path: str, *, in_process: bool
+) -> LocalBackend | MegatronBackend:
+    if backend_name == "local":
+        return LocalBackend(path=art_path, in_process=in_process)
+    if backend_name == "megatron":
+        return MegatronBackend(path=art_path, in_process=in_process)
+    raise ValueError(f"Unsupported BACKEND={backend_name!r}")
+
+
+def output_dir_for_model(model: art.TrainableModel) -> Path:
+    return Path(model.base_path) / model.project / "models" / model.name
+
+
+async def main() -> None:
+    load_dotenv()
+    _disable_wandb()
+
+    backend_name = os.environ.get("BACKEND", "local")
+    run_id = os.environ.get("RUN_ID", str(int(time.time())))
+    project = os.environ.get("PROJECT", f"yes-no-maybe-{backend_name}")
+    model_name = os.environ.get("MODEL_NAME", f"{backend_name}-{run_id}")
+    art_path = os.environ.get(
+        "ART_PATH",
+        f"/tmp/art_yes_no_maybe_trainability/{backend_name}/{run_id}",
+    )
+    base_model = os.environ.get("BASE_MODEL", "Qwen/Qwen3-30B-A3B-Instruct-2507")
+    in_process = bool(_get_env_bool("IN_PROCESS", False))
+    num_steps = int(os.environ.get("NUM_STEPS", "20"))
+    rollouts_per_prompt = int(os.environ.get("ROLLOUTS_PER_PROMPT", "32"))
+    eval_rollouts_per_prompt = int(os.environ.get("EVAL_ROLLOUTS_PER_PROMPT", "4"))
+    eval_prompts = int(os.environ.get("EVAL_PROMPTS", "12"))
+    max_tokens = int(os.environ.get("MAX_TOKENS", "100"))
+    timeout = float(os.environ.get("TIMEOUT", "100"))
+    learning_rate = float(os.environ.get("LEARNING_RATE", "1e-4"))
+    packed_sequence_length = os.environ.get("PACKED_SEQUENCE_LENGTH")
+    enable_thinking = bool(_get_env_bool("ENABLE_THINKING", False))
+
+    os.makedirs(art_path, exist_ok=True)
+    backend = make_backend(backend_name, art_path, in_process=in_process)
+    model = art.TrainableModel(
+        name=model_name,
+        project=project,
+        base_model=base_model,
+        report_metrics=[],
+        _internal_config=build_internal_config(),
+    )
+
+    prompts = build_prompts()
+    eval_prompt_subset = prompts[:eval_prompts]
+    run_summary: dict[str, object] = {
+        "backend": backend_name,
+        "art_path": art_path,
+        "project": project,
+        "model_name": model_name,
+        "base_model": base_model,
+        "in_process": in_process,
+        "num_steps": num_steps,
+        "rollouts_per_prompt": rollouts_per_prompt,
+        "eval_rollouts_per_prompt": eval_rollouts_per_prompt,
+        "eval_prompts": eval_prompts,
+        "max_tokens": max_tokens,
+        "learning_rate": learning_rate,
+        "packed_sequence_length": (
+            None if packed_sequence_length is None else int(packed_sequence_length)
+        ),
+        "steps": [],
+    }
+
+    try:
+        await model.register(backend)
+        client = model.openai_client()
+        start_step = await model.get_step()
+        summary_path = output_dir_for_model(model) / "trainability_summary.json"
+
+        for offset in range(num_steps):
+            current_step = start_step + offset
+            val_groups = await gather_groups(
+                client,
+                model,
+                eval_prompt_subset,
+                rollouts_per_prompt=eval_rollouts_per_prompt,
+                max_tokens=max_tokens,
+                timeout=timeout,
+                enable_thinking=enable_thinking,
+            )
+            await model.log(val_groups, split="val", step=current_step)
+
+            train_groups = await gather_groups(
+                client,
+                model,
+                prompts,
+                rollouts_per_prompt=rollouts_per_prompt,
+                max_tokens=max_tokens,
+                timeout=timeout,
+                enable_thinking=enable_thinking,
+            )
+            train_kwargs: dict[str, object] = {"learning_rate": learning_rate}
+            if packed_sequence_length is not None:
+                train_kwargs["packed_sequence_length"] = int(packed_sequence_length)
+            result = await backend.train(model, train_groups, **train_kwargs)
+            await model.log(
+                train_groups,
+                split="train",
+                step=result.step,
+                metrics=result.metrics,
+            )
+
+            step_summary = {
+                "step": result.step,
+                "pre_train_val_reward": mean_reward(val_groups),
+                "train_reward": mean_reward(train_groups),
+                "val_actor_tokens": total_actor_tokens(val_groups),
+                "train_actor_tokens": total_actor_tokens(train_groups),
+                "train_metrics": result.metrics,
+            }
+            cast(list[dict[str, object]], run_summary["steps"]).append(step_summary)
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            summary_path.write_text(json.dumps(run_summary, indent=2) + "\n")
+            print(json.dumps(step_summary, sort_keys=True))
+
+        print(f"SUMMARY_PATH={summary_path}")
+        print(f"HISTORY_PATH={output_dir_for_model(model) / 'history.jsonl'}")
+    finally:
+        await backend.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ megatron = [
     "megatron-core==0.16.0rc0",
     "pybind11>=2.13.6",
     "megatron-bridge",
+    "deep_ep @ git+https://github.com/deepseek-ai/DeepEP.git@v1.2.1 ; sys_platform == 'linux'",
     "nvidia-ml-py==13.580.82",
     "ml-dtypes>=0.5.0 ; python_full_version < '3.13'",
 ]
@@ -139,7 +140,7 @@ override-dependencies = [
     "quack-kernels==0.2.5",
 ]
 exclude-dependencies = ["pynvml", "emerging-optimizers"]
-no-build-isolation-package = ["apex", "transformer-engine", "transformer-engine-cu12", "transformer-engine-torch", "megatron-core", "megatron-bridge", "nv-grouped-gemm", "mamba-ssm", "causal-conv1d"]
+no-build-isolation-package = ["apex", "transformer-engine", "transformer-engine-cu12", "transformer-engine-torch", "megatron-core", "megatron-bridge", "deep-ep", "nv-grouped-gemm", "mamba-ssm", "causal-conv1d"]
 
 [tool.uv.extra-build-dependencies]
 apex = ["torch>=2.8.0"]

--- a/scripts/ci/build_and_push_uv_cache.sh
+++ b/scripts/ci/build_and_push_uv_cache.sh
@@ -13,6 +13,7 @@ AUTO_BUILD_JOBS_MAX="${AUTO_BUILD_JOBS_MAX:-8}"
 UV_BUILD_SLOTS="${UV_BUILD_SLOTS:-2}"
 CI_APEX_PARALLEL_BUILD="${CI_APEX_PARALLEL_BUILD:-8}"
 CI_APEX_NVCC_THREADS="${CI_APEX_NVCC_THREADS:-1}"
+TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-9.0}"
 KEEP_COUNT="${KEEP_COUNT:-4}"
 PART_SIZE_MB="${PART_SIZE_MB:-1900}"
 UPLOAD_JOBS="${UPLOAD_JOBS:-4}"
@@ -158,7 +159,8 @@ compute_fingerprint() {
     --pyproject "${REPO_ROOT}/pyproject.toml" \
     --uv-lock "${REPO_ROOT}/uv.lock" \
     --base-image "${BASE_IMAGE}" \
-    --python-mm "${PYTHON_MM}"
+    --python-mm "${PYTHON_MM}" \
+    --torch-cuda-arch-list "${TORCH_CUDA_ARCH_LIST}"
 }
 
 resolve_build_jobs() {
@@ -270,7 +272,7 @@ build_cache_archive() {
   export CMAKE_BUILD_PARALLEL_LEVEL="${compile_jobs}"
   export MAX_JOBS="${compile_jobs}"
   export NINJAFLAGS="-j${compile_jobs}"
-  export TORCH_CUDA_ARCH_LIST=8.0
+  export TORCH_CUDA_ARCH_LIST
 
   local cudnn_path="${TMP_DIR}/.venv/lib/python${PYTHON_MM}/site-packages/nvidia/cudnn"
   export CUDNN_PATH="${cudnn_path}"
@@ -281,7 +283,7 @@ build_cache_archive() {
   export LIBRARY_PATH="${CUDNN_LIBRARY_PATH}${LIBRARY_PATH:+:${LIBRARY_PATH}}"
   export LD_LIBRARY_PATH="${CUDNN_LIBRARY_PATH}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
-  log "Building full uv cache with compile_jobs=${compile_jobs}, apex_parallel_build=${apex_parallel_build}, nvcc_threads=${CI_APEX_NVCC_THREADS}, and uv_concurrent_builds=${UV_BUILD_SLOTS}."
+  log "Building full uv cache with compile_jobs=${compile_jobs}, apex_parallel_build=${apex_parallel_build}, nvcc_threads=${CI_APEX_NVCC_THREADS}, cuda_arch_list=${TORCH_CUDA_ARCH_LIST}, and uv_concurrent_builds=${UV_BUILD_SLOTS}."
   uv sync --frozen --all-extras --group dev --no-install-project --python "${PYTHON_MM}"
   rm -rf .venv
 

--- a/scripts/ci/build_and_push_uv_cache.sh
+++ b/scripts/ci/build_and_push_uv_cache.sh
@@ -16,7 +16,7 @@ CI_APEX_NVCC_THREADS="${CI_APEX_NVCC_THREADS:-1}"
 TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-9.0}"
 KEEP_COUNT="${KEEP_COUNT:-4}"
 PART_SIZE_MB="${PART_SIZE_MB:-1900}"
-UPLOAD_JOBS="${UPLOAD_JOBS:-4}"
+UPLOAD_TIMEOUT_MINUTES="${UPLOAD_TIMEOUT_MINUTES:-30}"
 SKIP_BUILD=0
 SKIP_PRUNE=0
 ARCHIVE_PATH=""
@@ -342,7 +342,7 @@ upload_cache_assets() {
   if ((PART_SIZE_MB > 1900)); then
     fail "--part-size-mb must be <= 1900 to stay within GitHub release asset limits."
   fi
-  [[ "${UPLOAD_JOBS}" =~ ^[1-9][0-9]*$ ]] || fail "UPLOAD_JOBS must be a positive integer."
+  [[ "${UPLOAD_TIMEOUT_MINUTES}" =~ ^[1-9][0-9]*$ ]] || fail "UPLOAD_TIMEOUT_MINUTES must be a positive integer."
 
   delete_assets_for_fingerprint "${repo}" "${fingerprint}"
 
@@ -362,21 +362,16 @@ upload_cache_assets() {
     fail "No cache parts produced from archive ${archive_path}."
   fi
 
-  local upload_jobs="${UPLOAD_JOBS}"
-  if ((upload_jobs > part_count)); then
-    upload_jobs="${part_count}"
-  fi
-
-  log "Uploading ${part_count} cache parts with ${upload_jobs} parallel upload jobs."
-  printf '%s\0' "${parts[@]}" | xargs -0 -n 1 -P "${upload_jobs}" sh -c '
-    chunk="$1"
-    part_asset="${chunk##*/}"
-    printf "[ci-cache] Uploading cache part %s\n" "${part_asset}"
-    gh release upload "'"${UV_CACHE_RELEASE_TAG}"'" \
-      --repo "'"${repo}"'" \
-      "${chunk}" \
-      --clobber
-  ' sh
+  log "Uploading ${part_count} cache parts serially with a ${UPLOAD_TIMEOUT_MINUTES} minute timeout per part."
+  for chunk in "${parts[@]}"; do
+    local part_asset="${chunk##*/}"
+    log "Uploading cache part ${part_asset}."
+    timeout "${UPLOAD_TIMEOUT_MINUTES}m" \
+      gh release upload "${UV_CACHE_RELEASE_TAG}" \
+        --repo "${repo}" \
+        "${chunk}" \
+        --clobber
+  done
 
   rm -rf "${parts_dir}"
   printf '%s\n' "${part_count}"

--- a/scripts/ci/compute_uv_fingerprint.py
+++ b/scripts/ci/compute_uv_fingerprint.py
@@ -43,6 +43,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Python major.minor string used in CI (for example: 3.11)",
     )
     parser.add_argument(
+        "--torch-cuda-arch-list",
+        default="9.0",
+        help="TORCH_CUDA_ARCH_LIST value used for native CUDA extension builds.",
+    )
+    parser.add_argument(
         "--length",
         type=int,
         default=16,
@@ -78,7 +83,7 @@ def main() -> int:
             "uv_lock_sha256": _sha256_file(args.uv_lock),
         },
         "ci_context": {
-            "fingerprint_schema_version": 8,
+            "fingerprint_schema_version": 9,
             "cache_kind": "full_uv_cache",
             "cache_scope": "prek_all_extras_group_dev",
             "cache_target": "uv_cache",
@@ -92,6 +97,7 @@ def main() -> int:
         {
             "base_image": args.base_image,
             "python_mm": args.python_mm,
+            "torch_cuda_arch_list": args.torch_cuda_arch_list,
             "ci_apex_parallel_build": args.ci_apex_parallel_build,
             "ci_apex_nvcc_threads": args.ci_apex_nvcc_threads,
         }

--- a/src/art/_backend_training.py
+++ b/src/art/_backend_training.py
@@ -33,6 +33,7 @@ def build_rl_train_configs(
     truncated_importance_sampling: float | None = None,
     scale_learning_rate_by_reward_std_dev: bool | None = None,
     logprob_calculation_chunk_size: int | None = None,
+    packed_sequence_length: int | None = None,
     num_trajectories_learning_rate_multiplier_power: float | None = None,
     kl_ref_adapter_path: str | None = None,
 ) -> tuple[TrainConfig, dev.TrainConfig]:
@@ -62,6 +63,8 @@ def build_rl_train_configs(
         )
     if logprob_calculation_chunk_size is not None:
         dev_config["logprob_calculation_chunk_size"] = logprob_calculation_chunk_size
+    if packed_sequence_length is not None:
+        dev_config["packed_sequence_length"] = packed_sequence_length
     if num_trajectories_learning_rate_multiplier_power is not None:
         dev_config["num_trajectories_learning_rate_multiplier_power"] = (
             num_trajectories_learning_rate_multiplier_power

--- a/src/art/dev/train.py
+++ b/src/art/dev/train.py
@@ -29,6 +29,7 @@ positive advantages. Defaults to 0.0 (perfectly balanced)."""
     moe_routing_replay_path: str | None
     moe_routing_replay_strict: bool
     num_trajectories_learning_rate_multiplier_power: float
+    packed_sequence_length: int | None
     plot_tensors: bool
     ppo: bool
     precalculate_logprobs: bool

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -108,6 +108,8 @@ class LocalBackend(Backend):
         self._services: dict[str, ModelService] = {}
         self._tokenizers: dict[str, PreTrainedTokenizerBase] = {}
         self._image_processors: dict[str, BaseImageProcessor | None] = {}
+        self._requires_explicit_packed_sequence_length = False
+        self._packed_sequence_length_requires_chunk_alignment = True
 
     def supports_automatic_train_step_metrics(self) -> bool:
         return True
@@ -325,6 +327,8 @@ class LocalBackend(Backend):
         allow_training_without_logprobs: bool,
         scale_rewards: bool,
         plot_tensors: bool,
+        packed_sequence_length: int | None,
+        logprob_calculation_chunk_size: int,
     ) -> PackedTensors | None:
         if model.base_model not in self._tokenizers:
             self._tokenizers[model.base_model] = AutoTokenizer.from_pretrained(
@@ -349,20 +353,65 @@ class LocalBackend(Backend):
         )
         if not tokenized_results:
             return None
-        max_tokens = max(len(result.token_ids) for result in tokenized_results)
-        # Round up max_tokens to the nearest multiple of 2048
-        sequence_length = math.ceil(max_tokens / 2048) * 2048
-        # Cap sequence length at the model's max sequence length
-        sequence_length = min(
-            sequence_length,
+        model_max_sequence_length = (
             (model._internal_config or dev.InternalModelConfig())
             .get("init_args", {})
-            .get("max_seq_length", 32_768),
+            .get("max_seq_length", 32_768)
         )
+        if packed_sequence_length is None:
+            assert not self._requires_explicit_packed_sequence_length, (
+                f"{type(self).__name__} requires packed_sequence_length to be set."
+            )
+            max_tokens = max(len(result.token_ids) for result in tokenized_results)
+            sequence_length = min(
+                math.ceil(max_tokens / 2048) * 2048,
+                model_max_sequence_length,
+            )
+        else:
+            sequence_length = packed_sequence_length
+
+        if sequence_length > model_max_sequence_length:
+            raise ValueError(
+                f"packed_sequence_length ({sequence_length}) exceeds model max_seq_length "
+                f"({model_max_sequence_length})"
+            )
+        if (
+            packed_sequence_length is not None
+            and self._packed_sequence_length_requires_chunk_alignment
+            and sequence_length % logprob_calculation_chunk_size != 0
+        ):
+            raise ValueError(
+                f"packed_sequence_length ({sequence_length}) must be divisible by "
+                f"logprob_calculation_chunk_size ({logprob_calculation_chunk_size})"
+            )
+
+        too_long_results = [
+            result
+            for result in tokenized_results
+            if len(result.token_ids) > sequence_length
+        ]
+        if too_long_results:
+            warnings.warn(
+                "Dropping "
+                f"{len(too_long_results)} tokenized results from "
+                f"{len({id(result.trajectory) for result in too_long_results})} "
+                f"trajectories longer than packed_sequence_length={sequence_length} "
+                f"(max seen {max(len(result.token_ids) for result in too_long_results)}).",
+                stacklevel=2,
+            )
+            tokenized_results = [
+                result
+                for result in tokenized_results
+                if len(result.token_ids) <= sequence_length
+            ]
+            if not tokenized_results:
+                return None
+
         packed_tensors = packed_tensors_from_tokenized_results(
             tokenized_results,
             sequence_length,
             pad_token_id=tokenizer.eos_token_id,
+            truncate_long_results=False,
             advantage_balance=advantage_balance,
         )
         if (
@@ -560,6 +609,7 @@ class LocalBackend(Backend):
         truncated_importance_sampling: float | None = None,
         scale_learning_rate_by_reward_std_dev: bool = False,
         logprob_calculation_chunk_size: int = 1024,
+        packed_sequence_length: int | None = None,
         num_trajectories_learning_rate_multiplier_power: float = 0.0,
         # Checkpoint behavior
         save_checkpoint: bool = True,
@@ -616,6 +666,9 @@ class LocalBackend(Backend):
                 by reward standard deviation. Defaults to False.
             logprob_calculation_chunk_size: Chunk size for logprob calculation.
                 Defaults to 1024.
+            packed_sequence_length: Packed sequence length to use for training.
+                When unset, Unsloth keeps the current max-length-rounded-to-2048
+                behavior. Required for Megatron.
             num_trajectories_learning_rate_multiplier_power: Power for learning
                 rate multiplier based on number of trajectories.
             save_checkpoint: Whether to save a checkpoint after training.
@@ -644,6 +697,13 @@ class LocalBackend(Backend):
             raise ValueError("LocalBackend requires normalize_advantages=True.")
         if adam_params is not None:
             raise ValueError("LocalBackend requires adam_params=None.")
+        if (
+            self._requires_explicit_packed_sequence_length
+            and packed_sequence_length is None
+        ):
+            raise ValueError(
+                f"{type(self).__name__}.train requires packed_sequence_length to be set."
+            )
 
         resolved_kl_ref_adapter_path = kl_ref_adapter_path
         if (
@@ -672,6 +732,7 @@ class LocalBackend(Backend):
             truncated_importance_sampling=truncated_importance_sampling,
             scale_learning_rate_by_reward_std_dev=scale_learning_rate_by_reward_std_dev,
             logprob_calculation_chunk_size=logprob_calculation_chunk_size,
+            packed_sequence_length=packed_sequence_length,
             num_trajectories_learning_rate_multiplier_power=num_trajectories_learning_rate_multiplier_power,
             kl_ref_adapter_path=resolved_kl_ref_adapter_path,
         )
@@ -741,6 +802,10 @@ class LocalBackend(Backend):
             ),
             scale_rewards=dev_config.get("scale_rewards", True),
             plot_tensors=dev_config.get("plot_tensors", False),
+            packed_sequence_length=dev_config.get("packed_sequence_length"),
+            logprob_calculation_chunk_size=dev_config.get(
+                "logprob_calculation_chunk_size", 1024
+            ),
         )
         if packed_tensors is None:
             print(

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -396,7 +396,8 @@ class LocalBackend(Backend):
                 f"{len(too_long_results)} tokenized results from "
                 f"{len({id(result.trajectory) for result in too_long_results})} "
                 f"trajectories longer than packed_sequence_length={sequence_length} "
-                f"(max seen {max(len(result.token_ids) for result in too_long_results)}).",
+                f"(max seen {max(len(result.token_ids) for result in too_long_results)}). "
+                "This affects training, but your model may still learn.",
                 stacklevel=2,
             )
             tokenized_results = [

--- a/src/art/megatron/backend.py
+++ b/src/art/megatron/backend.py
@@ -14,6 +14,8 @@ class MegatronBackend(LocalBackend):
         path: str | None = None,
     ) -> None:
         super().__init__(in_process=in_process, path=path)
+        self._requires_explicit_packed_sequence_length = True
+        self._packed_sequence_length_requires_chunk_alignment = False
 
     async def _get_service(self, model: TrainableModel) -> ModelService:
         from ..dev.get_model_config import get_model_config

--- a/src/art/megatron/client.py
+++ b/src/art/megatron/client.py
@@ -10,13 +10,17 @@ from .merge import merge_lora_adapter
 DEFAULT_TRAINING_LOG_DIR = "/tmp/megatron_training_logs"
 
 
-def create_megatron_job_paths() -> tuple[str, str]:
+def create_megatron_job_paths(
+    *,
+    jobs_dir: str = DEFAULT_JOBS_DIR,
+    training_log_dir: str = DEFAULT_TRAINING_LOG_DIR,
+) -> tuple[str, str]:
     timestamp = datetime.datetime.now().isoformat()
-    os.makedirs(DEFAULT_JOBS_DIR, exist_ok=True)
-    os.makedirs(DEFAULT_TRAINING_LOG_DIR, exist_ok=True)
+    os.makedirs(jobs_dir, exist_ok=True)
+    os.makedirs(training_log_dir, exist_ok=True)
     return (
-        os.path.join(DEFAULT_JOBS_DIR, f"{timestamp}.json"),
-        os.path.join(DEFAULT_TRAINING_LOG_DIR, f"{timestamp}.jsonl"),
+        os.path.join(jobs_dir, f"{timestamp}.json"),
+        os.path.join(training_log_dir, f"{timestamp}.jsonl"),
     )
 
 

--- a/src/art/megatron/compile_workarounds.py
+++ b/src/art/megatron/compile_workarounds.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import torch
+
+_INSTALLED = False
+
+
+def _disable(fn):
+    if getattr(fn, "__art_compile_disabled__", False):
+        return fn
+    wrapped = torch.compiler.disable(fn)
+    setattr(wrapped, "__art_compile_disabled__", True)
+    return wrapped
+
+
+def install_torch_compile_workarounds() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    from megatron.core.transformer.moe import moe_utils, token_dispatcher
+    from megatron.core.transformer.moe.moe_layer import MoELayer
+
+    moe_utils.maybe_move_tensor_to_cpu = _disable(moe_utils.maybe_move_tensor_to_cpu)
+    token_dispatcher.MoEAlltoAllTokenDispatcher._maybe_dtoh_and_synchronize = _disable(
+        token_dispatcher.MoEAlltoAllTokenDispatcher._maybe_dtoh_and_synchronize
+    )
+    MoELayer.preprocess = _disable(MoELayer.preprocess)
+    deepep_manager = getattr(token_dispatcher, "_DeepepManager", None)
+    if deepep_manager is not None:
+        deepep_manager.dispatch = _disable(deepep_manager.dispatch)
+        deepep_manager.combine = _disable(deepep_manager.combine)
+        deepep_manager.get_permuted_hidden_states_by_experts = _disable(
+            deepep_manager.get_permuted_hidden_states_by_experts
+        )
+        deepep_manager.get_restored_hidden_states_by_experts = _disable(
+            deepep_manager.get_restored_hidden_states_by_experts
+        )
+    _INSTALLED = True

--- a/src/art/megatron/cute_grouped_lora_quack.py
+++ b/src/art/megatron/cute_grouped_lora_quack.py
@@ -564,6 +564,9 @@ class _QuackGroupedLoraDualFn(torch.autograd.Function):
         )
 
 
+# Dynamo tracing through CuTe's DLPack interop fails on FakeTensor, so keep the
+# QuACK grouped kernels eager while the surrounding layer stays compiled.
+@torch.compiler.disable
 def quack_grouped_lora(
     x: torch.Tensor,
     a_t: torch.Tensor,
@@ -586,6 +589,7 @@ def quack_grouped_lora(
     return _QuackGroupedLoraFn.apply(x, a_t, b_t, counts_tensor, scale)
 
 
+@torch.compiler.disable
 def quack_grouped_lora_dual(
     x: torch.Tensor,
     gate_a_t: torch.Tensor,

--- a/src/art/megatron/flex_attention.py
+++ b/src/art/megatron/flex_attention.py
@@ -1,7 +1,8 @@
 """Flex attention plumbing for ART's Megatron backend."""
 
+from collections.abc import Callable
 import math
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, TypeAlias, cast
 
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -25,11 +26,14 @@ class SharedPrefixAttentionState(BaseModel):
     block_mask: BlockMask
 
 
+CompileOptions: TypeAlias = dict[str, str | int | bool | Callable[..., Any]]
+
+
 class FlexAttentionWrapper(torch.nn.Module):
     """Compiled `flex_attention` wrapper with Torchtitan-style inductor options."""
 
     # Torchtitan inductor options for compiling flex attention.
-    _compile_options = {
+    _compile_options: ClassVar[CompileOptions] = {
         "max_autotune": True,
         "coordinate_descent_tuning": True,
         "triton.cudagraphs": False,

--- a/src/art/megatron/flex_attention.py
+++ b/src/art/megatron/flex_attention.py
@@ -14,6 +14,7 @@ import torch
 from torch import Tensor
 from torch.nn.attention.flex_attention import (
     BlockMask,
+    FlexKernelOptions,
     create_block_mask,
     flex_attention,
 )
@@ -43,7 +44,7 @@ class FlexAttentionWrapper(torch.nn.Module):
     # failures (create_flex_decoding_kernel). The regular flex_attention
     # kernel autotunes against the actual hardware smem budget, so this
     # stays GPU-agnostic.
-    _kernel_options = {
+    _kernel_options: ClassVar[FlexKernelOptions] = {
         "FORCE_USE_FLEX_ATTENTION": True,
     }
     _compiled_flex_attention: ClassVar = torch.compile(

--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -22,6 +22,9 @@ import torch
 
 from .cute_grouped_lora_quack import quack_grouped_lora, quack_grouped_lora_dual
 
+LORA_RANK = 1
+LORA_ALPHA = 32
+
 ShardDomain = Literal["tp", "expert_tp"]
 GradSyncDomain = Literal["tp_default", "expert_tp"]
 GradSyncOp = Literal["none", "sum", "avg"]
@@ -743,8 +746,8 @@ def apply_lora_adapters(
                 module.self_attention.linear_proj = SelfAttentionLinearProjLoRA(
                     adapter_model_prefix=f"{adapter_model_prefix}.self_attn.o_proj",
                     linear_proj=self_attention_linear_proj,
-                    rank=1,
-                    alpha=32,
+                    rank=LORA_RANK,
+                    alpha=LORA_ALPHA,
                     provider=provider,
                 )
                 self_attention_linear_qkv = _unwrap_attr(
@@ -755,8 +758,8 @@ def apply_lora_adapters(
                 module.self_attention.linear_qkv = SelfAttentionLinearQKVLoRA(
                     adapter_model_prefix=f"{adapter_model_prefix}.self_attn",
                     linear_qkv=self_attention_linear_qkv,
-                    rank=1,
-                    alpha=32,
+                    rank=LORA_RANK,
+                    alpha=LORA_ALPHA,
                     provider=provider,
                 )
                 assert isinstance(module.mlp.experts, TEGroupedMLP)
@@ -768,8 +771,8 @@ def apply_lora_adapters(
                 module.mlp.experts.linear_fc1 = MLPExpertsLinearFC1LoRA(
                     adapter_model_prefix=f"{adapter_model_prefix}.mlp.experts",
                     linear_fc1=mlp_experts_linear_fc1,
-                    rank=1,
-                    alpha=32,
+                    rank=LORA_RANK,
+                    alpha=LORA_ALPHA,
                     num_local_experts=module.mlp.experts.num_local_experts,
                 )
                 mlp_experts_linear_fc2 = _unwrap_attr(
@@ -780,8 +783,8 @@ def apply_lora_adapters(
                 module.mlp.experts.linear_fc2 = MLPExpertsLinearFC2LoRA(
                     adapter_model_prefix=f"{adapter_model_prefix}.mlp.experts",
                     linear_fc2=mlp_experts_linear_fc2,
-                    rank=1,
-                    alpha=32,
+                    rank=LORA_RANK,
+                    alpha=LORA_ALPHA,
                     num_local_experts=module.mlp.experts.num_local_experts,
                 )
     return list(model)

--- a/src/art/megatron/model_chunks.py
+++ b/src/art/megatron/model_chunks.py
@@ -1,0 +1,42 @@
+from collections.abc import Sequence
+from typing import Any, cast
+
+from megatron.core.transformer.module import MegatronModule
+import torch
+
+ModelChunk = torch.nn.Module
+ModelChunks = list[ModelChunk]
+
+
+def unwrap_megatron_chunk(module: ModelChunk) -> MegatronModule:
+    current: Any = module
+    seen: set[int] = set()
+    while True:
+        if isinstance(current, MegatronModule):
+            return current
+        if id(current) in seen:
+            break
+        seen.add(id(current))
+        for attr_name in ("_orig_mod", "module"):
+            next_module = getattr(current, attr_name, None)
+            if isinstance(next_module, torch.nn.Module):
+                current = next_module
+                break
+        else:
+            break
+    raise TypeError(
+        f"Expected model chunk backed by MegatronModule, got {type(module).__name__}"
+    )
+
+
+def validate_model_chunks(model_chunks: Sequence[ModelChunk]) -> None:
+    for chunk in model_chunks:
+        try:
+            unwrap_megatron_chunk(chunk)
+        except TypeError as exc:
+            raise ValueError(str(exc)) from exc
+
+
+def as_megatron_api_chunks(model_chunks: Sequence[ModelChunk]) -> list[MegatronModule]:
+    validate_model_chunks(model_chunks)
+    return cast(list[MegatronModule], list(model_chunks))

--- a/src/art/megatron/offload.py
+++ b/src/art/megatron/offload.py
@@ -12,63 +12,40 @@ class OffloadState:
     is_offloaded: bool = False
 
 
-def _iter_megatron_optimizers(optimizer: Any) -> Iterator[Any]:
-    chained_optimizers = getattr(optimizer, "chained_optimizers", None)
-    if chained_optimizers is None:
-        yield optimizer
-        return
-    for child_optimizer in chained_optimizers:
-        yield from _iter_megatron_optimizers(child_optimizer)
-
-
-def iter_optimizer_state_items(optimizer: Any) -> Iterator[tuple[Any, dict[str, Any]]]:
-    for megatron_optimizer in _iter_megatron_optimizers(optimizer):
-        yield from megatron_optimizer.state.items()
-
-
-def clear_optimizer_state(optimizer: Any) -> None:
-    for megatron_optimizer in _iter_megatron_optimizers(optimizer):
-        megatron_optimizer.state.clear()
+def _iter_megatron_param_buffers(model: Sequence[torch.nn.Module]) -> Iterator[Any]:
+    for chunk in model:
+        chunk_buffers = getattr(chunk, "buffers", None)
+        if callable(chunk_buffers):
+            raise RuntimeError("Megatron chunk is missing distributed param buffers")
+        if chunk_buffers is not None:
+            yield from chunk_buffers
+        expert_buffers = getattr(chunk, "expert_parallel_buffers", None)
+        if expert_buffers is not None:
+            yield from expert_buffers
 
 
 def offload_to_cpu(
     model: Sequence[torch.nn.Module],
-    optimizer: Any,
     rank: int,
     offload_state: OffloadState,
 ) -> None:
-    """Offload model params and optimizer state to CPU pinned memory."""
+    """Offload model params to CPU pinned memory."""
     if offload_state.is_offloaded:
         return
     pinned_buffers = offload_state.pinned_buffers
 
-    for chunk in model:
-        for module in chunk.modules():
-            for attr in ["A_T", "B_T"]:
-                if not hasattr(module, attr):
-                    continue
-                param = getattr(module, attr)
-                if (
-                    not isinstance(param, torch.nn.Parameter)
-                    or param.device.type != "cuda"
-                ):
-                    continue
-                key = f"{id(module)}_{attr}"
-                if (
-                    key not in pinned_buffers
-                    or pinned_buffers[key].shape != param.shape
-                    or pinned_buffers[key].dtype != param.dtype
-                ):
-                    pinned_buffers[key] = torch.empty(
-                        param.shape, dtype=param.dtype, device="cpu", pin_memory=True
-                    )
-                pinned_buffers[key].copy_(param.data, non_blocking=True)
-                param.data = pinned_buffers[key]
+    for param_buffer in _iter_megatron_param_buffers(model):
+        param_buffer.offload_to_cpu(move_params=True, move_grads=True)
 
-    # Offload remaining model parameters (including base weights).
+    # Megatron remaps trainable params into contiguous DDP buffers. Offload those via the
+    # native buffer APIs above, and only manually offload frozen params here.
     for chunk in model:
         for param in chunk.parameters():
-            if not isinstance(param, torch.nn.Parameter) or param.device.type != "cuda":
+            if (
+                not isinstance(param, torch.nn.Parameter)
+                or param.requires_grad
+                or param.device.type != "cuda"
+            ):
                 continue
             key = f"param_{id(param)}"
             if (
@@ -82,37 +59,21 @@ def offload_to_cpu(
             pinned_buffers[key].copy_(param.data, non_blocking=True)
             param.data = pinned_buffers[key]
 
-    for param_id, opt_state in iter_optimizer_state_items(optimizer):
-        for k, v in opt_state.items():
-            if isinstance(v, torch.Tensor) and v.device.type == "cuda":
-                key = f"opt_{id(param_id)}_{k}"
-                if (
-                    key not in pinned_buffers
-                    or pinned_buffers[key].shape != v.shape
-                    or pinned_buffers[key].dtype != v.dtype
-                ):
-                    pinned_buffers[key] = torch.empty(
-                        v.shape, dtype=v.dtype, device="cpu", pin_memory=True
-                    )
-                pinned_buffers[key].copy_(v, non_blocking=True)
-                opt_state[k] = pinned_buffers[key]
-
     torch.cuda.synchronize()
     gc.collect()
     torch.cuda.empty_cache()
     offload_state.is_offloaded = True
     if rank == 0:
-        print("Offloaded model params and optimizer to CPU")
+        print("Offloaded model params to CPU")
 
 
 def reload_to_gpu(
     model: Sequence[torch.nn.Module],
-    optimizer: Any,
     rank: int,
     offload_state: OffloadState,
     device: torch.device | str | None = None,
 ) -> None:
-    """Reload model params and optimizer state to GPU."""
+    """Reload model params to GPU."""
     if not offload_state.is_offloaded:
         return
 
@@ -121,38 +82,23 @@ def reload_to_gpu(
     else:
         device = torch.device(device)
 
-    for chunk in model:
-        for module in chunk.modules():
-            for attr in ["A_T", "B_T"]:
-                if not hasattr(module, attr):
-                    continue
-                param = getattr(module, attr)
-                if (
-                    not isinstance(param, torch.nn.Parameter)
-                    or param.device.type != "cpu"
-                ):
-                    continue
-                gpu_tensor = torch.empty(param.shape, dtype=param.dtype, device=device)
-                gpu_tensor.copy_(param.data, non_blocking=True)
-                param.data = gpu_tensor
+    for param_buffer in _iter_megatron_param_buffers(model):
+        param_buffer.reload_from_cpu(move_params=True, move_grads=True)
 
-    # Reload remaining model parameters (including base weights).
+    # Reload frozen params that were manually offloaded.
     for chunk in model:
         for param in chunk.parameters():
-            if not isinstance(param, torch.nn.Parameter) or param.device.type != "cpu":
+            if (
+                not isinstance(param, torch.nn.Parameter)
+                or param.requires_grad
+                or param.device.type != "cpu"
+            ):
                 continue
             gpu_tensor = torch.empty(param.shape, dtype=param.dtype, device=device)
             gpu_tensor.copy_(param.data, non_blocking=True)
             param.data = gpu_tensor
 
-    for _param_id, opt_state in iter_optimizer_state_items(optimizer):
-        for k, v in opt_state.items():
-            if isinstance(v, torch.Tensor) and v.device.type == "cpu":
-                gpu_tensor = torch.empty(v.shape, dtype=v.dtype, device=device)
-                gpu_tensor.copy_(v, non_blocking=True)
-                opt_state[k] = gpu_tensor
-
     torch.cuda.synchronize()
     offload_state.is_offloaded = False
     if rank == 0:
-        print("Reloaded LoRA params and optimizer to GPU")
+        print("Reloaded LoRA params to GPU")

--- a/src/art/megatron/offload.py
+++ b/src/art/megatron/offload.py
@@ -1,9 +1,12 @@
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 import gc
-from typing import Any, Sequence
+from typing import Any, Sequence, cast
 
+from megatron.core.distributed import DistributedDataParallel
 import torch
+
+from art.megatron.model_chunks import unwrap_megatron_chunk
 
 
 @dataclass
@@ -14,14 +17,23 @@ class OffloadState:
 
 def _iter_megatron_param_buffers(model: Sequence[torch.nn.Module]) -> Iterator[Any]:
     for chunk in model:
-        chunk_buffers = getattr(chunk, "buffers", None)
-        if callable(chunk_buffers):
-            raise RuntimeError("Megatron chunk is missing distributed param buffers")
-        if chunk_buffers is not None:
-            yield from chunk_buffers
-        expert_buffers = getattr(chunk, "expert_parallel_buffers", None)
-        if expert_buffers is not None:
-            yield from expert_buffers
+        ddp_chunk = unwrap_megatron_chunk(chunk)
+        if not isinstance(ddp_chunk, DistributedDataParallel):
+            raise RuntimeError(
+                "Expected Megatron chunk wrapped by DistributedDataParallel, got "
+                f"{type(ddp_chunk).__name__}"
+            )
+        ddp_buffers = cast(Sequence[Any] | None, ddp_chunk.__dict__.get("buffers"))
+        expert_buffers = cast(
+            Sequence[Any] | None, ddp_chunk.__dict__.get("expert_parallel_buffers")
+        )
+        if ddp_buffers is None or expert_buffers is None:
+            raise RuntimeError(
+                "Megatron DistributedDataParallel chunk is missing expected "
+                "param buffer attributes"
+            )
+        yield from ddp_buffers
+        yield from expert_buffers
 
 
 def offload_to_cpu(

--- a/src/art/megatron/provider.py
+++ b/src/art/megatron/provider.py
@@ -98,17 +98,6 @@ def _env_optional_str_list(name: str) -> tuple[bool, list[str] | None]:
     return True, [part for part in parts if part]
 
 
-def _env_optional_moe_router_dtype(
-    name: str,
-) -> tuple[bool, Literal["fp32", "fp64"] | None]:
-    found, value = _env_optional_str(name)
-    if not found or value is None:
-        return found, None
-    if value not in {"fp32", "fp64"}:
-        raise ValueError(f"{name} must be one of 'fp32' or 'fp64', got {value!r}")
-    return True, cast(Literal["fp32", "fp64"], value)
-
-
 def _env_optional_recompute_granularity(
     name: str,
 ) -> tuple[bool, Literal["full", "selective"] | None]:
@@ -176,12 +165,6 @@ def _apply_runtime_env_overrides(provider: GPTModelProvider) -> None:
         provider.moe_deepep_num_sms = deepep_num_sms
     if "ART_MEGATRON_MOE_DEEPEP_NUM_SMS" not in os.environ:
         provider.moe_deepep_num_sms = _resolve_default_deepep_num_sms(provider)
-
-    moe_router_dtype_found, moe_router_dtype = _env_optional_moe_router_dtype(
-        "ART_MEGATRON_MOE_ROUTER_DTYPE"
-    )
-    if moe_router_dtype_found:
-        provider.moe_router_dtype = moe_router_dtype
 
     moe_apply_probs_on_input = _env_flag("ART_MEGATRON_MOE_APPLY_PROBS_ON_INPUT")
     if moe_apply_probs_on_input is not None:

--- a/src/art/megatron/provider.py
+++ b/src/art/megatron/provider.py
@@ -1,8 +1,9 @@
 import copy
 from functools import partial
 import inspect
+import os
 from pathlib import Path
-from typing import Callable, cast
+from typing import Callable, Literal, cast
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.gpt_provider import GPTModelProvider
@@ -12,6 +13,9 @@ from megatron.bridge.models.hf_pretrained.state import (
     StateSource,
 )
 from megatron.bridge.models.qwen.qwen3_moe_bridge import Qwen3MoEBridge
+from megatron.bridge.training.flex_dispatcher_backend import (
+    apply_flex_dispatcher_backend,
+)
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.spec_utils import ModuleSpec
 import torch
@@ -57,6 +61,193 @@ class _CastingStateSource(StateSource):
         return self._source.has_glob(pattern)
 
 
+def _env_flag(name: str) -> bool | None:
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean-like value, got {raw!r}")
+
+
+def _env_optional_str(name: str) -> tuple[bool, str | None]:
+    raw = os.environ.get(name)
+    if raw is None:
+        return False, None
+    value = raw.strip()
+    if not value or value.lower() in {"none", "null", "off", "disable", "disabled"}:
+        return True, None
+    return True, value
+
+
+def _env_optional_int(name: str) -> tuple[bool, int | None]:
+    found, value = _env_optional_str(name)
+    if not found or value is None:
+        return found, None
+    return True, int(value)
+
+
+def _env_optional_str_list(name: str) -> tuple[bool, list[str] | None]:
+    found, value = _env_optional_str(name)
+    if not found or value is None:
+        return found, None
+    parts = [part.strip() for part in value.split(",")]
+    return True, [part for part in parts if part]
+
+
+def _env_optional_moe_router_dtype(
+    name: str,
+) -> tuple[bool, Literal["fp32", "fp64"] | None]:
+    found, value = _env_optional_str(name)
+    if not found or value is None:
+        return found, None
+    if value not in {"fp32", "fp64"}:
+        raise ValueError(f"{name} must be one of 'fp32' or 'fp64', got {value!r}")
+    return True, cast(Literal["fp32", "fp64"], value)
+
+
+def _env_optional_recompute_granularity(
+    name: str,
+) -> tuple[bool, Literal["full", "selective"] | None]:
+    found, value = _env_optional_str(name)
+    if not found or value is None:
+        return found, None
+    if value not in {"full", "selective"}:
+        raise ValueError(f"{name} must be one of 'full' or 'selective', got {value!r}")
+    return True, cast(Literal["full", "selective"], value)
+
+
+def _env_optional_recompute_method(
+    name: str,
+) -> tuple[bool, Literal["uniform", "block"] | None]:
+    found, value = _env_optional_str(name)
+    if not found or value is None:
+        return found, None
+    if value not in {"uniform", "block"}:
+        raise ValueError(f"{name} must be one of 'uniform' or 'block', got {value!r}")
+    return True, cast(Literal["uniform", "block"], value)
+
+
+def _resolve_default_deepep_num_sms(provider: GPTModelProvider) -> int:
+    if provider.overlap_moe_expert_parallel_comm:
+        return 20
+    if not torch.cuda.is_available():
+        return 20
+    sm_count = torch.cuda.get_device_properties(0).multi_processor_count
+    sm_count -= sm_count % 2
+    return sm_count if sm_count >= 2 else 20
+
+
+def _apply_default_parallel_topology(provider: GPTModelProvider) -> None:
+    visible_gpu_count = max(torch.cuda.device_count(), 1)
+    provider.tensor_model_parallel_size = visible_gpu_count
+    provider.context_parallel_size = 1
+    provider.pipeline_model_parallel_size = 1
+    provider.expert_model_parallel_size = visible_gpu_count
+    provider.expert_tensor_parallel_size = 1
+
+
+def _tp_ep_parallel_domain_size(provider: GPTModelProvider) -> int:
+    return int(provider.tensor_model_parallel_size) * int(
+        provider.expert_model_parallel_size
+    )
+
+
+def _apply_runtime_env_overrides(provider: GPTModelProvider) -> None:
+    overlap = _env_flag("ART_MEGATRON_OVERLAP_MOE_EXPERT_PARALLEL_COMM")
+    if overlap is not None:
+        provider.overlap_moe_expert_parallel_comm = overlap
+
+    delay_wgrad = _env_flag("ART_MEGATRON_DELAY_WGRAD_COMPUTE")
+    if delay_wgrad is not None:
+        provider.delay_wgrad_compute = delay_wgrad
+        if delay_wgrad:
+            provider.overlap_moe_expert_parallel_comm = True
+
+    early_attn_release = _env_flag("ART_MEGATRON_EP_OVERLAP_EARLY_ATTN_MEMORY_RELEASE")
+    if early_attn_release is not None:
+        provider.ep_overlap_early_attn_memory_release = early_attn_release
+
+    found, deepep_num_sms = _env_optional_int("ART_MEGATRON_MOE_DEEPEP_NUM_SMS")
+    if found and deepep_num_sms is not None:
+        provider.moe_deepep_num_sms = deepep_num_sms
+    if "ART_MEGATRON_MOE_DEEPEP_NUM_SMS" not in os.environ:
+        provider.moe_deepep_num_sms = _resolve_default_deepep_num_sms(provider)
+
+    moe_router_dtype_found, moe_router_dtype = _env_optional_moe_router_dtype(
+        "ART_MEGATRON_MOE_ROUTER_DTYPE"
+    )
+    if moe_router_dtype_found:
+        provider.moe_router_dtype = moe_router_dtype
+
+    moe_apply_probs_on_input = _env_flag("ART_MEGATRON_MOE_APPLY_PROBS_ON_INPUT")
+    if moe_apply_probs_on_input is not None:
+        provider.moe_apply_probs_on_input = moe_apply_probs_on_input
+
+    bias_activation_fusion = _env_flag("ART_MEGATRON_BIAS_ACTIVATION_FUSION")
+    if bias_activation_fusion is not None:
+        provider.bias_activation_fusion = bias_activation_fusion
+
+    fine_grained_activation_offloading = _env_flag(
+        "ART_MEGATRON_FINE_GRAINED_ACTIVATION_OFFLOADING"
+    )
+    if fine_grained_activation_offloading is not None:
+        provider.fine_grained_activation_offloading = fine_grained_activation_offloading
+
+    offload_modules_found, offload_modules = _env_optional_str_list(
+        "ART_MEGATRON_OFFLOAD_MODULES"
+    )
+    if offload_modules_found:
+        provider.offload_modules = [] if offload_modules is None else offload_modules
+
+    found, tensor_model_parallel_size = _env_optional_int(
+        "ART_MEGATRON_TENSOR_MODEL_PARALLEL_SIZE"
+    )
+    if found and tensor_model_parallel_size is not None:
+        provider.tensor_model_parallel_size = tensor_model_parallel_size
+
+    recompute_granularity_found, recompute_granularity = (
+        _env_optional_recompute_granularity("ART_MEGATRON_RECOMPUTE_GRANULARITY")
+    )
+    if recompute_granularity_found:
+        provider.recompute_granularity = recompute_granularity
+
+    recompute_method_found, recompute_method = _env_optional_recompute_method(
+        "ART_MEGATRON_RECOMPUTE_METHOD"
+    )
+    if recompute_method_found:
+        provider.recompute_method = recompute_method
+
+    recompute_num_layers_found, recompute_num_layers = _env_optional_int(
+        "ART_MEGATRON_RECOMPUTE_NUM_LAYERS"
+    )
+    if recompute_num_layers_found:
+        provider.recompute_num_layers = recompute_num_layers
+
+    recompute_modules_found, recompute_modules = _env_optional_str_list(
+        "ART_MEGATRON_RECOMPUTE_MODULES"
+    )
+    if recompute_modules_found:
+        provider.recompute_modules = recompute_modules
+
+    shared_expert_overlap = _env_flag("ART_MEGATRON_MOE_SHARED_EXPERT_OVERLAP")
+    if shared_expert_overlap is not None:
+        provider.moe_shared_expert_overlap = shared_expert_overlap
+
+    if provider.overlap_moe_expert_parallel_comm:
+        # EP overlap is incompatible with full recompute in Megatron, so treat
+        # overlap as the authoritative request even if a launcher exported the
+        # usual recompute defaults. Selective recompute is still allowed.
+        provider.moe_shared_expert_overlap = False
+        provider.recompute_method = None
+        provider.recompute_num_layers = None
+        if provider.recompute_granularity != "selective":
+            provider.recompute_granularity = None
+
+
 def get_provider(
     model: str,
     *,
@@ -97,19 +288,20 @@ def get_provider(
     provider.recompute_granularity = "full"
     provider.recompute_method = "uniform"
     provider.recompute_num_layers = 1
-    provider.tensor_model_parallel_size = min(2, torch.cuda.device_count())
-    provider.context_parallel_size = 1
-    provider.pipeline_model_parallel_size = 1
-    provider.expert_model_parallel_size = torch.cuda.device_count()
-    provider.expert_tensor_parallel_size = 1
     provider.moe_shared_expert_overlap = True
+    _apply_default_parallel_topology(provider)
+    _apply_runtime_env_overrides(provider)
+    if _tp_ep_parallel_domain_size(provider) > 1:
+        # use DeepEP for MoE expert comm. comm can be the same amount of time as actual MLP
+        # compute, so these are very beneficial
+        apply_flex_dispatcher_backend(provider, moe_flex_dispatcher_backend="deepep")
+    provider.moe_permute_fusion = True
     provider.moe_router_dtype = "fp32"
     # params are disabled anyways, but should know about this if we switch to full FT
     # because DP 'dummy' microbatches will unintentionally have loss for this
     provider.moe_aux_loss_coeff = 0.0
     # effectively just a flag modifying finalize_model_grads behavior for DPxCP
     provider.calculate_per_token_loss = True
-    if provider.tensor_model_parallel_size > 1:
-        provider.sequence_parallel = True
+    provider.sequence_parallel = provider.tensor_model_parallel_size > 1
     provider.finalize()
     return provider

--- a/src/art/megatron/provider.py
+++ b/src/art/megatron/provider.py
@@ -1,9 +1,10 @@
 import copy
-from functools import partial
 import inspect
+import json
 import os
 from pathlib import Path
 from typing import Callable, Literal, cast
+import warnings
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.gpt_provider import GPTModelProvider
@@ -21,6 +22,8 @@ from megatron.core.transformer.spec_utils import ModuleSpec
 import torch
 
 from art.megatron.flex_attention import FlexDotProductAttention
+
+_finalized_env_settings_printed = False
 
 
 def _resolve_layer_spec(
@@ -90,6 +93,26 @@ def _env_optional_int(name: str) -> tuple[bool, int | None]:
     return True, int(value)
 
 
+def _env_default_or_even_positive_int(name: str) -> tuple[bool, int | None]:
+    raw = os.environ.get(name)
+    if raw is None:
+        return False, None
+    value = raw.strip().lower()
+    if value == "default":
+        return True, None
+    try:
+        parsed = int(raw.strip())
+    except ValueError as exc:
+        raise ValueError(
+            f"{name} must be 'default' or a positive, even integer, got {raw!r}"
+        ) from exc
+    if parsed <= 0 or parsed % 2 != 0:
+        raise ValueError(
+            f"{name} must be 'default' or a positive, even integer, got {raw!r}"
+        )
+    return True, parsed
+
+
 def _env_optional_str_list(name: str) -> tuple[bool, list[str] | None]:
     found, value = _env_optional_str(name)
     if not found or value is None:
@@ -145,6 +168,44 @@ def _tp_ep_parallel_domain_size(provider: GPTModelProvider) -> int:
     )
 
 
+def _maybe_print_finalized_env_settings(provider: GPTModelProvider) -> None:
+    global _finalized_env_settings_printed
+    if _finalized_env_settings_printed:
+        return
+    if torch.distributed.is_initialized():  # ty: ignore[possibly-missing-attribute]
+        if torch.distributed.get_rank() != 0:  # ty: ignore[possibly-missing-attribute]
+            _finalized_env_settings_printed = True
+            return
+    _finalized_env_settings_printed = True
+    print(
+        "Finalized Megatron env settings:",
+        json.dumps(
+            {
+                "tensor_model_parallel_size": provider.tensor_model_parallel_size,
+                "expert_model_parallel_size": provider.expert_model_parallel_size,
+                "overlap_moe_expert_parallel_comm": provider.overlap_moe_expert_parallel_comm,
+                "delay_wgrad_compute": provider.delay_wgrad_compute,
+                "ep_overlap_early_attn_memory_release": provider.ep_overlap_early_attn_memory_release,
+                "moe_deepep_num_sms": provider.moe_deepep_num_sms,
+                "moe_apply_probs_on_input": provider.moe_apply_probs_on_input,
+                "bias_activation_fusion": provider.bias_activation_fusion,
+                "fine_grained_activation_offloading": provider.fine_grained_activation_offloading,
+                "offload_modules": provider.offload_modules,
+                "recompute_granularity": provider.recompute_granularity,
+                "recompute_method": provider.recompute_method,
+                "recompute_num_layers": provider.recompute_num_layers,
+                "recompute_modules": provider.recompute_modules,
+                "moe_shared_expert_overlap": provider.moe_shared_expert_overlap,
+                "moe_flex_dispatcher_backend": (
+                    "deepep" if _tp_ep_parallel_domain_size(provider) > 1 else None
+                ),
+                "sequence_parallel": provider.sequence_parallel,
+            },
+            indent=2,
+        ),
+    )
+
+
 def _apply_runtime_env_overrides(provider: GPTModelProvider) -> None:
     overlap = _env_flag("ART_MEGATRON_OVERLAP_MOE_EXPERT_PARALLEL_COMM")
     if overlap is not None:
@@ -160,10 +221,16 @@ def _apply_runtime_env_overrides(provider: GPTModelProvider) -> None:
     if early_attn_release is not None:
         provider.ep_overlap_early_attn_memory_release = early_attn_release
 
-    found, deepep_num_sms = _env_optional_int("ART_MEGATRON_MOE_DEEPEP_NUM_SMS")
-    if found and deepep_num_sms is not None:
-        provider.moe_deepep_num_sms = deepep_num_sms
-    if "ART_MEGATRON_MOE_DEEPEP_NUM_SMS" not in os.environ:
+    found, deepep_num_sms = _env_default_or_even_positive_int(
+        "ART_MEGATRON_MOE_DEEPEP_NUM_SMS"
+    )
+    if found:
+        provider.moe_deepep_num_sms = (
+            _resolve_default_deepep_num_sms(provider)
+            if deepep_num_sms is None
+            else deepep_num_sms
+        )
+    else:
         provider.moe_deepep_num_sms = _resolve_default_deepep_num_sms(provider)
 
     moe_apply_probs_on_input = _env_flag("ART_MEGATRON_MOE_APPLY_PROBS_ON_INPUT")
@@ -224,6 +291,13 @@ def _apply_runtime_env_overrides(provider: GPTModelProvider) -> None:
         # EP overlap is incompatible with full recompute in Megatron, so treat
         # overlap as the authoritative request even if a launcher exported the
         # usual recompute defaults. Selective recompute is still allowed.
+        if shared_expert_overlap:
+            warnings.warn(
+                "ART_MEGATRON_MOE_SHARED_EXPERT_OVERLAP=true is incompatible with "
+                "ART_MEGATRON_OVERLAP_MOE_EXPERT_PARALLEL_COMM; forcing "
+                "moe_shared_expert_overlap=False",
+                stacklevel=2,
+            )
         provider.moe_shared_expert_overlap = False
         provider.recompute_method = None
         provider.recompute_num_layers = None
@@ -286,5 +360,6 @@ def get_provider(
     # effectively just a flag modifying finalize_model_grads behavior for DPxCP
     provider.calculate_per_token_loss = True
     provider.sequence_parallel = provider.tensor_model_parallel_size > 1
+    _maybe_print_finalized_env_settings(provider)
     provider.finalize()
     return provider

--- a/src/art/megatron/runtime_env.py
+++ b/src/art/megatron/runtime_env.py
@@ -8,7 +8,10 @@ def _set_cache_dir(env_var: str, default_path: str) -> None:
 
 
 def configure_megatron_runtime_env() -> None:
-    os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
+    os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = os.environ.get(
+        "ART_MEGATRON_CUDA_DEVICE_MAX_CONNECTIONS",
+        os.environ.get("CUDA_DEVICE_MAX_CONNECTIONS", "1"),
+    )
     os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
     os.environ["TORCH_CUDA_ARCH_LIST"] = "9.0"
     _set_cache_dir("TORCHINDUCTOR_CACHE_DIR", "~/.cache/torchinductor")

--- a/src/art/megatron/service.py
+++ b/src/art/megatron/service.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import shlex
 import shutil
+import socket
 import subprocess
 from typing import Any, AsyncIterator, Literal, cast
 
@@ -27,11 +28,10 @@ from ..utils.output_dirs import get_step_checkpoint_dir
 from ..vllm import get_llm, openai_server_task, run_on_workers
 from .client import create_megatron_job_paths, stream_megatron_job, write_megatron_job
 from .jobs import (
-    DEFAULT_JOBS_DIR,
-    DEFAULT_VLLM_WAKE_LOCK_PATH,
     MegatronSFTTrainingJob,
     MegatronTrainingJob,
 )
+from .lora import LORA_ALPHA, LORA_RANK
 from .sft_batches import materialize_sft_batches
 
 safetensors = importlib.import_module("safetensors")
@@ -39,7 +39,11 @@ safe_open = safetensors.safe_open
 
 
 def create_identity_lora(
-    base_model: str, lora_path: str, rank: int = 1, lora_alpha: int = 32
+    base_model: str,
+    lora_path: str,
+    rank: int = LORA_RANK,
+    lora_alpha: int = LORA_ALPHA,
+    random_state: int | None = None,
 ) -> None:
     """Create an identity LoRA adapter for a Megatron model.
 
@@ -59,6 +63,8 @@ def create_identity_lora(
     from peft import get_peft_model
     from transformers import AutoConfig, AutoModelForCausalLM
 
+    if random_state is not None:
+        torch.manual_seed(random_state)
     base_config = AutoConfig.from_pretrained(base_model, trust_remote_code=True)
     with init_empty_weights():
         model = AutoModelForCausalLM.from_config(
@@ -132,6 +138,30 @@ class MegatronService:
     _lora_id_counter: int = 1
     _megatron_process: asyncio.subprocess.Process | None = None
 
+    def _megatron_random_state(self) -> int | None:
+        for config_key in ("peft_args", "init_args"):
+            random_state = self.config.get(config_key, {}).get("random_state")
+            if random_state is not None:
+                return int(random_state)
+        return None
+
+    def _megatron_runtime_paths(self) -> tuple[str, str, str]:
+        runtime_dir = Path(self.output_dir) / "megatron_runtime"
+        jobs_dir = runtime_dir / "jobs"
+        training_log_dir = runtime_dir / "training_logs"
+        jobs_dir.mkdir(parents=True, exist_ok=True)
+        training_log_dir.mkdir(parents=True, exist_ok=True)
+        return (
+            str(jobs_dir),
+            str(training_log_dir),
+            str(runtime_dir / "vllm_waking.lock"),
+        )
+
+    def _allocate_master_port(self) -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("", 0))
+            return int(sock.getsockname()[1])
+
     def _next_lora_id(self) -> int:
         self._lora_id_counter += 1
         return self._lora_id_counter
@@ -144,11 +174,10 @@ class MegatronService:
         return optimizer_state_path
 
     def _default_lora_adapter_config(self) -> LoraConfig:
-        # Keep in sync with LoRA settings in megatron/train.py.
         return LoraConfig(
             base_model_name_or_path=self.base_model,
-            r=1,
-            lora_alpha=32,
+            r=LORA_RANK,
+            lora_alpha=LORA_ALPHA,
             target_modules=default_target_modules(self.base_model),
             bias="none",
         )
@@ -168,7 +197,11 @@ class MegatronService:
         return False
 
     def _create_identity_lora(self, lora_path: str) -> None:
-        create_identity_lora(self.base_model, lora_path)
+        create_identity_lora(
+            self.base_model,
+            lora_path,
+            random_state=self._megatron_random_state(),
+        )
 
     def _ensure_identity_lora(self, lora_path: str) -> None:
         if self._adapter_has_weights(lora_path):
@@ -224,26 +257,47 @@ class MegatronService:
             setup_script = Path(__file__).parent / "setup.sh"
             setup_cmd = f"bash {setup_script} && "
 
-        subprocess.run(["pkill", "-9", "megatron-service"], check=False)
         train_script = Path(__file__).parent / "train.py"
         project_root = Path(__file__).resolve().parents[3]
         num_gpus = torch.cuda.device_count()
-        os.environ["MODEL_IDENTIFIER"] = self.base_model
+        jobs_dir, _training_log_dir, wake_lock_path = self._megatron_runtime_paths()
+        env = os.environ.copy()
+        env["MODEL_IDENTIFIER"] = self.base_model
+        env["ART_MEGATRON_JOBS_DIR"] = jobs_dir
+        env["ART_MEGATRON_WAKE_LOCK_PATH"] = wake_lock_path
+        master_addr = env.get("MASTER_ADDR", "127.0.0.1")
+        master_port = str(self._allocate_master_port())
+        env["MASTER_ADDR"] = master_addr
+        env["MASTER_PORT"] = master_port
+        random_state = self._megatron_random_state()
+        if random_state is not None:
+            env["ART_MEGATRON_RANDOM_STATE"] = str(random_state)
 
         command = (
             f"{setup_cmd}uv run --project {shlex.quote(str(project_root))} "
-            f"torchrun --nproc_per_node {num_gpus} {shlex.quote(str(train_script))}"
+            f"torchrun --master-addr {shlex.quote(master_addr)} "
+            f"--master-port {shlex.quote(master_port)} "
+            f"--nproc_per_node {num_gpus} {shlex.quote(str(train_script))}"
         )
         self._megatron_process = await asyncio.create_subprocess_shell(
             command,
             cwd=str(project_root),
+            env=env,
         )
 
     def _clear_pending_jobs(self) -> None:
-        os.makedirs(DEFAULT_JOBS_DIR, exist_ok=True)
-        for job_name in os.listdir(DEFAULT_JOBS_DIR):
+        jobs_dir, _training_log_dir, _wake_lock_path = self._megatron_runtime_paths()
+        os.makedirs(jobs_dir, exist_ok=True)
+        for job_name in os.listdir(jobs_dir):
             if job_name.endswith(".json"):
-                os.remove(os.path.join(DEFAULT_JOBS_DIR, job_name))
+                os.remove(os.path.join(jobs_dir, job_name))
+
+    def _create_megatron_job_paths(self) -> tuple[str, str]:
+        jobs_dir, training_log_dir, _wake_lock_path = self._megatron_runtime_paths()
+        return create_megatron_job_paths(
+            jobs_dir=jobs_dir,
+            training_log_dir=training_log_dir,
+        )
 
     def _resolve_training_lora_path(self) -> str:
         lora_path = get_last_checkpoint_dir(self.output_dir)
@@ -282,7 +336,7 @@ class MegatronService:
         )
         self._ensure_lora_adapter_config(new_checkpoint_dir, source_path=lora_path)
 
-        wake_lock_path = DEFAULT_VLLM_WAKE_LOCK_PATH
+        _jobs_dir, _training_log_dir, wake_lock_path = self._megatron_runtime_paths()
         try:
             with open(wake_lock_path, "w") as lock_file:
                 lock_file.write("waking vllm\n")
@@ -339,7 +393,7 @@ class MegatronService:
                 "moe_routing_replay_bundle is only supported for in-process/runtime APIs; "
                 "MegatronService subprocess jobs must use moe_routing_replay_path."
             )
-        job_path, log_path = create_megatron_job_paths()
+        job_path, log_path = self._create_megatron_job_paths()
         job = MegatronTrainingJob(
             lora_path=lora_path,
             optimizer_state_path=self._get_optimizer_state_path("rl"),
@@ -365,7 +419,7 @@ class MegatronService:
     ) -> AsyncIterator[dict[str, float]]:
         llm, lora_path = await self._prepare_for_training()
         serialized_batches = materialize_sft_batches(batches)
-        job_path, log_path = create_megatron_job_paths()
+        job_path, log_path = self._create_megatron_job_paths()
         grad_accumulation_sequences = (
             config.batch_size if isinstance(config.batch_size, int) else None
         )

--- a/src/art/megatron/setup.sh
+++ b/src/art/megatron/setup.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda-12.8}"
 export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-9.0}"
-# install missing cudnn headers & ninja build tools
+# install missing cudnn headers, DeepEP RDMA headers, and ninja build tools
 apt-get update
-apt-get install -y libcudnn9-headers-cuda-12 ninja-build
+apt-get install -y libcudnn9-headers-cuda-12 libibverbs-dev ninja-build
 
 # Python dependencies are declared in pyproject.toml extras.
 # Keep backend + megatron together so setup does not prune runtime deps (e.g. vllm).

--- a/src/art/megatron/train.py
+++ b/src/art/megatron/train.py
@@ -876,6 +876,10 @@ def load_adapter_into_model(
             if hasattr(module, "load_lora"):
                 module.load_lora(adapter_model)  # type: ignore[attr-defined]
 
+    if optimizer is None:
+        return
+    optimizer.reload_model_params()
+
 
 def collect_sharded_lora_state(
     model_chunks: ModelChunks,

--- a/src/art/megatron/train.py
+++ b/src/art/megatron/train.py
@@ -163,94 +163,6 @@ def _install_fast_frozen_output_backward() -> None:
     LinearWithFrozenWeight.backward = staticmethod(_fast_backward)
 
 
-def _install_intranode_deepep_buffer_patch() -> None:
-    # currently needed because we don't build DeepEP with nvshmem, needed for inter-node comm
-    # when we upgrade to multi-node, we'll build with nvshmem, remove this patch and validate the performance
-    from megatron.core.transformer.moe import fused_a2a
-
-    fused_a2a_module = cast(Any, fused_a2a)
-
-    if getattr(fused_a2a_module.get_buffer, "__art_intranode_deepep_patch__", False):
-        return
-
-    def _safe_rdma_size_hint(config: Any, hidden_bytes: int, group_size: int) -> int:
-        try:
-            return int(config.get_rdma_buffer_size_hint(hidden_bytes, group_size))
-        except RuntimeError as exc:
-            if "NVSHMEM is disable" not in str(exc):
-                raise
-            return 0
-
-    def _patched_get_buffer(
-        group: torch.distributed.ProcessGroup,  # type: ignore[name-defined]
-        hidden_bytes: int,
-    ) -> Any:
-        num_nvl_bytes, num_rdma_bytes = 0, 0
-        for config in (
-            fused_a2a_module.Buffer.get_dispatch_config(group.size()),
-            fused_a2a_module.Buffer.get_combine_config(group.size()),
-        ):
-            num_nvl_bytes = max(
-                int(config.get_nvl_buffer_size_hint(hidden_bytes, group.size())),
-                num_nvl_bytes,
-            )
-            num_rdma_bytes = max(
-                _safe_rdma_size_hint(config, hidden_bytes, group.size()),
-                num_rdma_bytes,
-            )
-
-        buffer = fused_a2a_module._buffer
-        if (
-            buffer is None
-            or buffer.group != group
-            or buffer.num_nvl_bytes < num_nvl_bytes
-            or buffer.num_rdma_bytes < num_rdma_bytes
-        ):
-            buffer = fused_a2a_module.Buffer(group, num_nvl_bytes, num_rdma_bytes)
-            fused_a2a_module._buffer = buffer
-        return buffer
-
-    setattr(_patched_get_buffer, "__art_intranode_deepep_patch__", True)
-    fused_a2a_module.get_buffer = _patched_get_buffer
-
-
-def _install_deepep_metadata_release_patch() -> None:
-    from megatron.core.transformer.moe.token_dispatcher import _DeepepManager
-
-    deepep_manager = cast(Any, _DeepepManager)
-    if getattr(deepep_manager, "__art_metadata_release_patch__", False):
-        return
-
-    original_dispatch = deepep_manager.dispatch
-    original_permute = deepep_manager.get_permuted_hidden_states_by_experts
-    original_restore = deepep_manager.get_restored_hidden_states_by_experts
-
-    def _patched_dispatch(self: Any, *args: Any, **kwargs: Any) -> Any:
-        hidden_states = original_dispatch(self, *args, **kwargs)
-        self.token_indices = None
-        self.token_probs = None
-        return hidden_states
-
-    def _patched_permute(self: Any, *args: Any, **kwargs: Any) -> Any:
-        hidden_states, permuted_probs = original_permute(self, *args, **kwargs)
-        self.dispatched_indices = None
-        self.dispatched_probs = None
-        return hidden_states, permuted_probs
-
-    def _patched_restore(self: Any, *args: Any, **kwargs: Any) -> Any:
-        hidden_states = original_restore(self, *args, **kwargs)
-        self.dispatched_routing_map = None
-        self.reversed_mapping_for_combine = None
-        self.pad_offsets = None
-        self.hidden_shape_before_permute = None
-        return hidden_states
-
-    deepep_manager.dispatch = _patched_dispatch
-    deepep_manager.get_permuted_hidden_states_by_experts = _patched_permute
-    deepep_manager.get_restored_hidden_states_by_experts = _patched_restore
-    setattr(deepep_manager, "__art_metadata_release_patch__", True)
-
-
 def _eager_initialize_optimizer_state(optimizer: Any) -> None:
     chained_optimizers = getattr(optimizer, "chained_optimizers", None)
     if chained_optimizers is not None:
@@ -371,8 +283,6 @@ def build_training_runtime(
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(seed)
     _install_fast_frozen_output_backward()
-    _install_intranode_deepep_buffer_patch()
-    _install_deepep_metadata_release_patch()
     provider = get_provider(
         model_identifier
         or os.environ.get("MODEL_IDENTIFIER", DEFAULT_MODEL_IDENTIFIER),

--- a/src/art/megatron/train.py
+++ b/src/art/megatron/train.py
@@ -17,7 +17,7 @@ import importlib
 import json
 import math
 import os
-from pathlib import Path
+import random
 import shutil
 import time
 from typing import Any, Callable, cast
@@ -27,13 +27,14 @@ from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.transformer.module import MegatronModule
-from pydantic import BaseModel, ConfigDict
+from megatron.core.transformer.transformer_layer import TransformerLayer
+from pydantic import BaseModel, ConfigDict, field_validator
 import torch
 from torch._inductor.runtime.cache_dir_utils import cache_dir as inductor_cache_dir
 
 from art import dev, types
 from art.loss import loss_fn, shift_tensor
-from art.megatron.client import create_megatron_job_paths, write_megatron_job
+from art.megatron.compile_workarounds import install_torch_compile_workarounds
 from art.megatron.finalize_grads import finalize_model_grads_extended
 from art.megatron.flex_attention import create_shared_prefix_attention_state
 from art.megatron.jobs import (
@@ -45,9 +46,14 @@ from art.megatron.jobs import (
 )
 from art.megatron.lora import apply_lora_adapters
 from art.megatron.merge import merge_lora_adapter
+from art.megatron.model_chunks import (
+    ModelChunks,
+    as_megatron_api_chunks,
+    unwrap_megatron_chunk,
+    validate_model_chunks,
+)
 from art.megatron.offload import (
     OffloadState,
-    clear_optimizer_state,
     offload_to_cpu,
     reload_to_gpu,
 )
@@ -87,11 +93,18 @@ class TrainingRuntime(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     provider: Any
-    model: list[MegatronModule]
-    optimizer: Any
+    model: ModelChunks
+    optimizer: Any | None
+    optimizer_config: OptimizerConfig
     rank: int
     world_size: int
     moe_routing_replay_controller: MoeRoutingReplayController | None = None
+
+    @field_validator("model")
+    @classmethod
+    def _validate_model(cls, value: ModelChunks) -> ModelChunks:
+        validate_model_chunks(value)
+        return value
 
 
 class TrainStepResult(BaseModel):
@@ -99,7 +112,7 @@ class TrainStepResult(BaseModel):
 
     reduced_loss: torch.Tensor
     probs_corr: float
-    new_logprobs: torch.Tensor | None
+    new_logprobs: list[torch.Tensor] | None = None
     update_successful: bool
     grad_norm: float
     num_zeros_in_grad: int | None
@@ -123,10 +136,7 @@ def _frozen_linear_grad_input(
 ) -> torch.Tensor:
     if grad_output.dim() <= 2 or weight.dim() != 2:
         return grad_output.matmul(weight)
-    try:
-        grad_output_2d = grad_output.view(-1, int(grad_output.shape[-1]))
-    except RuntimeError:
-        grad_output_2d = grad_output.reshape(-1, int(grad_output.shape[-1]))
+    grad_output_2d = grad_output.reshape(-1, int(grad_output.shape[-1]))
     grad_input_2d = grad_output_2d.matmul(weight)
     return grad_input_2d.reshape(*grad_output.shape[:-1], int(weight.shape[-1]))
 
@@ -154,9 +164,117 @@ def _install_fast_frozen_output_backward() -> None:
     LinearWithFrozenWeight.backward = staticmethod(_fast_backward)
 
 
-def _install_gpt_preprocess_hook(model_chunks: list[MegatronModule]) -> None:
+def _install_intranode_deepep_buffer_patch() -> None:
+    # currently needed because we don't build DeepEP with nvshmem, needed for inter-node comm
+    # when we upgrade to multi-node, we'll build with nvshmem, remove this patch and validate the performance
+    from megatron.core.transformer.moe import fused_a2a
+
+    fused_a2a_module = cast(Any, fused_a2a)
+
+    if getattr(fused_a2a_module.get_buffer, "__art_intranode_deepep_patch__", False):
+        return
+
+    def _safe_rdma_size_hint(config: Any, hidden_bytes: int, group_size: int) -> int:
+        try:
+            return int(config.get_rdma_buffer_size_hint(hidden_bytes, group_size))
+        except RuntimeError as exc:
+            if "NVSHMEM is disable" not in str(exc):
+                raise
+            return 0
+
+    def _patched_get_buffer(
+        group: torch.distributed.ProcessGroup,  # type: ignore[name-defined]
+        hidden_bytes: int,
+    ) -> Any:
+        num_nvl_bytes, num_rdma_bytes = 0, 0
+        for config in (
+            fused_a2a_module.Buffer.get_dispatch_config(group.size()),
+            fused_a2a_module.Buffer.get_combine_config(group.size()),
+        ):
+            num_nvl_bytes = max(
+                int(config.get_nvl_buffer_size_hint(hidden_bytes, group.size())),
+                num_nvl_bytes,
+            )
+            num_rdma_bytes = max(
+                _safe_rdma_size_hint(config, hidden_bytes, group.size()),
+                num_rdma_bytes,
+            )
+
+        buffer = fused_a2a_module._buffer
+        if (
+            buffer is None
+            or buffer.group != group
+            or buffer.num_nvl_bytes < num_nvl_bytes
+            or buffer.num_rdma_bytes < num_rdma_bytes
+        ):
+            buffer = fused_a2a_module.Buffer(group, num_nvl_bytes, num_rdma_bytes)
+            fused_a2a_module._buffer = buffer
+        return buffer
+
+    setattr(_patched_get_buffer, "__art_intranode_deepep_patch__", True)
+    fused_a2a_module.get_buffer = _patched_get_buffer
+
+
+def _install_deepep_metadata_release_patch() -> None:
+    from megatron.core.transformer.moe.token_dispatcher import _DeepepManager
+
+    deepep_manager = cast(Any, _DeepepManager)
+    if getattr(deepep_manager, "__art_metadata_release_patch__", False):
+        return
+
+    original_dispatch = deepep_manager.dispatch
+    original_permute = deepep_manager.get_permuted_hidden_states_by_experts
+    original_restore = deepep_manager.get_restored_hidden_states_by_experts
+
+    def _patched_dispatch(self: Any, *args: Any, **kwargs: Any) -> Any:
+        hidden_states = original_dispatch(self, *args, **kwargs)
+        self.token_indices = None
+        self.token_probs = None
+        return hidden_states
+
+    def _patched_permute(self: Any, *args: Any, **kwargs: Any) -> Any:
+        hidden_states, permuted_probs = original_permute(self, *args, **kwargs)
+        self.dispatched_indices = None
+        self.dispatched_probs = None
+        return hidden_states, permuted_probs
+
+    def _patched_restore(self: Any, *args: Any, **kwargs: Any) -> Any:
+        hidden_states = original_restore(self, *args, **kwargs)
+        self.dispatched_routing_map = None
+        self.reversed_mapping_for_combine = None
+        self.pad_offsets = None
+        self.hidden_shape_before_permute = None
+        return hidden_states
+
+    deepep_manager.dispatch = _patched_dispatch
+    deepep_manager.get_permuted_hidden_states_by_experts = _patched_permute
+    deepep_manager.get_restored_hidden_states_by_experts = _patched_restore
+    setattr(deepep_manager, "__art_metadata_release_patch__", True)
+
+
+def _eager_initialize_optimizer_state(optimizer: Any) -> None:
+    chained_optimizers = getattr(optimizer, "chained_optimizers", None)
+    if chained_optimizers is not None:
+        for child_optimizer in chained_optimizers:
+            _eager_initialize_optimizer_state(child_optimizer)
+        return
+    init_state_fn = getattr(optimizer, "init_state_fn", None)
+    inner_optimizer = getattr(optimizer, "optimizer", None)
+    if callable(init_state_fn) and inner_optimizer is not None:
+        init_state_fn(inner_optimizer, getattr(optimizer, "config", None))
+
+
+def _compile_enabled() -> bool:
+    return os.environ.get("ART_DISABLE_MEGATRON_COMPILE", "0") in {
+        "0",
+        "false",
+        "False",
+    }
+
+
+def _install_gpt_preprocess_hook(model_chunks: ModelChunks) -> None:
     for chunk in model_chunks:
-        module: Any = chunk
+        module: Any = unwrap_megatron_chunk(chunk)
         while not isinstance(module, GPTModel) and hasattr(module, "module"):
             module = module.module
         if not isinstance(module, GPTModel):
@@ -192,6 +310,13 @@ def _default_optimizer_config() -> OptimizerConfig:
         clip_grad=0.1,
         weight_decay=0.1,
         adam_eps=1e-13,
+    )
+
+
+def _build_optimizer(model: ModelChunks, optimizer_config: OptimizerConfig) -> Any:
+    return get_megatron_optimizer(
+        config=optimizer_config,
+        model_chunks=as_megatron_api_chunks(model),
     )
 
 
@@ -240,7 +365,15 @@ def build_training_runtime(
     print_env: bool = True,
     print_optimizer_stats: bool = True,
 ) -> TrainingRuntime:
+    if random_state := os.environ.get("ART_MEGATRON_RANDOM_STATE"):
+        seed = int(random_state)
+        random.seed(seed)
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
     _install_fast_frozen_output_backward()
+    _install_intranode_deepep_buffer_patch()
+    _install_deepep_metadata_release_patch()
     provider = get_provider(
         model_identifier
         or os.environ.get("MODEL_IDENTIFIER", DEFAULT_MODEL_IDENTIFIER),
@@ -254,7 +387,7 @@ def build_training_runtime(
     )
 
     model = cast(
-        list[MegatronModule],
+        ModelChunks,
         provider.provide_distributed_model(
             ddp_config=DistributedDataParallelConfig(
                 # memory and comm for this should be small anyways cause lora
@@ -278,11 +411,13 @@ def build_training_runtime(
         print("TRITON_CACHE_DIR:", os.environ["TRITON_CACHE_DIR"])
 
     _install_gpt_preprocess_hook(model)
+    if _compile_enabled():
+        install_torch_compile_workarounds()
+        for chunk in model:
+            _compile_transformer_layers(chunk)
 
-    optimizer = get_megatron_optimizer(
-        config=optimizer_config or _default_optimizer_config(),
-        model_chunks=model,
-    )
+    optimizer_config = optimizer_config or _default_optimizer_config()
+    optimizer = _build_optimizer(model, optimizer_config)
 
     if rank == 0 and print_optimizer_stats:
         num_params = sum(
@@ -300,6 +435,7 @@ def build_training_runtime(
         provider=provider,
         model=model,
         optimizer=optimizer,
+        optimizer_config=optimizer_config,
         rank=rank,
         world_size=world_size,
     )
@@ -320,13 +456,12 @@ def run_megatron_worker_loop(
     before_job: Callable[[], None] | None = None,
     after_job: Callable[[], None] | None = None,
 ) -> None:
+    jobs_dir = os.environ.get("ART_MEGATRON_JOBS_DIR", DEFAULT_JOBS_DIR)
     while True:
         torch.distributed.barrier()  # type: ignore[possibly-missing-attribute]
-        os.makedirs(DEFAULT_JOBS_DIR, exist_ok=True)
+        os.makedirs(jobs_dir, exist_ok=True)
         job_names = sorted(
-            job_name
-            for job_name in os.listdir(DEFAULT_JOBS_DIR)
-            if job_name.endswith(".json")
+            job_name for job_name in os.listdir(jobs_dir) if job_name.endswith(".json")
         )
         if not job_names:
             time.sleep(1)
@@ -337,7 +472,7 @@ def run_megatron_worker_loop(
         if before_job is not None:
             before_job()
 
-        job_path = os.path.join(DEFAULT_JOBS_DIR, job_names[0])
+        job_path = os.path.join(jobs_dir, job_names[0])
         job = _load_megatron_job(job_path, supports_sft=supports_sft)
         print0(runtime.rank, "Loaded job from", job_path)
         print0(runtime.rank, "Job:", job)
@@ -453,7 +588,7 @@ def run_megatron_rl_job(
         torch.cuda.empty_cache()
 
 
-def _flush_param_grads_to_main_grads(model_chunks: list[MegatronModule]) -> None:
+def _flush_param_grads_to_main_grads(model_chunks: ModelChunks) -> None:
     """Fallback for direct SFT jobs when DDP post-hooks leave grads in param.grad.
 
     Megatron's distributed optimizer reads gradients from `main_grad`, which is
@@ -489,6 +624,7 @@ def run_megatron_sft_job(
             optimizer_state_path=job.optimizer_state_path,
         )
 
+        assert runtime.optimizer is not None
         runtime.optimizer.config.clip_grad = job.max_grad_norm
         for param_group in runtime.optimizer.param_groups:
             param_group["weight_decay"] = job.weight_decay
@@ -614,7 +750,9 @@ def _load_lora_and_optimizer(
         raise FileNotFoundError(f"No adapter model found at {adapter_model_path}")
     print0(runtime.rank, "Loading adapter model from", adapter_model_path)
     adapter_model = load_file(adapter_model_path)
-    load_adapter_into_model(runtime.model, adapter_model, runtime.optimizer)
+    load_adapter_into_model(runtime.model, adapter_model)
+    runtime.optimizer = _build_optimizer(runtime.model, runtime.optimizer_config)
+    assert runtime.optimizer is not None
 
     optimizer_shard_path = os.path.join(
         optimizer_state_path,
@@ -630,8 +768,7 @@ def _load_lora_and_optimizer(
             optimizer_shard_path,
             "- resetting optimizer for new run",
         )
-        clear_optimizer_state(runtime.optimizer)
-        runtime.optimizer.reload_model_params()
+        _eager_initialize_optimizer_state(runtime.optimizer)
     return adapter_model
 
 
@@ -642,6 +779,7 @@ def _save_lora_and_optimizer(
     lora_path: str,
     optimizer_state_path: str,
 ) -> None:
+    assert runtime.optimizer is not None
     sharded_state_dict, sharded_state_manifest = collect_sharded_lora_state(
         runtime.model,
         adapter_model,
@@ -702,14 +840,34 @@ def _causal_attention_state(seq_len: int, device: torch.device) -> Any:
     )
 
 
-def iter_modules(model_chunks: list[MegatronModule]) -> Any:
+def _set_child_module(
+    parent: torch.nn.Module,
+    name: str,
+    child: torch.nn.Module,
+) -> None:
+    if isinstance(parent, torch.nn.ModuleList | torch.nn.Sequential):
+        parent[int(name)] = child
+        return
+    setattr(parent, name, child)
+
+
+def _compile_transformer_layers(module: torch.nn.Module) -> None:
+    for name, child in list(module.named_children()):
+        if isinstance(child, TransformerLayer):
+            compiled_child = cast(torch.nn.Module, torch.compile(child))
+            _set_child_module(parent=module, name=name, child=compiled_child)
+            continue
+        _compile_transformer_layers(child)
+
+
+def iter_modules(model_chunks: ModelChunks) -> Any:
     for chunk in model_chunks:
         for module in chunk.modules():
             yield module
 
 
 def load_adapter_into_model(
-    model_chunks: list[MegatronModule],
+    model_chunks: ModelChunks,
     adapter_model: dict[str, torch.Tensor],
     optimizer: Any | None = None,
 ) -> None:
@@ -718,13 +876,9 @@ def load_adapter_into_model(
             if hasattr(module, "load_lora"):
                 module.load_lora(adapter_model)  # type: ignore[attr-defined]
 
-    if optimizer is None:
-        return
-    optimizer.reload_model_params()
-
 
 def collect_sharded_lora_state(
-    model_chunks: list[MegatronModule],
+    model_chunks: ModelChunks,
     adapter_model: dict[str, torch.Tensor],
 ) -> tuple[dict[str, torch.Tensor], dict[str, dict[str, Any]]]:
     sharded_state_dict: dict[str, torch.Tensor] = {}
@@ -738,7 +892,7 @@ def collect_sharded_lora_state(
                 target_dtype = (
                     adapter_model[key].dtype if key in adapter_model else value.dtype
                 )
-                sharded_state_dict[key] = value.to(target_dtype)
+                sharded_state_dict[key] = value.to(target_dtype).contiguous()
         if hasattr(module, "sharded_lora_manifest"):
             module_sharded_lora_manifest: dict[str, dict[str, Any]] = (
                 module.sharded_lora_manifest()  # type: ignore[attr-defined]
@@ -960,7 +1114,7 @@ def _prepare_sft_micro_inputs(
 
 def run_megatron_sft_step(
     *,
-    model_chunks: list[MegatronModule],
+    model_chunks: ModelChunks,
     optimizer: Any,
     learning_rate: float,
     inputs: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
@@ -1029,7 +1183,9 @@ def run_megatron_sft_step(
         raise RuntimeError("run_megatron_sft_step did not produce outputs")
 
     _flush_param_grads_to_main_grads(model_chunks)
-    finalize_model_grads_extended(model_chunks, num_tokens=num_tokens)
+    finalize_model_grads_extended(
+        as_megatron_api_chunks(model_chunks), num_tokens=num_tokens
+    )
     update_successful, grad_norm, num_zeros_in_grad = _optimizer_step(
         optimizer,
         learning_rate,
@@ -1056,7 +1212,7 @@ def run_megatron_sft_step(
 
 def run_training_step(
     *,
-    model_chunks: list[MegatronModule],
+    model_chunks: ModelChunks,
     optimizer: Any,
     learning_rate: float,
     inputs: PackedTensors | list[PackedTensors],
@@ -1101,9 +1257,9 @@ def run_training_step(
 
     micro_count = len(micro_inputs)
     raw_loss_sum: torch.Tensor | None = None
-    num_tokens = _local_trainable_token_count_tensor(micro_inputs, device=device)
+    token_count = _local_trainable_token_count_tensor(micro_inputs, device=device)
     probs_corr_sum = 0.0
-    new_logprobs: torch.Tensor | None = None
+    new_logprobs_list: list[torch.Tensor] = []
 
     for micro in micro_inputs:
         _move_inputs_to_device(micro, device)
@@ -1137,17 +1293,28 @@ def run_training_step(
             raw_loss_sum = detached_micro_loss
         else:
             raw_loss_sum = raw_loss_sum + detached_micro_loss
+        del loss_info
+        del micro_loss
+        del attention_mask
+        del attention_state
+        new_logprobs_list.append(
+            new_logprobs.detach().to(device="cpu", non_blocking=True)
+        )
+        del new_logprobs
 
-    if new_logprobs is None or raw_loss_sum is None:
+    if raw_loss_sum is None:
         raise RuntimeError("run_training_step did not produce outputs")
 
-    # num_tokens is reduced in place across ranks by finalize_model_grads().
-    finalize_model_grads_extended(model_chunks, num_tokens=num_tokens)
+    torch.cuda.empty_cache()
+    finalize_model_grads_extended(
+        as_megatron_api_chunks(model_chunks),
+        num_tokens=token_count,
+    )
     update_successful, grad_norm, num_zeros_in_grad = _optimizer_step(
         optimizer,
         learning_rate,
     )
-    global_num_tokens = max(num_tokens.item(), 1.0)
+    global_num_tokens = max(token_count.item(), 1.0)
     reduced_loss = _reduce_loss(
         raw_loss_sum / global_num_tokens,
         op=torch.distributed.ReduceOp.SUM,  # ty: ignore[possibly-missing-attribute]
@@ -1160,7 +1327,7 @@ def run_training_step(
     return TrainStepResult(
         reduced_loss=reduced_loss,
         probs_corr=probs_corr_sum / micro_count,
-        new_logprobs=new_logprobs,
+        new_logprobs=new_logprobs_list,
         update_successful=update_successful,
         grad_norm=grad_norm,
         num_zeros_in_grad=num_zeros_in_grad,
@@ -1169,22 +1336,33 @@ def run_training_step(
 
 def _run_service_loop(runtime: TrainingRuntime) -> None:
     offload_state = OffloadState()
-    offload_to_cpu(runtime.model, runtime.optimizer, runtime.rank, offload_state)
+    wake_lock_path = os.environ.get(
+        "ART_MEGATRON_WAKE_LOCK_PATH", DEFAULT_VLLM_WAKE_LOCK_PATH
+    )
 
     def wait_until_ready() -> None:
-        while os.path.exists(DEFAULT_VLLM_WAKE_LOCK_PATH):
+        while os.path.exists(wake_lock_path):
             time.sleep(0.2)
 
+    def before_job() -> None:
+        reload_to_gpu(runtime.model, runtime.rank, offload_state)
+
+    def after_job() -> None:
+        optimizer = runtime.optimizer
+        runtime.optimizer = None
+        if optimizer is not None:
+            del optimizer
+        gc.collect()
+        torch.cuda.empty_cache()
+        offload_to_cpu(runtime.model, runtime.rank, offload_state)
+
+    after_job()
     run_megatron_worker_loop(
         runtime,
         supports_sft=True,
         wait_until_ready=wait_until_ready,
-        before_job=lambda: reload_to_gpu(
-            runtime.model, runtime.optimizer, runtime.rank, offload_state
-        ),
-        after_job=lambda: offload_to_cpu(
-            runtime.model, runtime.optimizer, runtime.rank, offload_state
-        ),
+        before_job=before_job,
+        after_job=after_job,
     )
 
 

--- a/src/art/megatron/train.py
+++ b/src/art/megatron/train.py
@@ -57,7 +57,7 @@ from art.megatron.offload import (
     offload_to_cpu,
     reload_to_gpu,
 )
-from art.megatron.provider import get_provider
+from art.megatron.provider import _env_flag, get_provider
 from art.megatron.routing_replay import (
     MoeRoutingReplayBundle,
     MoeRoutingReplayController,
@@ -75,6 +75,7 @@ safe_open = safetensors.safe_open
 save_file = safetensors_torch.save_file
 
 DEFAULT_MODEL_IDENTIFIER = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+_optimizer_stats_printed = False
 
 __all__ = [
     "DEFAULT_MODEL_IDENTIFIER",
@@ -176,11 +177,8 @@ def _eager_initialize_optimizer_state(optimizer: Any) -> None:
 
 
 def _compile_enabled() -> bool:
-    return os.environ.get("ART_DISABLE_MEGATRON_COMPILE", "0") in {
-        "0",
-        "false",
-        "False",
-    }
+    disabled = _env_flag("ART_DISABLE_MEGATRON_COMPILE")
+    return disabled is not True
 
 
 def _install_gpt_preprocess_hook(model_chunks: ModelChunks) -> None:
@@ -224,11 +222,40 @@ def _default_optimizer_config() -> OptimizerConfig:
     )
 
 
-def _build_optimizer(model: ModelChunks, optimizer_config: OptimizerConfig) -> Any:
-    return get_megatron_optimizer(
+def _maybe_print_optimizer_stats(
+    optimizer: Any,
+    model: ModelChunks,
+) -> None:
+    global _optimizer_stats_printed
+    if _optimizer_stats_printed:
+        return
+    if torch.distributed.is_initialized():  # ty: ignore[possibly-missing-attribute]
+        if torch.distributed.get_rank() != 0:  # ty: ignore[possibly-missing-attribute]
+            _optimizer_stats_printed = True
+            return
+    num_params = sum(
+        p.numel()
+        for group in optimizer.param_groups
+        if not group["is_decoupled_lr"]
+        for p in group["params"]
+    )
+    print(f"Number of parameters in optimizer: {num_params:,}")
+    total_params = sum(p.numel() for module in model for p in module.parameters())
+    percent = (num_params / total_params) * 100 if total_params > 0 else 0
+    print(f"Optimizer parameters as percent of total: {percent:0.2f}%")
+    _optimizer_stats_printed = True
+
+
+def _build_optimizer(
+    model: ModelChunks,
+    optimizer_config: OptimizerConfig,
+) -> Any:
+    optimizer = get_megatron_optimizer(
         config=optimizer_config,
         model_chunks=as_megatron_api_chunks(model),
     )
+    _maybe_print_optimizer_stats(optimizer, model)
+    return optimizer
 
 
 def configure_moe_routing_replay(
@@ -274,7 +301,7 @@ def build_training_runtime(
     moe_routing_replay_bundle: MoeRoutingReplayBundle | None = None,
     moe_routing_replay_strict: bool = True,
     print_env: bool = True,
-    print_optimizer_stats: bool = True,
+    build_optimizer: bool = True,
 ) -> TrainingRuntime:
     if random_state := os.environ.get("ART_MEGATRON_RANDOM_STATE"):
         seed = int(random_state)
@@ -326,19 +353,14 @@ def build_training_runtime(
             _compile_transformer_layers(chunk)
 
     optimizer_config = optimizer_config or _default_optimizer_config()
-    optimizer = _build_optimizer(model, optimizer_config)
-
-    if rank == 0 and print_optimizer_stats:
-        num_params = sum(
-            p.numel()
-            for group in optimizer.param_groups
-            if not group["is_decoupled_lr"]
-            for p in group["params"]
+    optimizer = (
+        _build_optimizer(
+            model,
+            optimizer_config,
         )
-        print(f"Number of parameters in optimizer: {num_params:,}")
-        total_params = sum(p.numel() for module in model for p in module.parameters())
-        percent = (num_params / total_params) * 100 if total_params > 0 else 0
-        print(f"Optimizer parameters as percent of total: {percent:0.2f}%")
+        if build_optimizer
+        else None
+    )
 
     runtime = TrainingRuntime(
         provider=provider,
@@ -672,7 +694,10 @@ def _load_lora_and_optimizer(
     print0(runtime.rank, "Loading adapter model from", lora_path)
     adapter_model = load_lora_adapter_state_dict(lora_path)
     load_adapter_into_model(runtime.model, adapter_model)
-    runtime.optimizer = _build_optimizer(runtime.model, runtime.optimizer_config)
+    runtime.optimizer = _build_optimizer(
+        runtime.model,
+        runtime.optimizer_config,
+    )
     assert runtime.optimizer is not None
 
     optimizer_shard_path = os.path.join(
@@ -1273,10 +1298,7 @@ def _run_service_loop(runtime: TrainingRuntime) -> None:
         reload_to_gpu(runtime.model, runtime.rank, offload_state)
 
     def after_job() -> None:
-        optimizer = runtime.optimizer
         runtime.optimizer = None
-        if optimizer is not None:
-            del optimizer
         gc.collect()
         torch.cuda.empty_cache()
         offload_to_cpu(runtime.model, runtime.rank, offload_state)
@@ -1293,7 +1315,8 @@ def _run_service_loop(runtime: TrainingRuntime) -> None:
 
 def main() -> None:
     runtime = build_training_runtime(
-        model_identifier=os.environ.get("MODEL_IDENTIFIER", DEFAULT_MODEL_IDENTIFIER)
+        model_identifier=os.environ.get("MODEL_IDENTIFIER", DEFAULT_MODEL_IDENTIFIER),
+        build_optimizer=False,
     )
     _run_service_loop(runtime)
 

--- a/src/art/pipeline_trainer/trainer.py
+++ b/src/art/pipeline_trainer/trainer.py
@@ -78,6 +78,7 @@ class PipelineTrainer(Generic[ScenarioT, ConfigT]):
         loss_fn_config: dict | None = None,
         normalize_advantages: bool = True,
         adam_params: object | None = None,
+        packed_sequence_length: int | None = None,
         max_steps: int | None = None,
         # Discard handling
         discard_queue_multiplier: int = 100,
@@ -129,6 +130,7 @@ class PipelineTrainer(Generic[ScenarioT, ConfigT]):
         self.loss_fn_config = loss_fn_config
         self.normalize_advantages = normalize_advantages
         self.adam_params = adam_params
+        self.packed_sequence_length = packed_sequence_length
         self.max_steps = max_steps
         self._status_log_interval_seconds = log_interval_seconds
         self.eval_every_n_steps = eval_every_n_steps
@@ -452,15 +454,20 @@ class PipelineTrainer(Generic[ScenarioT, ConfigT]):
             if os.getenv("ART_TRAIN_STEP_LOG"):
                 print(f"[train] step {expected_step} starting (batch={len(batch)})")
             try:
+                train_kwargs: dict[str, Any] = {
+                    "learning_rate": self.learning_rate,
+                    "loss_fn": self.loss_fn,
+                    "loss_fn_config": self.loss_fn_config,
+                    "normalize_advantages": self.normalize_advantages,
+                    "save_checkpoint": should_checkpoint,
+                    "adam_params": self.adam_params,
+                }
+                if self.packed_sequence_length is not None:
+                    train_kwargs["packed_sequence_length"] = self.packed_sequence_length
                 result = await self.backend.train(
                     self.model,
                     batch,
-                    learning_rate=self.learning_rate,
-                    loss_fn=self.loss_fn,
-                    loss_fn_config=self.loss_fn_config,
-                    normalize_advantages=self.normalize_advantages,
-                    save_checkpoint=should_checkpoint,
-                    adam_params=self.adam_params,
+                    **train_kwargs,
                 )
             except Exception:
                 self._status.note_training_end()

--- a/tests/integration/megatron_oracle_worker.py
+++ b/tests/integration/megatron_oracle_worker.py
@@ -62,10 +62,12 @@ def run_worker_subprocess(
         "--run-request",
         str(request_path),
     ]
+    env = {**os.environ, "PYTHONUNBUFFERED": "1"}
+    env["ART_DISABLE_MEGATRON_COMPILE"] = "1"
     run = subprocess.run(
         command,
         cwd=str(worker_cwd),
-        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+        env=env,
         capture_output=True,
         text=True,
         check=False,
@@ -279,6 +281,45 @@ def _configure_provider(
         provider.attention_dropout = 0.0
     if hasattr(provider, "hidden_dropout"):
         provider.hidden_dropout = 0.0
+
+
+@contextmanager
+def _patch_get_provider_for_oracle(
+    megatron_train_module: Any,
+    topology: Topology,
+    case_config: OracleCaseConfig,
+):
+    from art.megatron import provider as provider_module
+
+    original_get_provider = megatron_train_module.get_provider
+
+    def _oracle_get_provider(
+        model: str,
+        *,
+        torch_dtype: torch.dtype = torch.bfloat16,
+    ) -> Any:
+        provider = original_get_provider(model, torch_dtype=torch_dtype)
+        _configure_provider(provider, topology, case_config)
+        provider_module._apply_runtime_env_overrides(provider)
+        if case_config.precision == "fp32":
+            provider.moe_token_dispatcher_type = "alltoall"
+            provider.moe_flex_dispatcher_backend = None
+            provider.moe_shared_expert_overlap = True
+            provider.overlap_moe_expert_parallel_comm = False
+            provider.delay_wgrad_compute = False
+            provider.ep_overlap_early_attn_memory_release = False
+        elif provider_module._tp_ep_parallel_domain_size(provider) > 1:
+            provider_module.apply_flex_dispatcher_backend(
+                provider, moe_flex_dispatcher_backend="deepep"
+            )
+        provider.finalize()
+        return provider
+
+    megatron_train_module.get_provider = _oracle_get_provider
+    try:
+        yield
+    finally:
+        megatron_train_module.get_provider = original_get_provider
 
 
 def _build_optimizer_config(case_config: OracleCaseConfig):
@@ -774,18 +815,19 @@ def _worker_run(request: WorkerRunRequest) -> None:
     _set_deterministic_seed(request.case_config.seed)
     _configure_cuda_precision(request.case_config)
 
-    runtime = megatron_train.build_training_runtime(
-        model_identifier=request.case_config.base_model,
-        provider_torch_dtype=(
-            torch.float32 if request.case_config.precision == "fp32" else torch.bfloat16
-        ),
-        provider_configure=lambda provider: _configure_provider(
-            provider, request.topology, request.case_config
-        ),
-        optimizer_config=_build_optimizer_config(request.case_config),
-        print_env=False,
-        print_optimizer_stats=False,
-    )
+    with _patch_get_provider_for_oracle(
+        megatron_train, request.topology, request.case_config
+    ):
+        runtime = megatron_train.build_training_runtime(
+            model_identifier=request.case_config.base_model,
+            provider_torch_dtype=(
+                torch.float32
+                if request.case_config.precision == "fp32"
+                else torch.bfloat16
+            ),
+            optimizer_config=_build_optimizer_config(request.case_config),
+            print_env=False,
+        )
     model_chunks = runtime.model
     optimizer = runtime.optimizer
     megatron_train.configure_moe_routing_replay(

--- a/tests/unit/test_megatron_provider_env.py
+++ b/tests/unit/test_megatron_provider_env.py
@@ -1,0 +1,164 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def _ensure_package(name: str) -> ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = ModuleType(name)
+        module.__path__ = []  # type: ignore[attr-defined]
+        sys.modules[name] = module
+    return module
+
+
+def _stub_module(name: str, **attrs: object) -> ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = ModuleType(name)
+        sys.modules[name] = module
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+def _load_provider_module() -> ModuleType:
+    module_name = "art_megatron_provider_under_test"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+
+    for package_name in [
+        "art",
+        "art.megatron",
+        "megatron",
+        "megatron.bridge",
+        "megatron.bridge.models",
+        "megatron.bridge.models.hf_pretrained",
+        "megatron.bridge.models.qwen",
+        "megatron.bridge.training",
+        "megatron.core",
+        "megatron.core.transformer",
+    ]:
+        _ensure_package(package_name)
+
+    class _StateSource:
+        pass
+
+    class _ModuleSpec:
+        pass
+
+    class _GPTModelProvider:
+        pass
+
+    class _AutoBridge:
+        @staticmethod
+        def from_hf_pretrained(*args: object, **kwargs: object) -> object:
+            raise NotImplementedError
+
+    _stub_module("art.megatron.flex_attention", FlexDotProductAttention=object)
+    _stub_module("megatron.bridge", AutoBridge=_AutoBridge)
+    _stub_module(
+        "megatron.bridge.models.gpt_provider",
+        GPTModelProvider=_GPTModelProvider,
+    )
+    _stub_module(
+        "megatron.bridge.models.hf_pretrained.state",
+        SafeTensorsStateSource=object,
+        StateDict=object,
+        StateSource=_StateSource,
+    )
+    _stub_module(
+        "megatron.bridge.models.qwen.qwen3_moe_bridge",
+        Qwen3MoEBridge=object,
+    )
+    _stub_module(
+        "megatron.bridge.training.flex_dispatcher_backend",
+        apply_flex_dispatcher_backend=lambda *args, **kwargs: None,
+    )
+    _stub_module(
+        "megatron.core.transformer.enums",
+        AttnBackend=SimpleNamespace(auto="auto"),
+    )
+    _stub_module("megatron.core.transformer.spec_utils", ModuleSpec=_ModuleSpec)
+
+    provider_path = Path(__file__).resolve().parents[2] / "src/art/megatron/provider.py"
+    spec = spec_from_file_location(module_name, provider_path)
+    assert spec is not None and spec.loader is not None
+    module = module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+megatron_provider = _load_provider_module()
+
+
+def _fake_provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        overlap_moe_expert_parallel_comm=False,
+        delay_wgrad_compute=False,
+        ep_overlap_early_attn_memory_release=False,
+        moe_deepep_num_sms=None,
+        moe_apply_probs_on_input=False,
+        bias_activation_fusion=False,
+        fine_grained_activation_offloading=False,
+        offload_modules=[],
+        tensor_model_parallel_size=1,
+        recompute_granularity="full",
+        recompute_method="uniform",
+        recompute_num_layers=1,
+        recompute_modules=None,
+        moe_shared_expert_overlap=True,
+    )
+
+
+def test_apply_runtime_env_overrides_warns_on_shared_expert_overlap_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _fake_provider()
+    monkeypatch.setenv("ART_MEGATRON_OVERLAP_MOE_EXPERT_PARALLEL_COMM", "true")
+    monkeypatch.setenv("ART_MEGATRON_MOE_SHARED_EXPERT_OVERLAP", "true")
+    monkeypatch.setattr(
+        megatron_provider, "_resolve_default_deepep_num_sms", lambda _: 20
+    )
+
+    with pytest.warns(UserWarning, match="moe_shared_expert_overlap=False"):
+        megatron_provider._apply_runtime_env_overrides(provider)
+
+    assert provider.moe_shared_expert_overlap is False
+
+
+@pytest.mark.parametrize("raw_value", [None, "default"])
+def test_apply_runtime_env_overrides_uses_resolved_default_num_sms(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_value: str | None,
+) -> None:
+    provider = _fake_provider()
+    monkeypatch.setattr(
+        megatron_provider, "_resolve_default_deepep_num_sms", lambda _: 42
+    )
+    if raw_value is None:
+        monkeypatch.delenv("ART_MEGATRON_MOE_DEEPEP_NUM_SMS", raising=False)
+    else:
+        monkeypatch.setenv("ART_MEGATRON_MOE_DEEPEP_NUM_SMS", raw_value)
+
+    megatron_provider._apply_runtime_env_overrides(provider)
+
+    assert provider.moe_deepep_num_sms == 42
+
+
+@pytest.mark.parametrize("raw_value", ["none", "3", "0", "-2"])
+def test_env_default_or_even_positive_int_rejects_invalid_values(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_value: str,
+) -> None:
+    monkeypatch.setenv("ART_MEGATRON_MOE_DEEPEP_NUM_SMS", raw_value)
+
+    with pytest.raises(ValueError, match="positive, even integer"):
+        megatron_provider._env_default_or_even_positive_int(
+            "ART_MEGATRON_MOE_DEEPEP_NUM_SMS"
+        )

--- a/tests/unit/test_pipeline_trainer_local_backend.py
+++ b/tests/unit/test_pipeline_trainer_local_backend.py
@@ -5,11 +5,14 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from art import TrainableModel, Trajectory, TrajectoryGroup
 from art.dev.model import InternalModelConfig
 from art.local import LocalBackend
+from art.megatron import MegatronBackend
 from art.pipeline_trainer.trainer import PipelineTrainer
+from art.preprocessing.tokenize import TokenizedResult
 from art.utils.output_dirs import get_model_dir
 
 
@@ -89,6 +92,33 @@ async def test_pipeline_trainer_preserves_backend_train_kwargs(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_pipeline_trainer_forwards_packed_sequence_length_when_set(
+    tmp_path: Path,
+) -> None:
+    model = TrainableModel(
+        name="pipeline-packed-sequence-length",
+        project="pipeline-tests",
+        base_model="test-model",
+        base_path=str(tmp_path),
+    )
+    backend = MagicMock()
+    backend.train = AsyncMock(return_value=SimpleNamespace(step=1, metrics={}))
+
+    trainer = _make_trainer(
+        model=model,
+        backend=backend,
+        packed_sequence_length=4096,
+    )
+    trainer._output_queue = asyncio.Queue()
+    await trainer._output_queue.put(_make_group([0.0, 1.0]))
+    await trainer._output_queue.put(None)
+
+    await trainer._training_stage()
+
+    assert backend.train.await_args.kwargs["packed_sequence_length"] == 4096
+
+
+@pytest.mark.asyncio
 async def test_pipeline_trainer_uses_same_train_kwargs_for_local_backend(
     tmp_path: Path,
 ) -> None:
@@ -157,12 +187,122 @@ async def test_local_backend_train_translates_loss_fn(tmp_path: Path) -> None:
             model,
             [_make_group([1.0])],
             loss_fn="ppo",
+            packed_sequence_length=2048,
             save_checkpoint=False,
         )
 
     assert result.step == 1
     assert seen["config"].learning_rate == 5e-6
     assert seen["dev_config"]["ppo"] is True
+    assert seen["dev_config"]["packed_sequence_length"] == 2048
+
+
+def _make_tokenized_result(
+    trajectory: Trajectory,
+    token_ids: list[int],
+) -> TokenizedResult:
+    tokenizer = cast(
+        PreTrainedTokenizerBase,
+        SimpleNamespace(eos_token_id=0, decode=lambda token_id: str(token_id)),
+    )
+    return TokenizedResult(
+        advantage=1.0,
+        chat="",
+        token_ids=token_ids,
+        input_pos=list(range(len(token_ids))),
+        assistant_mask=[0] * (len(token_ids) - 1) + [1],
+        logprobs=[float("nan")] * (len(token_ids) - 1) + [-0.1],
+        pixel_values=None,
+        image_grid_thw=None,
+        trajectory=trajectory,
+        choice_offsets=[],
+        extra_logprobs={},
+        _tokenizer=tokenizer,
+        weight=1.0,
+        prompt_id=123,
+        prompt_length=1,
+    )
+
+
+def test_local_backend_get_packed_tensors_warns_and_drops_overlong_results(
+    tmp_path: Path,
+) -> None:
+    backend = LocalBackend(path=str(tmp_path))
+    model = TrainableModel(
+        name="local-backend-packed-sequence-length",
+        project="pipeline-tests",
+        base_model="test-model",
+        base_path=str(tmp_path),
+    )
+    short_trajectory = Trajectory(
+        reward=1.0,
+        initial_policy_version=0,
+        messages_and_choices=[
+            {"role": "user", "content": "short"},
+            {"role": "assistant", "content": "answer"},
+        ],
+    )
+    long_trajectory = Trajectory(
+        reward=1.0,
+        initial_policy_version=0,
+        messages_and_choices=[
+            {"role": "user", "content": "long"},
+            {"role": "assistant", "content": "answer"},
+        ],
+    )
+    short_result = _make_tokenized_result(short_trajectory, [1, 2, 3, 4])
+    long_result = _make_tokenized_result(long_trajectory, list(range(10)))
+
+    with (
+        patch(
+            "art.local.backend.AutoTokenizer.from_pretrained",
+            return_value=short_result._tokenizer,
+        ),
+        patch(
+            "art.local.backend.AutoImageProcessor.from_pretrained", return_value=None
+        ),
+        patch(
+            "art.local.backend.tokenize_trajectory_groups",
+            return_value=iter([short_result, long_result]),
+        ),
+        pytest.warns(UserWarning, match="Dropping 1 tokenized results"),
+    ):
+        packed_tensors = backend._get_packed_tensors(
+            model,
+            [_make_group([0.0, 1.0])],
+            advantage_balance=0.0,
+            allow_training_without_logprobs=False,
+            scale_rewards=True,
+            plot_tensors=False,
+            packed_sequence_length=4,
+            logprob_calculation_chunk_size=2,
+        )
+
+    assert packed_tensors is not None
+    assert packed_tensors["tokens"].shape == (1, 4)
+
+
+@pytest.mark.asyncio
+async def test_megatron_backend_train_requires_packed_sequence_length(
+    tmp_path: Path,
+) -> None:
+    model = TrainableModel(
+        name="megatron-backend-packed-sequence-length",
+        project="pipeline-tests",
+        base_model="test-model",
+        base_path=str(tmp_path),
+    )
+    backend = MegatronBackend(path=str(tmp_path))
+
+    with patch.object(model, "_get_wandb_run", return_value=None):
+        with pytest.raises(
+            ValueError, match="MegatronBackend\\.train requires packed_sequence_length"
+        ):
+            await backend.train(
+                model,
+                [_make_group([1.0])],
+                save_checkpoint=False,
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pipeline_trainer_local_backend.py
+++ b/tests/unit/test_pipeline_trainer_local_backend.py
@@ -5,12 +5,14 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import torch
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from art import TrainableModel, Trajectory, TrajectoryGroup
 from art.dev.model import InternalModelConfig
 from art.local import LocalBackend
 from art.megatron import MegatronBackend
+from art.megatron.train import load_adapter_into_model
 from art.pipeline_trainer.trainer import PipelineTrainer
 from art.preprocessing.tokenize import TokenizedResult
 from art.utils.output_dirs import get_model_dir
@@ -303,6 +305,32 @@ async def test_megatron_backend_train_requires_packed_sequence_length(
                 [_make_group([1.0])],
                 save_checkpoint=False,
             )
+
+
+def test_load_adapter_into_model_reloads_optimizer_when_provided() -> None:
+    class FakeModule(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.loaded_adapter: dict[str, torch.Tensor] | None = None
+
+        def load_lora(self, adapter_model: dict[str, torch.Tensor]) -> None:
+            self.loaded_adapter = adapter_model
+
+    class FakeOptimizer:
+        def __init__(self) -> None:
+            self.reload_calls = 0
+
+        def reload_model_params(self) -> None:
+            self.reload_calls += 1
+
+    module = FakeModule()
+    optimizer = FakeOptimizer()
+    adapter_model = {"weight": torch.tensor([1.0])}
+
+    load_adapter_into_model([module], adapter_model, optimizer)
+
+    assert module.loaded_adapter is adapter_model
+    assert optimizer.reload_calls == 1
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -900,6 +900,7 @@ dependencies = [
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/74/ec/636ab2aa7ad9e6bf6e297240ac2d44dba63cc6611e2d5038db318436d449/boto3-1.42.74.tar.gz", hash = "sha256:dbacd808cf2a3dadbf35f3dbd8de97b94dc9f78b1ebd439f38f552e0f9753577", size = 112739, upload-time = "2026-03-23T19:34:09.815Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/16/a264b4da2af99f4a12609b93fea941cce5ec41da14b33ed3fef77a910f0c/boto3-1.42.74-py3-none-any.whl", hash = "sha256:4bf89c044d618fe4435af854ab820f09dd43569c0df15d7beb0398f50b9aa970", size = 140557, upload-time = "2026-03-23T19:34:07.084Z" },
 ]
@@ -1718,6 +1719,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b6
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
 ]
+
+[[package]]
+name = "deep-ep"
+version = "1.2.1+9af0e0d"
+source = { git = "https://github.com/deepseek-ai/DeepEP.git?rev=v1.2.1#9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee" }
 
 [[package]]
 name = "defusedxml"
@@ -4018,7 +4024,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.82.6"
+version = "1.82.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -4034,9 +4040,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/75/1c537aa458426a9127a92bc2273787b2f987f4e5044e21f01f2eed5244fd/litellm-1.82.6.tar.gz", hash = "sha256:2aa1c2da21fe940c33613aa447119674a3ad4d2ad5eb064e4d5ce5ee42420136", size = 17414147, upload-time = "2026-03-22T06:36:00.452Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/00/49bb5c28e0dea0f5086229a2a08d5fdc6c8dc0d8e2acb2a2d1f7dd9f4b70/litellm-1.82.0.tar.gz", hash = "sha256:d388f52447daccbcaafa19a3e68d17b75f1374b5bf2cde680d65e1cd86e50d22", size = 16800355, upload-time = "2026-03-01T02:35:30.363Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/6c/5327667e6dbe9e98cbfbd4261c8e91386a52e38f41419575854248bbab6a/litellm-1.82.6-py3-none-any.whl", hash = "sha256:164a3ef3e19f309e3cabc199bef3d2045212712fefdfa25fc7f75884a5b5b205", size = 15591595, upload-time = "2026-03-22T06:35:56.795Z" },
+    { url = "https://files.pythonhosted.org/packages/28/89/eb28bfcf97d6b045c400e72eb047c381594467048c237dbb6c227764084c/litellm-1.82.0-py3-none-any.whl", hash = "sha256:5496b5d4532cccdc7a095c21cbac4042f7662021c57bc1d17be4e39838929e80", size = 14911978, upload-time = "2026-03-01T02:35:26.844Z" },
 ]
 
 [[package]]
@@ -5519,6 +5525,7 @@ langgraph = [
 ]
 megatron = [
     { name = "apex" },
+    { name = "deep-ep", marker = "sys_platform == 'linux'" },
     { name = "megatron-bridge" },
     { name = "megatron-core" },
     { name = "ml-dtypes", marker = "python_full_version < '3.13'" },
@@ -5573,6 +5580,7 @@ requires-dist = [
     { name = "awscli", marker = "extra == 'backend'", specifier = ">=1.38.1" },
     { name = "bitsandbytes", marker = "extra == 'backend'", specifier = ">=0.45.2" },
     { name = "datrie", marker = "extra == 'tinker'", specifier = ">=0.8.3" },
+    { name = "deep-ep", marker = "sys_platform == 'linux' and extra == 'megatron'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=v1.2.1" },
     { name = "duckdb", marker = "extra == 'backend'", specifier = ">=1.0.0" },
     { name = "fastapi", marker = "extra == 'tinker'", specifier = ">=0.128.0" },
     { name = "gql", marker = "extra == 'backend'", specifier = "<4" },


### PR DESCRIPTION
Summary: 1.15x faster Megatron training and it actually trains now.

### DeepEP
DeepEP allows for faster expert parallel (EP) comm. EP comm and the pre/post-processing work surrounding it take roughly as much time as the actual expert MLP computation (on Qwen 3 30B A3B at least) so improvements to this are important. DeepEP gives us a ~1.05x speedup. The gap between DeepEP and Megatron may grow in multi-node settings.

### `torch.compile`
We add `torch.compile` to the model layers and disable some regions that are not compatible. This gives a ~1.10x speedup on top of DeepEP. I did not test max-autotune or cuda graphs here, just basic compilation.

### Megatron Training
We noticed that megatron failed to train in the simple yes-no-maybe example. This was caused by the parameter offload. Megatron expects param data tensors to stay constant and offload/reload creating new tensors caused Megatron to lose track of them for updates. We shift to Megatron's offload API to do this properly. 

We also remove the optimizer offload, since the optimizer is loaded from disk at the start of each job anyways.

### Megatron Provider Options
We expose env variables for controlling Megatron parallelism. We will refactor the configuration system at some point so that you can naturally modify these, but this is the minimal control plane.