### PR TITLE
Disable result packing for Unsloth training

### DIFF
--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -109,6 +109,7 @@ class LocalBackend(Backend):
         self._image_processors: dict[str, BaseImageProcessor | None] = {}
         self._requires_explicit_packed_sequence_length = False
         self._packed_sequence_length_requires_chunk_alignment = True
+        self._supports_result_packing = False
 
     def supports_automatic_train_step_metrics(self) -> bool:
         return True
@@ -413,6 +414,7 @@ class LocalBackend(Backend):
             pad_token_id=tokenizer.eos_token_id,
             truncate_long_results=False,
             advantage_balance=advantage_balance,
+            pack_results=self._supports_result_packing,
         )
         if (
             not allow_training_without_logprobs

--- a/src/art/megatron/backend.py
+++ b/src/art/megatron/backend.py
@@ -18,6 +18,7 @@ class MegatronBackend(LocalBackend):
         super().__init__(in_process=in_process, path=path)
         self._requires_explicit_packed_sequence_length = True
         self._packed_sequence_length_requires_chunk_alignment = False
+        self._supports_result_packing = True
 
     async def _get_service(self, model: TrainableModel) -> ModelService:
         from ..dev.get_model_config import get_model_config

--- a/src/art/preprocessing/pack.py
+++ b/src/art/preprocessing/pack.py
@@ -38,6 +38,7 @@ def packed_tensors_from_tokenized_results(
     truncate_long_results: bool = True,
     advantage_balance: float = 0.0,
     verbosity: Verbosity = 1,
+    pack_results: bool = True,
 ) -> PackedTensors:
     # TODO: This function could potentially be optimized with vectorized operations
     token_ids: list[list[int]] = [[]]
@@ -61,8 +62,9 @@ def packed_tensors_from_tokenized_results(
             if verbosity > 1:
                 print("Result has no unique completion tokens, skipping")
             continue
-        if (
-            len(token_ids[-1])
+        if token_ids[-1] and (
+            not pack_results
+            or len(token_ids[-1])
             + (
                 len(result_without_prompt.token_ids)
                 if result.prompt_id in group_ids[-1]


### PR DESCRIPTION
## Summary

Disable multi-result packing for the local Unsloth backend while preserving the existing packed/shared-prefix behavior for Megatron.

## Root cause

The ART packer can place multiple completions that share a prompt into one packed row. That requires custom shared-prefix attention semantics so later completions do not attend to earlier completions.

The current Unsloth training path passes the dense shared-prefix mask as `causal_mask`, but Unsloth replaces it with its own lower-triangular causal mask before self-attention. That makes shared-prefix packed rows semantically incorrect for Unsloth.

GDN layers are also broken on shared-prefix packed inputs without custom operations. On a shared-prefix packed row, a standard recurrent/linear GDN layer advances state through completion A before completion B. Without a custom packed GDN operator that materializes prefix state and fans it out to each completion, completion B receives recurrent/conv state from completion A. The Megatron path has custom packed GDN handling; Unsloth/Transformers does not.

## Changes

- Add `pack_results` to `packed_tensors_from_tokenized_results`, defaulting to the existing behavior.
- Set `LocalBackend._supports_result_packing = False`, so Unsloth/local training emits one trajectory per packed row.
- Set `MegatronBackend._supports_result_packing = True`, preserving the Megatron packed/shared-prefix path.

## Validation

- `uv run --extra backend python scripts/repro_unsloth_result_packing.py` (local proof only, not committed)
  - old target-logit `mean_abs_pct`: `17.378351`
  - fixed target-logit `mean_abs_pct`: `0.000017`
- `uv run prek run --all-files`
- commit hook: ruff, ruff format, ty, uv.lock sync check
