### PR TITLE
fix: resolve ruler function/module name collision in art.rewards (#339)

### DIFF
--- a/src/art/rewards/__init__.py
+++ b/src/art/rewards/__init__.py
@@ -1,3 +1,5 @@
-from .ruler import ruler, ruler_score_group
+from . import ruler as _ruler  # noqa: F811 — keep module accessible for DEFAULT_RUBRIC, Response, etc.
+ruler = _ruler.ruler
+ruler_score_group = _ruler.ruler_score_group
 
 __all__ = ["ruler", "ruler_score_group"]


### PR DESCRIPTION
### Problem

The import `from .ruler import ruler` in `art.rewards.__init__` shadowed the `art.rewards.ruler` module name with the `ruler()` function, making the module-level constants (`DEFAULT_RUBRIC`, `Response`, `TrajectoryScore`, etc.) inaccessible via `import art.rewards.ruler` or `from art.rewards import ruler as art_ruler`.

Attempting to access `DEFAULT_RUBRIC` through the module raised:
```
AttributeError: function object has no attribute DEFAULT_RUBRIC
```

### Fix

Changed the import pattern from:
```python
from .ruler import ruler, ruler_score_group
```
to:
```python
from . import ruler as _ruler
ruler = _ruler.ruler
ruler_score_group = _ruler.ruler_score_group
```

This keeps both the module accessible (via `_ruler` internals) and the existing public API (`art.rewards.ruler()`, `art.rewards.ruler_score_group()`) intact — no breaking changes.

Fixes #339