### PR TITLE
Fix megatron grad norm explosion

### DIFF
--- a/src/art/megatron/flex_attention.py
+++ b/src/art/megatron/flex_attention.py
@@ -29,9 +29,8 @@ class FlexAttentionWrapper(torch.nn.Module):
     """Compiled `flex_attention` wrapper with Torchtitan-style inductor options."""
 
     # Torchtitan inductor options for compiling flex attention.
-    _compile_options = {
+    _compile_options: dict[str, Any] = {
         "max_autotune": True,
-        "coordinate_descent_tuning": True,
         "triton.cudagraphs": False,
     }
     # Skip Inductor's flex_decoding specialization: it has triggered both
@@ -72,14 +71,11 @@ class FlexAttentionWrapper(torch.nn.Module):
         )
 
 
-_compiled_create_block_mask = torch.compile(create_block_mask)
-
-
 def create_shared_prefix_attention_state(
     group_ids: Tensor,
     parent_ids: Tensor,
 ) -> SharedPrefixAttentionState:
-    """Build a compiled block mask for ART shared-prefix packing.
+    """Build a block mask for ART shared-prefix packing.
 
     Initialized on the device of the group_ids tensor.
 
@@ -102,7 +98,15 @@ def create_shared_prefix_attention_state(
         parent_prefix = parent_ids[batch_idx, query_idx] == group_ids[batch_idx, kv_idx]
         return (query_idx >= kv_idx) & (same_group | parent_prefix)
 
-    block_mask = _compiled_create_block_mask(
+    # NOTE: build the BlockMask eagerly, NOT through torch.compile.
+    # `_shared_prefix_mask` is a fresh closure on every call that captures
+    # different `group_ids` / `parent_ids` tensors from the enclosing scope.
+    # torch.compile's cache can reuse a compiled BlockMask built against stale
+    # closure captures, producing a mask whose block structure mismatches the
+    # forward — the compiled flex_attention backward then computes gradients
+    # over the wrong regions and produces astronomical-but-finite grads on a
+    # subset of micro-batches. Keep this call eager.
+    block_mask = create_block_mask(
         _shared_prefix_mask,
         group_ids.shape[0],
         None,

--- a/src/art/megatron/flex_attention.py
+++ b/src/art/megatron/flex_attention.py
@@ -36,6 +36,7 @@ class FlexAttentionWrapper(torch.nn.Module):
     # Torchtitan inductor options for compiling flex attention.
     _compile_options: ClassVar[CompileOptions] = {
         "max_autotune": True,
+        "coordinate_descent_tuning": True,
         "triton.cudagraphs": False,
     }
     # Skip Inductor's flex_decoding specialization: it has triggered both

--- a/src/art/megatron/flex_attention.py
+++ b/src/art/megatron/flex_attention.py
@@ -13,6 +13,7 @@ import torch
 from torch import Tensor
 from torch.nn.attention.flex_attention import (
     BlockMask,
+    FlexKernelOptions,
     create_block_mask,
     flex_attention,
 )
@@ -38,7 +39,7 @@ class FlexAttentionWrapper(torch.nn.Module):
     # failures (create_flex_decoding_kernel). The regular flex_attention
     # kernel autotunes against the actual hardware smem budget, so this
     # stays GPU-agnostic.
-    _kernel_options = {
+    _kernel_options: FlexKernelOptions = {
         "FORCE_USE_FLEX_ATTENTION": True,
     }
     _compiled_flex_attention: ClassVar = torch.compile(

--- a/src/art/megatron/flex_attention.py
+++ b/src/art/megatron/flex_attention.py
@@ -72,6 +72,11 @@ class FlexAttentionWrapper(torch.nn.Module):
         )
 
 
+# Sequence-length churn can break the Inductor backend here. Keep this
+# on aot_eager instead.
+_compiled_create_block_mask = torch.compile(create_block_mask, backend="aot_eager")
+
+
 def create_shared_prefix_attention_state(
     group_ids: Tensor,
     parent_ids: Tensor,
@@ -99,15 +104,7 @@ def create_shared_prefix_attention_state(
         parent_prefix = parent_ids[batch_idx, query_idx] == group_ids[batch_idx, kv_idx]
         return (query_idx >= kv_idx) & (same_group | parent_prefix)
 
-    # NOTE: build the BlockMask eagerly, NOT through torch.compile.
-    # `_shared_prefix_mask` is a fresh closure on every call that captures
-    # different `group_ids` / `parent_ids` tensors from the enclosing scope.
-    # torch.compile's cache can reuse a compiled BlockMask built against stale
-    # closure captures, producing a mask whose block structure mismatches the
-    # forward — the compiled flex_attention backward then computes gradients
-    # over the wrong regions and produces astronomical-but-finite grads on a
-    # subset of micro-batches. Keep this call eager.
-    block_mask = create_block_mask(
+    block_mask = _compiled_create_block_mask(
         _shared_prefix_mask,
         group_ids.shape[0],
         None,


### PR DESCRIPTION


> TL DR;
src/art/megatron/flex_attention.py wrapped create_block_mask in torch.compile, and passed it a fresh Python closure (_shared_prefix_mask) on every call that captured different group_ids/parent_ids tensors. Dynamo's cache doesn't properly invalidate on closure-cell changes, so it silently reused a compiled BlockMask built against stale captures — giving back a  mask whose block-sparsity structure didn't match the actual Q/K of the current batch.


**Symptoms:**
Grad norm metric is `Infinite` during training on some steps.

**Root-cause analysis**                                                                                                          
                                                                  
Every bad step, the top-5 worst grads are layer 0 and layer 1 self-attention LoRA B_T parameters (k_proj_lora.B_T, v_proj_lora.B_T, q_proj_lora.B_T, linear_proj.lora.B_T). Nothing else ever appears at the top of bad-step scans. This is the signature of a problem specific to attention backward at the earliest layers.                             
                                                                                                                               
Step 0 is healthy. Worst grad = 536 (MoE linear_fc2.lora.A_T). Normal backward distribution.                                 
                                                                                                                               
Step 1, micro 0 is healthy. Worst = 67 (layer-12 q_proj_lora.B_T). Normal.                                                   
                                                                                                                               
Step 1, micro 1 → the worst parameter suddenly becomes `layers.0.self_attention.linear_qkv.k_proj_lora.B_T with max_abs = 6.655e+30`. Layer 0 k_proj_lora.B_T **went from < 67 to 6.655e30 in a single backward pass — a ~28 order-of-magnitude jump**, triggered purely by a different input micro-batch (same model state as the previous micro).    

**The bug**                                                                                                                      
                                                                                                                               
`src/art/megatron/flex_attention.py` had:                                                                                      
                                                                                                                               
`  _compiled_create_block_mask = torch.compile(create_block_mask)
`                                                                                                                               

Result: astronomical-but-finite gradients.

**The fix**                                                         
                                                                                                                               
  One-liner: `_compiled_create_block_mask = torch.compile(create_block_mask, backend="aot_eager")`


The block-mask construction is a one-time cost per step and doesn't sit on the hot kernel path, so eager is essentially free.