### PR TITLE
Fix flex attention compilation failures in Megatron training                                                                 

### DIFF
--- a/src/art/megatron/flex_attention.py
+++ b/src/art/megatron/flex_attention.py
@@ -34,6 +34,14 @@ class FlexAttentionWrapper(torch.nn.Module):
         "coordinate_descent_tuning": True,
         "triton.cudagraphs": False,
     }
+    # Skip Inductor's flex_decoding specialization: it has triggered both
+    # shared-memory OOMs (triton_flex_decoding) and symbolic-shape assertion
+    # failures (create_flex_decoding_kernel). The regular flex_attention
+    # kernel autotunes against the actual hardware smem budget, so this
+    # stays GPU-agnostic.
+    _kernel_options = {
+        "FORCE_USE_FLEX_ATTENTION": True,
+    }
     _compiled_flex_attention: ClassVar = torch.compile(
         flex_attention,
         options=_compile_options,
@@ -59,6 +67,7 @@ class FlexAttentionWrapper(torch.nn.Module):
                 block_mask=block_mask,
                 scale=scale,
                 enable_gqa=enable_gqa,
+                kernel_options=FlexAttentionWrapper._kernel_options,
             ),
         )
 


### PR DESCRIPTION
**Issue:**
Megatron jobs were crashing during compilation of flex_attention, with two different errors depending on the setup:      
   
  1. Shared-memory OOM during Triton autotune:                                                                                 
  No valid triton configs. OutOfMemoryError: out of resource: triton_flex_decoding
  Required: 312320  Hardware limit: 232448                                                                                     
  2. Symbolic-shape assertion inside Inductor's lowering:         
  File ".../torch/_inductor/kernel/flex/flex_decoding.py", line 286, in create_flex_decoding_kernel                            
      V.graph.sizevars.check_leq(...)                                                                                          
  AssertionError                                                                                                               
                                                                                                                               
  **Root cause**                                                                                                                   
   
  Both errors come from the same wrong kernel. Inductor's flex_attention lowering has two Triton templates:                    
                                                                  
  - triton_flex_attention — the training kernel (Q and KV similar length).                                                     
  - triton_flex_decoding — the inference-decode kernel (short Q, long KV cache), with very large BLOCK_M configs and extra decode-specific symbolic-shape assertions.                                                                                   
                                                                  
  With packed training sequences + shared-prefix block masks, query lengths are small and symbolic (s29, s64 in the logs), so Inductor's dispatch heuristic decided the shape "looks like decoding" and silently routed the call into create_flex_decoding_kernel. That kernel:                                                                                    
                                                                  
  - autotunes over configs up to BLOCK_M=1024, which blows past SM shared-memory limits on any consumer/H100 GPU, and          
  - has invariants it can't discharge against our symbolic packed-sequence shapes, which trip check_leq during lowering.
                                                                                                                               
  So we were never actually running the training kernel — Inductor was specializing us into the wrong one.                     
                                                                                                                               
  **Fix**                                                                                                                          
                                                                  
  Pass kernel_options={"FORCE_USE_FLEX_ATTENTION": True} to the compiled call in FlexAttentionWrapper. This disables the flex_decoding dispatch so all calls go through the regular training kernel.