### PR TITLE
Fix LocalBackend LoRA registry sync

### DIFF
--- a/src/art/megatron/service.py
+++ b/src/art/megatron/service.py
@@ -31,7 +31,7 @@ from ..utils.convert_moe_lora import convert_checkpoint_if_needed
 from ..utils.get_model_step import get_step_from_dir
 from ..utils.network import find_free_tcp_port
 from ..utils.output_dirs import get_step_checkpoint_dir
-from ..vllm import get_llm, openai_server_task, run_on_workers
+from ..vllm import get_llm, openai_server_task, register_lora_request, run_on_workers
 from .client import create_megatron_job_paths, stream_megatron_job, write_megatron_job
 from .jobs import (
     MegatronMergedTrainJob,
@@ -478,15 +478,15 @@ class MegatronService:
     async def _add_lora_aliases(
         self, llm: AsyncLLM, step: int, checkpoint_dir: str
     ) -> None:
-        added = await llm.add_lora(
-            LoRARequest(
-                lora_name=f"{self.model_name}@{step}",
-                lora_int_id=self._next_lora_id(),
-                lora_path=checkpoint_dir,
-            )
+        lora_request = LoRARequest(
+            lora_name=f"{self.model_name}@{step}",
+            lora_int_id=self._next_lora_id(),
+            lora_path=checkpoint_dir,
         )
+        added = await llm.add_lora(lora_request)
         if not added:
             raise RuntimeError(f"Failed to add LoRA adapter for step {step}")
+        register_lora_request(lora_request)
         self._latest_step = step
 
     async def register_lora_for_step(self, step: int, checkpoint_dir: str) -> None:

--- a/src/art/unsloth/service.py
+++ b/src/art/unsloth/service.py
@@ -26,7 +26,13 @@ from ..utils.convert_moe_lora import convert_checkpoint_if_needed
 from ..utils.get_model_step import get_step_from_dir
 from ..utils.network import find_free_tcp_port
 from ..utils.output_dirs import get_step_checkpoint_dir
-from ..vllm import get_llm, get_worker, openai_server_task, run_on_workers
+from ..vllm import (
+    get_llm,
+    get_worker,
+    openai_server_task,
+    register_lora_request,
+    run_on_workers,
+)
 from .train import (
     UnslothTrainContext,
     create_unsloth_train_context,
@@ -526,6 +532,22 @@ class UnslothService:
             return False
         return self._is_sleeping
 
+    async def _add_lora_adapter(
+        self, llm: AsyncLLM, step: int, checkpoint_dir: str
+    ) -> None:
+        lora_request = LoRARequest(
+            lora_name=f"{self.model_name}@{step}",
+            lora_int_id=self._next_lora_id(),
+            lora_path=checkpoint_dir,
+        )
+        added = await llm.add_lora(lora_request)
+        if not added:
+            raise RuntimeError(
+                f"Failed to add LoRA adapter for step {step} at {checkpoint_dir}"
+            )
+        register_lora_request(lora_request)
+        self._latest_step = step
+
     async def register_lora_for_step(self, step: int, checkpoint_dir: str) -> None:
         """Register a LoRA adapter for a specific checkpoint step.
         This is called when training is skipped but the checkpoint is renamed.
@@ -544,18 +566,7 @@ class UnslothService:
 
         llm = await self.llm
         await llm.pause_generation()
-        added = await llm.add_lora(
-            LoRARequest(
-                lora_name=f"{self.model_name}@{step}",
-                lora_int_id=self._next_lora_id(),
-                lora_path=checkpoint_dir,
-            )
-        )
-        if not added:
-            raise RuntimeError(
-                f"Failed to add LoRA adapter for step {step} at {checkpoint_dir}"
-            )
-        self._latest_step = step
+        await self._add_lora_adapter(llm, step, checkpoint_dir)
         await llm.resume_generation()
 
     async def train(
@@ -685,18 +696,7 @@ class UnslothService:
 
         # Add the new LoRA adapter
         # We keep old LoRAs loaded - vLLM will page them out as needed
-        added = await llm.add_lora(
-            LoRARequest(
-                lora_name=f"{self.model_name}@{new_step}",
-                lora_int_id=self._next_lora_id(),
-                lora_path=checkpoint_dir,
-            )
-        )
-        if not added:
-            raise RuntimeError(
-                f"Failed to add LoRA adapter for step {new_step} at {checkpoint_dir}"
-            )
-        self._latest_step = new_step
+        await self._add_lora_adapter(llm, new_step, checkpoint_dir)
 
         # Resume generation after LoRA add is complete
         await llm.resume_generation()
@@ -787,18 +787,7 @@ class UnslothService:
 
         # Add the new LoRA adapter
         new_step = int(os.path.basename(checkpoint_dir))
-        added = await llm.add_lora(
-            LoRARequest(
-                lora_name=f"{self.model_name}@{new_step}",
-                lora_int_id=self._next_lora_id(),
-                lora_path=checkpoint_dir,
-            )
-        )
-        if not added:
-            raise RuntimeError(
-                f"Failed to add LoRA adapter for step {new_step} at {checkpoint_dir}"
-            )
-        self._latest_step = new_step
+        await self._add_lora_adapter(llm, new_step, checkpoint_dir)
 
         # Resume generation after LoRA swap is complete
         await llm.resume_generation()

--- a/src/art/vllm/__init__.py
+++ b/src/art/vllm/__init__.py
@@ -18,6 +18,7 @@ from .patches import (
 from .server import (
     get_uvicorn_logging_config,
     openai_server_task,
+    register_lora_request,
     set_vllm_log_file,
 )
 
@@ -25,6 +26,7 @@ __all__ = [
     # Server
     "openai_server_task",
     "get_uvicorn_logging_config",
+    "register_lora_request",
     "set_vllm_log_file",
     # Engine
     "get_llm",

--- a/src/art/vllm/server.py
+++ b/src/art/vllm/server.py
@@ -19,6 +19,11 @@ from ..dev.openai_server import OpenAIServerConfig
 _openai_serving_models: Any | None = None
 
 
+def register_lora_request(lora_request: Any) -> None:
+    if _openai_serving_models is not None:
+        _openai_serving_models.lora_requests[lora_request.lora_name] = lora_request
+
+
 async def openai_server_task(
     engine: EngineClient,
     config: OpenAIServerConfig,
@@ -80,8 +85,8 @@ async def openai_server_task(
                 load_inplace=getattr(lora_request, "load_inplace", False),
             )
         added = await add_lora(lora_request)
-        if added and _openai_serving_models is not None:
-            _openai_serving_models.lora_requests[lora_request.lora_name] = lora_request
+        if added:
+            register_lora_request(lora_request)
         return added
 
     engine.add_lora = _add_lora  # ty:ignore[invalid-assignment]

--- a/tests/unit/test_vllm_patches_contract.py
+++ b/tests/unit/test_vllm_patches_contract.py
@@ -1,6 +1,7 @@
 """Unit tests for ART's vLLM patch contract."""
 
 import importlib
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -86,3 +87,17 @@ def test_patch_transformers_v5_compat_normalizes_rope_ignore_keys() -> None:
     )
 
     assert dummy.ignore_keys == {"mrope_section", "partial_rotary_factor"}
+
+
+def test_register_lora_request_updates_openai_serving_models() -> None:
+    server = cast(Any, importlib.import_module("art.vllm.server"))
+    original_serving_models = server._openai_serving_models
+    serving_models = SimpleNamespace(lora_requests={})
+    request = SimpleNamespace(lora_name="test-model@1")
+
+    try:
+        server._openai_serving_models = serving_models
+        server.register_lora_request(request)
+        assert serving_models.lora_requests == {"test-model@1": request}
+    finally:
+        server._openai_serving_models = original_serving_models


### PR DESCRIPTION
## Summary
Closes #661.

Make LoRA registration update the vLLM OpenAI serving-model registry explicitly after successful shared-mode `add_lora` calls. This keeps `model.get_inference_name()` targets visible to the OpenAI-compatible layer after LocalBackend checkpoint advances.

## Changes
- Added a shared `register_lora_request()` helper for vLLM OpenAI serving-model state.
- Routed Unsloth shared RL, SFT, and skipped-step LoRA registration through one helper that registers the same `LoRARequest` with vLLM and the OpenAI serving registry.
- Applied the same explicit registry update to Megatron shared LoRA aliases.
- Added a unit contract test for the serving-model registry helper.

## Test plan
- `uv run prek run --all-files`
- SkyPilot H200 cluster: `.venv/bin/python -m pytest --tb=short tests/unit/test_vllm_patches_contract.py` (4 passed)
- SkyPilot H200 cluster: `.venv/bin/python -m pytest --tb=short tests/unit/test_multi_checkpoint_inference.py::TestUnslothServiceMaxLoras` (2 passed)
- SkyPilot H200 cluster: `ART_TEST_GPU_MEMORY_UTILIZATION=0.2 ART_TEST_MIN_FREE_GPU_GIB=5 .venv/bin/python -m pytest -s --tb=short tests/integration/test_vllm_contract.py` (1 passed)

Note: local vLLM tests skip on macOS because `vllm` is not installed. The SkyPilot setup command reached a known optional Megatron `deep-ep` build failure due missing `infiniband/mlx5dv.h`, but the backend/vLLM environment was installed enough to run the focused vLLM tests directly from `.venv`.
