### PR TITLE
Update torchao for Torch 2.10 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ backend = [
     "unsloth==2026.3.3",
     "unsloth-zoo==2026.3.1",
     "torch==2.10.0",
-    "torchao==0.15.0",
+    "torchao==0.16.0",
     "accelerate==1.7.0",
     "awscli>=1.38.1",
     "setuptools>=78.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -5844,7 +5844,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'backend'", specifier = "==2.10.0" },
     { name = "torch", marker = "extra == 'megatron'", specifier = "==2.10.0" },
     { name = "torch", marker = "extra == 'tinker'", specifier = "==2.10.0" },
-    { name = "torchao", marker = "extra == 'backend'", specifier = "==0.15.0" },
+    { name = "torchao", marker = "extra == 'backend'", specifier = "==0.16.0" },
     { name = "transformer-engine", marker = "extra == 'megatron'", specifier = "==2.11.0" },
     { name = "transformer-engine-cu12", marker = "extra == 'megatron'", specifier = "==2.11.0" },
     { name = "transformer-engine-torch", marker = "extra == 'megatron'", git = "https://github.com/NVIDIA/TransformerEngine.git?subdirectory=transformer_engine%2Fpytorch&rev=v2.11" },
@@ -9418,11 +9418,11 @@ wheels = [
 
 [[package]]
 name = "torchao"
-version = "0.15.0"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/2d/472b9362dceae05a4599e2b94f86e69a29c0e20964a6af84f34f6ead5938/torchao-0.15.0-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1cbe813201314ba6329a650a76944502f3e8ec4b1b44523f3f48676810d8d1f6", size = 7163930, upload-time = "2025-12-18T23:14:41.876Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/3b/6b9d5618720f63dbc2e2509cd6b57aae9c0d61b738d1d2172f4d5d9efaab/torchao-0.15.0-py3-none-any.whl", hash = "sha256:3f3812676048ef8a2a0e9d492d12d8971ba7a7ebb16f54aa56f690414e130d2c", size = 1080679, upload-time = "2025-12-18T23:14:43.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/7f/0acda8a429ac9cfabd142d30af624d7958bf828c438be5a54ca87bbe16d7/torchao-0.16.0-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d6293a0c57c9dd505efb025a7189459d154965fbed000efd638cf299f9362dd", size = 3160415, upload-time = "2026-02-10T22:12:12.32Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3d/0c5a5833a135a045510e06c06b3d4cf316b06d59415bc21e0b021a000cc8/torchao-0.16.0-py3-none-any.whl", hash = "sha256:d0a8d773351fd17b95fee81dfbcbf98577b567dcdbec47d221b0ee258432101d", size = 1164150, upload-time = "2026-02-10T22:12:15.28Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump the backend `torchao` pin from `0.15.0` to `0.16.0`.
- Refresh `uv.lock` so Torch 2.10 environments use the compatible torchao wheel.

## Test plan
- `uv sync --all-extras --group dev --frozen`
- `uv run --no-sync prek run --all-files`
- `uv run --no-sync prek run pytest`
- Package install smoke: `uv build --wheel`, `uv add "openpipe-art[backend] @ file://..."`, `uv sync`


Made with [Cursor](https://cursor.com)