### PR TITLE
[codex] Tighten ART training type surface

### DIFF
--- a/docs/experimental/gspo.mdx
+++ b/docs/experimental/gspo.mdx
@@ -40,12 +40,12 @@ This sequence-level approach makes GSPO more robust to noise and eliminates the 
 GSPO can be configured using the `importance_sampling_level` parameter when training with ART:
 
 ```python
-model.train(
+result = await backend.train(
+    model,
     trajectory_groups,
-    _config=art.dev.TrainConfig(
-        importance_sampling_level="sequence",
-    )
+    importance_sampling_level="sequence",
 )
+await model.log(trajectory_groups, metrics=result.metrics, step=result.step, split="train")
 ```
 
 ## Technical Details

--- a/docs/features/checkpoint-deletion.mdx
+++ b/docs/features/checkpoint-deletion.mdx
@@ -72,12 +72,10 @@ for _step in range(await model.get_step(), TRAINING_STEPS):
         ),
         pbar_desc=f"gather(train:{step})",
     )
-    # trains model and automatically persists each LoRA as a W&B Artifact
+    # trains model and persists each LoRA as a W&B Artifact
     # ~120MB per step
-    await model.train(
-        train_groups,
-        config=art.TrainConfig(learning_rate=5e-5),
-    )
+    result = await backend.train(model, train_groups, learning_rate=5e-5)
+    await model.log(train_groups, metrics=result.metrics, step=result.step, split="train")
 
 # ~6GB of storage used by checkpoints
 ```
@@ -96,12 +94,10 @@ for _step in range(await model.get_step(), TRAINING_STEPS):
         ),
         pbar_desc=f"gather(train:{step})",
     )
-    # trains model and automatically persists each LoRA as a W&B Artifact
+    # trains model and persists each LoRA as a W&B Artifact
     # ~120MB per step
-    await model.train(
-        train_groups,
-        config=art.TrainConfig(learning_rate=5e-5),
-    )
+    result = await backend.train(model, train_groups, learning_rate=5e-5)
+    await model.log(train_groups, metrics=result.metrics, step=result.step, split="train")
     # clear all but the most recent and best-performing checkpoint on the train/reward metric
     await model.delete_checkpoints(best_checkpoint_metric="train/reward")
 

--- a/docs/features/mcp-rl.mdx
+++ b/docs/features/mcp-rl.mdx
@@ -75,10 +75,8 @@ scored_groups = [
     for group in groups
 ]
 
-await model.train(
-    scored_groups,
-    config=art.TrainConfig(learning_rate=1e-5),
-)
+result = await backend.train(model, scored_groups, learning_rate=1e-5)
+await model.log(scored_groups, metrics=result.metrics, step=result.step, split="train")
 ```
 
 The model learns from RULER feedback using reinforcement learning, improving its ability to select appropriate tools, use correct parameters, chain tools effectively, and handle failures gracefully.
@@ -143,10 +141,8 @@ scored_groups = [
 ]
 
 # Train the model
-await model.train(
-    scored_groups,
-    config=art.TrainConfig(learning_rate=1e-5),
-)
+result = await backend.train(model, scored_groups, learning_rate=1e-5)
+await model.log(scored_groups, metrics=result.metrics, step=result.step, split="train")
 ```
 
 ### Example Use Cases

--- a/docs/features/tracking-metrics.mdx
+++ b/docs/features/tracking-metrics.mdx
@@ -16,8 +16,9 @@ Use this page for three things:
 
 ## What ART logs automatically
 
-When you call `await model.train(...)` or `await model.log(train_groups, split="train")`,
-ART already logs most of the metrics you need to monitor a run.
+When you call `await model.log(train_groups, split="train")` with trajectory
+groups and training metrics, ART logs most of the values you need to monitor a
+run.
 
 | Type | Examples |
 | --- | --- |
@@ -102,8 +103,7 @@ A few useful patterns:
 - log `time/step_eval_s` when eval runs happen outside the backend
 - use fully qualified keys like `time/step_actor_s` or `data/step_actor_tokens` for builder-managed metrics
 
-ART flushes builder-managed metrics on the next `model.log(...)` or
-`model.train(...)` call.
+ART flushes builder-managed metrics on the next `model.log(...)` call.
 
 ## Track judge and API costs
 

--- a/docs/fundamentals/art-client.mdx
+++ b/docs/fundamentals/art-client.mdx
@@ -190,11 +190,9 @@ async def train(): # train for 50 steps
         # length of each train group: 8
 
         # send the grouped trajectories to the backend and wait until training finishes
-        await model.train(
-            train_groups,
-            config=art.TrainConfig(learning_rate=1e-5),
-        )
-        # once model.train finishes for the current step
+        result = await backend.train(model, train_groups, learning_rate=1e-5)
+        await model.log(train_groups, metrics=result.metrics, step=result.step, split="train")
+        # once backend.train finishes for the current step
         # the backend updates the LoRA weights for inference and
         # the training loop continues until 50 steps have completed
 ```

--- a/docs/fundamentals/ruler.mdx
+++ b/docs/fundamentals/ruler.mdx
@@ -275,7 +275,8 @@ groups = await art.gather_trajectory_groups(
 )
 
 # Train on the judged groups
-await model.train(groups)
+result = await backend.train(model, groups)
+await model.log(groups, metrics=result.metrics, step=result.step, split="train")
 ```
 
 The `swallow_exceptions=True` parameter is recommended in production to handle judge API failures gracefully - groups that fail to be judged are simply filtered out rather than crashing the training loop.

--- a/docs/fundamentals/sft-training.mdx
+++ b/docs/fundamentals/sft-training.mdx
@@ -222,7 +222,8 @@ async def main():
                 for scenario in scenarios
             ]
         )
-        await model.train(train_groups)
+        result = await backend.train(model, train_groups)
+        await model.log(train_groups, metrics=result.metrics, step=result.step, split="train")
 ```
 
 This works because both SFT and RL train the same LoRA adapter. After SFT completes, RL continues from the updated weights.

--- a/docs/integrations/langgraph-integration.mdx
+++ b/docs/integrations/langgraph-integration.mdx
@@ -183,11 +183,13 @@ for batch in training_iterator:
         judged_groups.append(judged_group)
 
     # Train the model
-    await model.train(
+    result = await backend.train(
+        model,
         judged_groups,
-        config=art.TrainConfig(learning_rate=training_config["learning_rate"]),
-        _config={"logprob_calculation_chunk_size": 8},
+        learning_rate=training_config["learning_rate"],
+        logprob_calculation_chunk_size=8,
     )
+    await model.log(judged_groups, metrics=result.metrics, step=result.step, split="train")
 ```
 
 ### Correctness Evaluation
@@ -491,10 +493,12 @@ async def main():
             judged_groups.append(judged_group)
 
         # Train model
-        await model.train(
+        result = await backend.train(
+            model,
             judged_groups,
-            config=art.TrainConfig(learning_rate=training_config["learning_rate"]),
+            learning_rate=training_config["learning_rate"],
         )
+        await model.log(judged_groups, metrics=result.metrics, step=result.step, split="train")
 
         print(f"Completed training step {batch.step}")
 

--- a/docs/integrations/openenv-integration.mdx
+++ b/docs/integrations/openenv-integration.mdx
@@ -95,7 +95,8 @@ async def main() -> None:
         ])
 
         # Train the model on collected trajectories
-        await model.train(groups)
+        result = await backend.train(model, groups)
+        await model.log(groups, metrics=result.metrics, step=result.step, split="train")
 
 
 if __name__ == "__main__":

--- a/src/art/backend.py
+++ b/src/art/backend.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Iterable, Protocol, TypeAl
 
 from . import dev
 from .trajectories import Trajectory, TrajectoryGroup
-from .types import TrainConfig, TrainResult, TrainSFTConfig
+from .types import TrainResult, TrainSFTConfig
 
 if TYPE_CHECKING:
     from .model import Model, TrainableModel
@@ -41,15 +41,6 @@ class Backend(Protocol):
         trajectory_groups: Iterable[TrajectoryGroup],
         **kwargs: Any,
     ) -> TrainResult: ...
-
-    def _train_model(
-        self,
-        model: AnyTrainableModel,
-        trajectory_groups: list[TrajectoryGroup],
-        config: TrainConfig,
-        dev_config: dev.TrainConfig,
-        verbose: bool = False,
-    ) -> AsyncIterator[dict[str, float]]: ...
 
     def _train_sft(
         self,

--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -1,7 +1,6 @@
-import json
 from pathlib import Path
 import socket
-from typing import Any, AsyncIterator
+from typing import Any
 
 from dotenv import load_dotenv
 import typer
@@ -233,7 +232,7 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
     from contextlib import asynccontextmanager
 
     from fastapi import Body, FastAPI, Request
-    from fastapi.responses import JSONResponse, StreamingResponse
+    from fastapi.responses import JSONResponse
     import pydantic
     import uvicorn
 
@@ -242,7 +241,6 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
     from .local import LocalBackend
     from .model import Model, TrainableModel
     from .trajectories import TrajectoryGroup
-    from .types import TrainConfig
 
     # check if port is available
     def is_port_available(port: int) -> bool:
@@ -301,22 +299,6 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
         return await backend._prepare_backend_for_training(model, config)
 
     # Note: /_log endpoint removed - logging now handled by frontend (Model.log())
-
-    @app.post("/_train_model")
-    async def _train_model(
-        model: TrainableModel,
-        trajectory_groups: list[TrajectoryGroup],
-        config: TrainConfig,
-        dev_config: dev.TrainConfig,
-        verbose: bool = Body(False),
-    ) -> StreamingResponse:
-        async def stream() -> AsyncIterator[str]:
-            async for result in backend._train_model(
-                model, trajectory_groups, config, dev_config, verbose
-            ):
-                yield json.dumps(result) + "\n"
-
-        return StreamingResponse(stream())
 
     # Wrap in function with Body(...) to ensure FastAPI correctly interprets
     # all parameters as body parameters

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -679,9 +679,9 @@ class LocalBackend(Backend):
     ) -> LocalTrainResult:
         """Train the model on the given trajectory groups.
 
-        This is the recommended way to train models. Unlike model.train(), this
-        method does NOT automatically log trajectories or metrics. Call model.log()
-        explicitly before and/or after training if you want to log data.
+        This method does NOT automatically log trajectories or metrics. Call
+        model.log() explicitly before and/or after training if you want to log
+        data.
 
         Args:
             model: The trainable model to train.
@@ -741,10 +741,6 @@ class LocalBackend(Backend):
             LocalTrainResult with step number, training metrics, and checkpoint path.
 
         Example:
-            # Before (deprecated):
-            await model.train(trajectory_groups, config=TrainConfig(learning_rate=5e-6))
-
-            # After (recommended):
             await model.log(trajectory_groups, split="train")
             result = await backend.train(model, trajectory_groups, learning_rate=5e-6)
             # Optionally log training metrics:

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -23,7 +23,7 @@ from .metrics_taxonomy import (
     summarize_trajectory_groups,
 )
 from .trajectories import Trajectory, TrajectoryGroup
-from .types import TrainConfig, TrainSFTConfig
+from .types import TrainSFTConfig
 from .utils.trajectory_logging import write_trajectory_groups_parquet
 
 if TYPE_CHECKING:
@@ -224,7 +224,8 @@ class Model(
         report_metrics: list[str] | None = None,
         **kwargs: Never,
     ) -> None:
-        super().__init__(
+        BaseModel.__init__(
+            self,
             name=name,
             project=project,
             entity=entity,
@@ -236,6 +237,9 @@ class Model(
             report_metrics=report_metrics,
             **kwargs,
         )
+        self._init_runtime_state()
+
+    def _init_runtime_state(self) -> None:
         object.__setattr__(self, "_wandb_defined_metrics", set())
         object.__setattr__(self, "_wandb_config", {})
         object.__setattr__(self, "_run_start_time", time.time())
@@ -283,10 +287,10 @@ class Model(
 
     def __new__(  # pyright: ignore[reportInconsistentOverload]
         cls,
-        *args,
-        **kwargs,
-    ) -> "Model[ModelConfig, StateType]":
-        return super().__new__(cls)
+        *args: Any,
+        **kwargs: Any,
+    ) -> "Model[Any, Any]":
+        return BaseModel.__new__(cls)
 
     def safe_model_dump(self, *args, **kwargs) -> dict:
         """
@@ -459,7 +463,7 @@ class Model(
         )
         self.overwrite_state(state)
 
-    def merge_state(self, state: StateType) -> StateType:
+    def merge_state(self, state: dict[str, Any]) -> StateType:
         """Deep-merge state into the existing state and persist it.
 
         Args:
@@ -746,7 +750,7 @@ class Model(
         )
         if callable(gpu_cost_getter) and "costs/gpu" not in provided_metric_keys:
             gpu_cost_per_hour_usd = gpu_cost_getter(self)
-            if gpu_cost_per_hour_usd is not None:
+            if isinstance(gpu_cost_per_hour_usd, int | float):
                 automatic_metrics["costs/gpu"] = (
                     step_wall_s * float(gpu_cost_per_hour_usd) / 3600.0
                 )
@@ -1027,7 +1031,8 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
         _internal_config: dev.InternalModelConfig | None = None,
         **kwargs: Never,
     ) -> None:
-        super().__init__(
+        BaseModel.__init__(
+            self,
             name=name,
             project=project,
             entity=entity,
@@ -1038,6 +1043,7 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
             report_metrics=report_metrics,
             **kwargs,
         )
+        self._init_runtime_state()
         object.__setattr__(self, "_cost_calculator", self._noop_cost_calculator)
         if _internal_config is not None:
             # Bypass BaseModel __setattr__ to allow setting private attr
@@ -1122,10 +1128,10 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
 
     def __new__(  # pyright: ignore[reportInconsistentOverload]
         cls,
-        *args,
-        **kwargs,
-    ) -> "TrainableModel[ModelConfig, StateType]":
-        return super().__new__(cls)
+        *args: Any,
+        **kwargs: Any,
+    ) -> "TrainableModel[Any, Any]":
+        return BaseModel.__new__(cls)
 
     def model_dump(self, *args, **kwargs) -> dict:
         data = super().model_dump(*args, **kwargs)
@@ -1193,65 +1199,6 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
 
         # Backend only does file deletion
         await self.backend()._delete_checkpoint_files(self, steps_to_keep)
-
-    async def train(
-        self,
-        trajectory_groups: Iterable[TrajectoryGroup],
-        config: TrainConfig = TrainConfig(),
-        _config: dev.TrainConfig | None = None,
-        verbose: bool = False,
-    ) -> None:
-        """
-        Reinforce fine-tune the model with a batch of trajectory groups.
-
-        .. deprecated::
-            Use ``backend.train(model, trajectory_groups, ...)`` instead.
-            This method will be removed in a future version.
-
-        Args:
-            trajectory_groups: A batch of trajectory groups.
-            config: Fine-tuning specific configuration
-            _config: Additional configuration that is subject to change and
-                not yet part of the public API. Use at your own risk.
-        """
-        warnings.warn(
-            "model.train() is deprecated. Use backend.train(model, ...) instead.\n\n"
-            "Migration guide:\n"
-            "  # Before (deprecated):\n"
-            "  await model.train(trajectory_groups, config=TrainConfig(learning_rate=5e-6))\n\n"
-            "  # After (recommended):\n"
-            "  result = await backend.train(model, trajectory_groups, learning_rate=5e-6)\n"
-            "  await model.log(trajectory_groups, metrics=result.metrics, step=result.step, split='train')\n\n"
-            "Key differences:\n"
-            "  - backend.train() does NOT automatically log trajectories or metrics\n"
-            "  - backend.train() returns a TrainResult with step, metrics, and checkpoint info\n"
-            "  - Each backend has its own type-checked parameters (no more generic config objects)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        groups_list = list(trajectory_groups)
-        _config = _config or {}  # ty:ignore[invalid-assignment]
-
-        # 1. Train (backend no longer logs internally)
-        training_metrics: list[dict[str, float]] = []
-        trainer_started = time.monotonic()
-        async for metrics in self.backend()._train_model(
-            self,
-            groups_list,
-            config,
-            _config,  # ty:ignore[invalid-argument-type]
-            verbose,
-        ):
-            training_metrics.append(metrics)
-        trainer_elapsed = time.monotonic() - trainer_started
-
-        # 2. Calculate aggregated training metrics
-        avg_metrics = average_metric_samples(training_metrics)
-        avg_metrics.setdefault("time/step_trainer_s", trainer_elapsed)
-
-        # 3. Log trajectories and training metrics together (single wandb log call)
-        step = await self.get_step()
-        await self.log(groups_list, split="train", metrics=avg_metrics, step=step)
 
     async def train_sft(
         self,

--- a/src/art/pipeline_trainer/trainer.py
+++ b/src/art/pipeline_trainer/trainer.py
@@ -24,7 +24,7 @@ _ACTOR_IDLE_TIME_KEY = "_art_actor_idle_s"
 def _to_async_iterator(iterable: Iterable[T] | AsyncIterator[T]) -> AsyncIterator[T]:
     """Convert a sync Iterable to an AsyncIterator, or pass through if already async."""
     if isinstance(iterable, AsyncIterator):
-        return iterable
+        return cast(AsyncIterator[T], iterable)
 
     async def _iter():
         for item in iterable:

--- a/src/art/rewards/ruler.py
+++ b/src/art/rewards/ruler.py
@@ -11,7 +11,6 @@ For detailed documentation and examples, see: https://art.openpipe.ai/fundamenta
 
 import json
 from textwrap import dedent
-from typing import List
 
 from litellm import acompletion
 from litellm.types.utils import ModelResponse
@@ -35,7 +34,9 @@ class TrajectoryScore(BaseModel):
 class Response(BaseModel):
     """Response format expected from the LLM judge."""
 
-    scores: List[TrajectoryScore] = Field(description="The scores for each trajectory.")
+    scores: list[TrajectoryScore] = Field(
+        description="The scores for each trajectory."
+    )
 
 
 DEFAULT_RUBRIC = dedent(
@@ -87,9 +88,9 @@ def _record_ruler_cost(judge_model: str, response: ModelResponse) -> None:
 async def ruler(
     message_lists: list[list[ChatCompletionMessageParam]],
     judge_model: str = "openai/o3",
-    extra_litellm_params: dict | None = None,
+    extra_litellm_params: dict[str, object] | None = None,
     rubric: str = DEFAULT_RUBRIC,
-    tools: list | None = None,
+    tools: art.Tools | None = None,
     *,
     debug: bool = False,
 ) -> list[TrajectoryScore]:
@@ -182,7 +183,7 @@ async def ruler(
 
     # Serialize each trajectory (minus the common prefix) for the judge.
     # If all trajectories are identical, only serialize one full trajectory to save tokens.
-    serialized_trajectories: List[str] = []
+    serialized_trajectories: list[str] = []
     if all_identical:
         # Send the full trajectory since they're all identical
         full_trajectory = message_lists[0]
@@ -264,7 +265,7 @@ async def ruler(
 async def ruler_score_group(
     group: art.TrajectoryGroup,
     judge_model: str = "openai/o3",
-    extra_litellm_params: dict | None = None,
+    extra_litellm_params: dict[str, object] | None = None,
     rubric: str = DEFAULT_RUBRIC,
     *,
     swallow_exceptions: bool = False,

--- a/src/art/rewards/ruler.py
+++ b/src/art/rewards/ruler.py
@@ -34,9 +34,7 @@ class TrajectoryScore(BaseModel):
 class Response(BaseModel):
     """Response format expected from the LLM judge."""
 
-    scores: list[TrajectoryScore] = Field(
-        description="The scores for each trajectory."
-    )
+    scores: list[TrajectoryScore] = Field(description="The scores for each trajectory.")
 
 
 DEFAULT_RUBRIC = dedent(

--- a/src/art/serverless/backend.py
+++ b/src/art/serverless/backend.py
@@ -218,9 +218,9 @@ class ServerlessBackend(Backend):
     ) -> ServerlessTrainResult:
         """Train the model on the given trajectory groups.
 
-        This is the recommended way to train models. Unlike model.train(), this
-        method does NOT automatically log trajectories or metrics. Call model.log()
-        explicitly before and/or after training if you want to log data.
+        This method does NOT automatically log trajectories or metrics. Call
+        model.log() explicitly before and/or after training if you want to log
+        data.
 
         Args:
             model: The trainable model to train.
@@ -246,10 +246,6 @@ class ServerlessBackend(Backend):
             ServerlessTrainResult with step number, training metrics, and artifact name.
 
         Example:
-            # Before (deprecated):
-            await model.train(trajectory_groups, config=TrainConfig(learning_rate=5e-6))
-
-            # After (recommended):
             await model.log(trajectory_groups, split="train")
             result = await backend.train(model, trajectory_groups, learning_rate=5e-6)
             # Optionally log training metrics:

--- a/src/art/test/test_step_skipping.py
+++ b/src/art/test/test_step_skipping.py
@@ -32,6 +32,7 @@ BASE_TRAJECTORY = Trajectory(
     reward=1.0,
 )
 
+
 async def test_step_skipping():
     """Test that step counting works correctly when training is skipped."""
 

--- a/src/art/test/test_step_skipping.py
+++ b/src/art/test/test_step_skipping.py
@@ -14,7 +14,6 @@ import tempfile
 import uuid
 
 from art import TrainableModel, Trajectory, TrajectoryGroup
-from art.dev import TrainConfig as DevTrainConfig
 from art.local import LocalBackend
 from art.utils.output_dirs import get_model_dir, get_step_checkpoint_dir
 
@@ -32,9 +31,6 @@ BASE_TRAJECTORY = Trajectory(
     ],
     reward=1.0,
 )
-
-train_config = DevTrainConfig(allow_training_without_logprobs=True)
-
 
 async def test_step_skipping():
     """Test that step counting works correctly when training is skipped."""
@@ -115,9 +111,10 @@ async def test_step_skipping():
                 ]
             )
 
-            await model.train(
+            await backend.train(
+                model,
                 [group1, group2, group3, group4, group5],
-                _config=train_config,
+                allow_training_without_logprobs=True,
                 verbose=True,
             )
 
@@ -161,9 +158,10 @@ async def test_step_skipping():
                 ]
             )
 
-            await model.train(
+            await backend.train(
+                model,
                 [group1_skip, group2_skip, group3_skip],
-                _config=train_config,
+                allow_training_without_logprobs=True,
                 verbose=True,
             )
 
@@ -225,9 +223,10 @@ async def test_step_skipping():
                 ]
             )
 
-            await model.train(
+            await backend.train(
+                model,
                 [group1_final, group2_final, group3_final, group4_final],
-                _config=train_config,
+                allow_training_without_logprobs=True,
                 verbose=True,
             )
 

--- a/src/art/tinker_native/backend.py
+++ b/src/art/tinker_native/backend.py
@@ -38,7 +38,7 @@ from ..model import Model, TrainableModel
 from ..tinker.backend import get_renderer_name
 from ..tinker.server import get_free_port
 from ..trajectories import Trajectory, TrajectoryGroup
-from ..types import TrainConfig, TrainResult, TrainSFTConfig
+from ..types import TrainResult, TrainSFTConfig
 from ..utils.output_dirs import get_model_dir
 from ..utils.trajectory_migration import auto_migrate_on_register
 from .data import (
@@ -354,20 +354,6 @@ class TinkerNativeBackend(Backend):
         metrics["time/step_trainer_s"] = time.monotonic() - trainer_started
 
         return TrainResult(step=state.current_step, metrics=metrics)
-
-    async def _train_model(
-        self,
-        model: TrainableModel,
-        trajectory_groups: list[TrajectoryGroup],
-        config: TrainConfig,
-        dev_config: dev.TrainConfig,
-        verbose: bool = False,
-    ) -> AsyncIterator[dict[str, float]]:
-        raise NotImplementedError(
-            "TinkerNativeBackend does not support TrainableModel.train(). "
-            "Use TinkerNativeBackend.train() through PipelineTrainer instead."
-        )
-        yield {}
 
     async def _train_sft(
         self,

--- a/src/art/tinker_native/backend.py
+++ b/src/art/tinker_native/backend.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 import time
-from typing import Any, Awaitable, Iterable, Literal, TypeVar, cast
+from typing import Any, AsyncIterator, Awaitable, Iterable, Literal, TypeVar, cast
 import uuid
 
 from fastapi import FastAPI, HTTPException
@@ -37,8 +37,8 @@ from ..metrics_taxonomy import (
 from ..model import Model, TrainableModel
 from ..tinker.backend import get_renderer_name
 from ..tinker.server import get_free_port
-from ..trajectories import TrajectoryGroup
-from ..types import TrainResult
+from ..trajectories import Trajectory, TrajectoryGroup
+from ..types import TrainConfig, TrainResult, TrainSFTConfig
 from ..utils.output_dirs import get_model_dir
 from ..utils.trajectory_migration import auto_migrate_on_register
 from .data import (
@@ -232,7 +232,7 @@ class TinkerNativeBackend(Backend):
         await self._wait_for_server_ready(base_url, api_key, model)
         return base_url, api_key
 
-    async def train(  # type: ignore[override]
+    async def train(
         self,
         model: TrainableModel,
         trajectory_groups: Iterable[TrajectoryGroup],
@@ -243,7 +243,11 @@ class TinkerNativeBackend(Backend):
         save_checkpoint: bool = False,
         loss_fn_config: dict | None = None,
         adam_params: tinker.AdamParams | None = None,
+        **kwargs: Any,
     ) -> TrainResult:
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unexpected training kwargs: {unexpected}")
         state = self._model_state[model.name]
         groups_list = list(trajectory_groups)
         summary = summarize_trajectory_groups(groups_list)
@@ -350,6 +354,33 @@ class TinkerNativeBackend(Backend):
         metrics["time/step_trainer_s"] = time.monotonic() - trainer_started
 
         return TrainResult(step=state.current_step, metrics=metrics)
+
+    async def _train_model(
+        self,
+        model: TrainableModel,
+        trajectory_groups: list[TrajectoryGroup],
+        config: TrainConfig,
+        dev_config: dev.TrainConfig,
+        verbose: bool = False,
+    ) -> AsyncIterator[dict[str, float]]:
+        raise NotImplementedError(
+            "TinkerNativeBackend does not support TrainableModel.train(). "
+            "Use TinkerNativeBackend.train() through PipelineTrainer instead."
+        )
+        yield {}
+
+    async def _train_sft(
+        self,
+        model: TrainableModel,
+        trajectories: Iterable[Trajectory],
+        config: TrainSFTConfig,
+        dev_config: dev.TrainSFTConfig,
+        verbose: bool = False,
+    ) -> AsyncIterator[dict[str, float]]:
+        raise NotImplementedError(
+            "TinkerNativeBackend does not support TrainableModel.train_sft()."
+        )
+        yield {}
 
     async def _get_step(self, model: TrainableModel) -> int:
         if model.name in self._model_state:

--- a/src/art/tinker_native/backend.py
+++ b/src/art/tinker_native/backend.py
@@ -245,9 +245,6 @@ class TinkerNativeBackend(Backend):
         adam_params: tinker.AdamParams | None = None,
         **kwargs: Any,
     ) -> TrainResult:
-        if kwargs:
-            unexpected = ", ".join(sorted(kwargs))
-            raise TypeError(f"Unexpected training kwargs: {unexpected}")
         state = self._model_state[model.name]
         groups_list = list(trajectory_groups)
         summary = summarize_trajectory_groups(groups_list)

--- a/tests/unit/test_frontend_logging.py
+++ b/tests/unit/test_frontend_logging.py
@@ -1154,52 +1154,6 @@ class TestTrainSFTMetricsAggregation:
 
 class TestGradientStepMetrics:
     @pytest.mark.asyncio
-    async def test_model_train_logs_gradient_step_count(self, tmp_path: Path):
-        model = TrainableModel(
-            name="test-train",
-            project="test-project",
-            base_model="gpt-4",
-            base_path=str(tmp_path),
-            report_metrics=[],
-        )
-
-        async def mock_train_model(*args, **kwargs):
-            for loss in (1.0, 0.8, 0.6):
-                yield {
-                    "loss/train": loss,
-                    TRAIN_GRADIENT_STEPS_KEY: 3.0,
-                }
-
-        mock_backend = MagicMock()
-        mock_backend._train_model = mock_train_model
-        mock_backend._get_step = AsyncMock(return_value=1)
-        model._backend = mock_backend
-
-        groups = [
-            TrajectoryGroup(
-                trajectories=[
-                    Trajectory(
-                        reward=1.0,
-                        messages_and_choices=[
-                            {"role": "user", "content": "hello"},
-                            {"role": "assistant", "content": "hi"},
-                        ],
-                    )
-                ]
-            )
-        ]
-
-        await model.train(groups)
-
-        history_path = tmp_path / "test-project/models/test-train/history.jsonl"
-        rows = [json.loads(line) for line in history_path.open() if line.strip()]
-        merged: dict[str, float] = {}
-        for row in rows:
-            merged.update(row)
-
-        assert merged[TRAIN_GRADIENT_STEPS_KEY] == pytest.approx(3.0)
-
-    @pytest.mark.asyncio
     async def test_local_backend_train_returns_gradient_step_count(
         self, tmp_path: Path
     ):


### PR DESCRIPTION
## Summary

- Tighten public RULER annotations for `extra_litellm_params`, `tools`, and list types.
- Make `TinkerNativeBackend` satisfy the `Backend` protocol without downstream casts.
- Remove the deprecated public `TrainableModel.train()` API and repo call sites; active docs/examples now use `backend.train(...)` plus explicit `model.log(...)`.
- Stop requiring `_train_model` on the shared `Backend` protocol while keeping Local/Serverless internal helpers for their `backend.train(...)` implementations.

## Validation

- `uvx ruff check src/art/backend.py src/art/cli.py src/art/model.py src/art/local/backend.py src/art/serverless/backend.py src/art/tinker_native/backend.py src/art/pipeline_trainer/trainer.py src/art/test/test_step_skipping.py tests/unit/test_frontend_logging.py`
- `uvx ty check --python /workspace/simple-cl/.venv src/art/backend.py src/art/model.py src/art/tinker_native/backend.py src/art/pipeline_trainer/trainer.py`
- `uvx pyright --pythonpath /workspace/simple-cl/.venv/bin/python src/art/backend.py src/art/model.py src/art/tinker_native/backend.py src/art/pipeline_trainer/trainer.py`
- `/workspace/simple-cl`: `uvx ty check art_rl`
- `/workspace/simple-cl`: strict Pyright over `art_rl` with `extraPaths=["art/src"]`
- `python -m py_compile` on touched ART files and downstream `art_rl` files