### PR TITLE
Cancel monitor and server tasks on backend shutdown

### DIFF
--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -105,6 +105,7 @@ class LocalBackend(Backend):
 
         # Other initialization
         self._services: dict[str, ModelService] = {}
+        self._monitor_tasks: dict[str, asyncio.Task[None]] = {}
         self._tokenizers: dict[str, PreTrainedTokenizerBase] = {}
         self._image_processors: dict[str, BaseImageProcessor | None] = {}
         self._requires_explicit_packed_sequence_length = False
@@ -188,7 +189,16 @@ class LocalBackend(Backend):
         """
         If running vLLM in a separate process, this will kill that process and close the communication threads.
         """
-        for service in self._services.values():
+        tasks = list(self._monitor_tasks.values())
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._monitor_tasks.clear()
+        for service in list(self._services.values()):
             aclose = getattr(service, "aclose", None)
             if aclose is None:
                 close = getattr(service, "close", None)
@@ -199,7 +209,10 @@ class LocalBackend(Backend):
             close_proxy(service)
 
     def _close(self) -> None:
-        for service in self._services.values():
+        for task in list(self._monitor_tasks.values()):
+            task.cancel()
+        self._monitor_tasks.clear()
+        for service in list(self._services.values()):
             close = getattr(service, "close", None)
             if close is not None:
                 close()
@@ -486,11 +499,14 @@ class LocalBackend(Backend):
         api_key = server_args.get("api_key") or "default"
 
         def done_callback(_: asyncio.Task[None]) -> None:
+            self._monitor_tasks.pop(model.name, None)
             close_proxy(self._services.pop(model.name))
 
-        asyncio.create_task(
+        task = asyncio.create_task(
             self._monitor_openai_server(model, base_url, api_key)
-        ).add_done_callback(done_callback)
+        )
+        task.add_done_callback(done_callback)
+        self._monitor_tasks[model.name] = task
 
         return base_url, api_key
 

--- a/src/art/unsloth/service.py
+++ b/src/art/unsloth/service.py
@@ -115,6 +115,9 @@ class UnslothService:
     _vllm_host: str = "127.0.0.1"
     _vllm_port: int = 0
     _weight_transfer_group: Any = field(default=None, init=False, repr=False)
+    _server_task: asyncio.Task[None] | None = field(
+        default=None, init=False, repr=False
+    )
 
     @property
     def is_dedicated(self) -> bool:
@@ -139,6 +142,13 @@ class UnslothService:
         state = self.__dict__.get("_state")
         if isinstance(state, UnslothTrainContext):
             await state.stop_background_training()
+        if self._server_task is not None:
+            self._server_task.cancel()
+            try:
+                await self._server_task
+            except asyncio.CancelledError:
+                pass
+            self._server_task = None
         self.close()
 
     # =========================================================================
@@ -458,8 +468,11 @@ class UnslothService:
         )
 
     def close(self) -> None:
-        """Terminate vLLM subprocess if running."""
+        """Terminate vLLM subprocess and cancel server task if running."""
         self._weight_transfer_group = None
+        if self._server_task is not None:
+            self._server_task.cancel()
+            self._server_task = None
         if self._vllm_process is None:
             return
         self._vllm_process.terminate()
@@ -513,7 +526,7 @@ class UnslothService:
             lora_path=lora_path,
             config=config,
         )
-        await openai_server_task(
+        self._server_task = await openai_server_task(
             engine=await self.llm,
             config=server_config,
         )

--- a/tests/unit/test_local_backend_monitor.py
+++ b/tests/unit/test_local_backend_monitor.py
@@ -88,3 +88,54 @@ async def test_monitor_openai_server_uses_health_probe_when_idle(
         "http://127.0.0.1:1234/metrics",
         "http://127.0.0.1:1234/health",
     ]
+
+
+@pytest.mark.asyncio
+async def test_close_cancels_monitor_tasks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Monitor tasks should be cancelled during close() to avoid
+    ConnectionRefusedError after vLLM shuts down."""
+    backend = LocalBackend(path=str(tmp_path))
+
+    class _FakeService:
+        aclose_called = False
+
+        async def aclose(self) -> None:
+            self.aclose_called = True
+
+        async def vllm_engine_is_sleeping(self) -> bool:
+            return False
+
+    service = _FakeService()
+    backend._services["test-model"] = service  # type: ignore[index]
+
+    async def fake_sleep(_seconds: float) -> None:
+        await asyncio.sleep(0)  # yield control
+
+    monkeypatch.setattr("art.local.backend.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr(
+        "art.local.backend.aiohttp.ClientSession",
+        lambda: _FakeSession([]),
+    )
+
+    model = TrainableModel(
+        name="test-model",
+        project="unit-tests",
+        base_model="test/model",
+        base_path=str(tmp_path),
+    )
+
+    task = asyncio.create_task(
+        backend._monitor_openai_server(model, "http://127.0.0.1:1234/v1", "default")
+    )
+    backend._monitor_tasks["test-model"] = task
+
+    # Let the monitor run one iteration
+    await asyncio.sleep(0)
+
+    await backend.close()
+
+    assert task.cancelled() or task.done()
+    assert len(backend._monitor_tasks) == 0


### PR DESCRIPTION
## Summary
- Store `_monitor_openai_server` task references in `LocalBackend` and cancel them during `close()`/`_close()`
- Store `openai_server_task` reference in `UnslothService` and cancel it during `aclose()`/`close()`
- Iterate over `list()` copies to avoid `RuntimeError` from dict mutation when done_callbacks fire during await
- Add unit test verifying `close()` cancels monitor tasks

Fixes #https://github.com/OpenPipe/ART/issues/668

## Test plan
- [ ] Existing `test_local_backend_monitor.py` test passes
- [ ] New `test_close_cancels_monitor_tasks` test passes
- [ ] Run `LocalBackend` training in shared mode inside a container — pod should exit cleanly after training completes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>