### PR TITLE
feat: Preserve thinking content in chat templates

### DIFF
--- a/src/art/preprocessing/tokenize.py
+++ b/src/art/preprocessing/tokenize.py
@@ -20,20 +20,16 @@ ChatTemplateTool = dict[Any, Any] | Callable[..., Any]
 ChatTemplateToolSchemaFormat = Literal["default", "vllm_openai"]
 
 
-def _chat_template_disables_thinking(tokenizer: PreTrainedTokenizerBase) -> bool:
-    chat_template = tokenizer.chat_template
-    return isinstance(chat_template, str) and "enable_thinking" in chat_template
-
-
 def _chat_template_kwargs(
     tokenizer: PreTrainedTokenizerBase,
     chat_template_kwargs: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    kwargs = (
-        {"enable_thinking": False}
-        if _chat_template_disables_thinking(tokenizer)
-        else {}
-    )
+    kwargs: dict[str, Any] = {}
+    if isinstance(tokenizer.chat_template, str):
+        if "enable_thinking" in tokenizer.chat_template:
+            kwargs["enable_thinking"] = False
+        if "preserve_thinking" in tokenizer.chat_template:
+            kwargs["preserve_thinking"] = True
     kwargs.update(chat_template_kwargs or {})
     return kwargs
 


### PR DESCRIPTION
## Summary
- Set `preserve_thinking=True` automatically for chat templates that expose that option.
- Keep the existing `enable_thinking=False` default while allowing caller-provided kwargs to override either value.

## Test plan
- `uv run pytest tests/unit/test_preprocessing_tokenize.py`
- `uv run ty check src/art/preprocessing/tokenize.py tests/unit/test_preprocessing_tokenize.py`
- `uv run prek run --all-files` fails locally in `ty` because optional Megatron/Triton dependencies such as `transformer_engine`, `triton`, `causal_conv1d`, and `fla` are not installed.


Made with [Cursor](https://cursor.com)