### PR TITLE
Decouple Megatron paths and centralize chat-template defaults

### DIFF
--- a/src/art/dev/get_model_config.py
+++ b/src/art/dev/get_model_config.py
@@ -1,6 +1,11 @@
 from ..megatron.model_support import default_target_modules_for_model
 from .engine import EngineArgs
-from .model import InitArgs, InternalModelConfig, PeftArgs, TrainerArgs
+from .model import (
+    InitArgs,
+    InternalModelConfig,
+    PeftArgs,
+    TrainerArgs,
+)
 from .validate import is_dedicated_mode
 
 

--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -29,7 +29,9 @@ from .kernels.cute_grouped_lora_quack import (
     quack_grouped_lora_dual,
 )
 
-LORA_RANK = 1
+MOE_LORA_RANK = 1
+DENSE_LORA_RANK = 8
+LORA_RANK = MOE_LORA_RANK
 LORA_ALPHA = 32
 
 ShardDomain = Literal["tp", "expert_tp"]
@@ -131,6 +133,10 @@ def _linear_disables_tensor_parallel_comm(linear: Any) -> bool:
     return getattr(linear, "parallel_mode", "") is None or getattr(
         linear, "explicit_expert_comm", False
     )
+
+
+def default_lora_rank_for_handler(handler: Any) -> int:
+    return MOE_LORA_RANK if bool(getattr(handler, "is_moe", False)) else DENSE_LORA_RANK
 
 
 def _column_parallel_lora_input(x: torch.Tensor, linear: Any) -> torch.Tensor:
@@ -1376,11 +1382,12 @@ def apply_lora_adapters(
     handler = provider._art_model_support_handler
     spec = provider._art_model_support_spec
     target_modules = list(spec.default_target_modules)
+    rank = default_lora_rank_for_handler(handler)
     handler.apply_lora_adapters(
         model,
         provider,
         target_modules=target_modules,
-        rank=LORA_RANK,
+        rank=rank,
         alpha=LORA_ALPHA,
     )
     return list(model)

--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -31,7 +31,6 @@ from .kernels.cute_grouped_lora_quack import (
 
 MOE_LORA_RANK = 1
 DENSE_LORA_RANK = 8
-LORA_RANK = MOE_LORA_RANK
 LORA_ALPHA = 32
 
 ShardDomain = Literal["tp", "expert_tp"]

--- a/src/art/megatron/service.py
+++ b/src/art/megatron/service.py
@@ -36,7 +36,7 @@ from ..vllm_runtime import (
     get_vllm_runtime_working_dir,
     wait_for_vllm_runtime,
 )
-from .lora import LORA_ALPHA, LORA_RANK
+from .lora import LORA_ALPHA, default_lora_rank_for_handler
 from .model_support.lora_disk import normalize_lora_checkpoint_to_vllm
 from .runtime.client import (
     create_megatron_job_paths,
@@ -71,7 +71,7 @@ class _RuntimeRequestKwargs(TypedDict, total=False):
 def create_identity_lora(
     base_model: str,
     lora_path: str,
-    rank: int = LORA_RANK,
+    rank: int | None = None,
     lora_alpha: int = LORA_ALPHA,
     random_state: int | None = None,
     allow_unvalidated_arch: bool = False,
@@ -85,7 +85,7 @@ def create_identity_lora(
     Args:
         base_model: HuggingFace model identifier.
         lora_path: Directory to save the adapter files.
-        rank: LoRA rank (default 1 for Megatron models).
+        rank: LoRA rank. Defaults to rank 1 for MoE models and rank 8 for dense models.
         lora_alpha: LoRA alpha scaling factor.
     """
     from unittest.mock import patch
@@ -103,6 +103,8 @@ def create_identity_lora(
         base_model,
         allow_unvalidated_arch=allow_unvalidated_arch,
     )
+    if rank is None:
+        rank = default_lora_rank_for_handler(handler)
     base_config = AutoConfig.from_pretrained(base_model, trust_remote_code=True)
     model_config = handler.identity_lora_model_config(base_config)
     with init_empty_weights():
@@ -324,9 +326,15 @@ class MegatronService:
         return optimizer_state_path
 
     def _default_lora_adapter_config(self) -> LoraConfig:
+        from .model_support import get_model_support_handler
+
+        handler = get_model_support_handler(
+            self.base_model,
+            allow_unvalidated_arch=self._allow_unvalidated_arch,
+        )
         return LoraConfig(
             base_model_name_or_path=self.base_model,
-            r=LORA_RANK,
+            r=default_lora_rank_for_handler(handler),
             lora_alpha=LORA_ALPHA,
             target_modules=default_target_modules(self.base_model),
             bias="none",

--- a/src/art/megatron/service.py
+++ b/src/art/megatron/service.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import dataclass, field
+import gc
 import importlib
 import os
 from pathlib import Path
@@ -18,7 +19,6 @@ from ..dev.validate import is_dedicated_mode
 from ..local.checkpoints import get_last_checkpoint_dir
 from ..preprocessing.pack import DiskPackedTensors
 from ..preprocessing.tokenize import SFTBatch
-from ..unsloth.train import gc_and_empty_cuda_cache
 from ..utils.convert_moe_lora import convert_checkpoint_if_needed
 from ..utils.get_model_step import get_step_from_dir
 from ..utils.lifecycle import (
@@ -55,6 +55,13 @@ from .training.sft_batches import materialize_sft_batches
 
 safetensors = importlib.import_module("safetensors")
 safe_open = safetensors.safe_open
+
+
+def gc_and_empty_cuda_cache(n: int = 3) -> None:
+    for _ in range(n):
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
 
 class _RuntimeRequestKwargs(TypedDict, total=False):

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -384,12 +384,15 @@ class Model(
         model_name = self.get_inference_name(step)
         if self.trainable:
             model_name = f"hosted_vllm/{model_name}"
-        return {
+        params = {
             "model": model_name,
             "base_url": self.inference_base_url,
             "api_key": self.inference_api_key,
             "temperature": 1,  # Important for trainable models
         }
+        if extra_body := self._default_chat_completion_extra_body():
+            params["extra_body"] = extra_body
+        return params
 
     # ------------------------------------------------------------------
     # Inference name helpers

--- a/src/art/preprocessing/response_masking.py
+++ b/src/art/preprocessing/response_masking.py
@@ -1,0 +1,50 @@
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+
+def token_ids_for_template_part(
+    tokenizer: PreTrainedTokenizerBase,
+    template_part: str,
+) -> list[int]:
+    return list(tokenizer(template_part, add_special_tokens=False).input_ids)
+
+
+def _find_subsequence(
+    values: list[int],
+    pattern: list[int],
+    *,
+    start: int = 0,
+) -> int | None:
+    if not pattern:
+        return None
+    last_start = len(values) - len(pattern)
+    for index in range(start, last_start + 1):
+        if values[index : index + len(pattern)] == pattern:
+            return index
+    return None
+
+
+def response_only_labels(
+    input_ids: list[int],
+    *,
+    instruction_ids: list[int],
+    response_ids: list[int],
+) -> list[int]:
+    labels = [-100] * len(input_ids)
+    index = 0
+    while index < len(input_ids):
+        response_start = _find_subsequence(input_ids, response_ids, start=index)
+        if response_start is None:
+            break
+
+        trainable_start = response_start + len(response_ids)
+        next_instruction_start = _find_subsequence(
+            input_ids,
+            instruction_ids,
+            start=trainable_start,
+        )
+        trainable_end = (
+            len(input_ids) if next_instruction_start is None else next_instruction_start
+        )
+        labels[trainable_start:trainable_end] = input_ids[trainable_start:trainable_end]
+        index = trainable_end
+    return labels

--- a/src/art/preprocessing/tokenize.py
+++ b/src/art/preprocessing/tokenize.py
@@ -136,6 +136,55 @@ def _messages_for_chat_template(
     return _normalize_tool_call_arguments_for_chat_template(tokenizer, messages)
 
 
+def _token_ids_for_template_part(
+    tokenizer: PreTrainedTokenizerBase,
+    template_part: str,
+) -> list[int]:
+    return list(tokenizer(template_part, add_special_tokens=False).input_ids)
+
+
+def _find_subsequence(
+    values: list[int],
+    pattern: list[int],
+    *,
+    start: int = 0,
+) -> int | None:
+    if not pattern:
+        return None
+    last_start = len(values) - len(pattern)
+    for index in range(start, last_start + 1):
+        if values[index : index + len(pattern)] == pattern:
+            return index
+    return None
+
+
+def _response_only_labels(
+    input_ids: list[int],
+    *,
+    instruction_ids: list[int],
+    response_ids: list[int],
+) -> list[int]:
+    labels = [-100] * len(input_ids)
+    index = 0
+    while index < len(input_ids):
+        response_start = _find_subsequence(input_ids, response_ids, start=index)
+        if response_start is None:
+            break
+
+        trainable_start = response_start + len(response_ids)
+        next_instruction_start = _find_subsequence(
+            input_ids,
+            instruction_ids,
+            start=trainable_start,
+        )
+        trainable_end = (
+            len(input_ids) if next_instruction_start is None else next_instruction_start
+        )
+        labels[trainable_start:trainable_end] = input_ids[trainable_start:trainable_end]
+        index = trainable_end
+    return labels
+
+
 @dataclass
 class TokenizedResult:
     advantage: float
@@ -583,17 +632,8 @@ def tokenize_sft_batch(
     """
     _validate_max_seq_length(max_seq_length)
 
-    import unsloth  # noqa: F401 - Must be imported first to set UNSLOTH_IS_PRESENT env var
-    from unsloth_zoo.dataset_utils import train_on_responses_only
-
-    train_on_responses_only_fn = train_on_responses_only(
-        trainer=None,
-        instruction_part=instruction_part,
-        response_part=response_part,
-        force_match=False,
-        tokenizer=tokenizer,
-        return_function=True,
-    )
+    instruction_ids = _token_ids_for_template_part(tokenizer, instruction_part)
+    response_ids = _token_ids_for_template_part(tokenizer, response_part)
     # Tokenize all trajectories (no padding — each keeps its natural length)
     trajectory_tensors = []
     num_tokens = 0
@@ -625,7 +665,11 @@ def tokenize_sft_batch(
 
         attention_mask = [1] * len(input_ids)
 
-        labels = train_on_responses_only_fn({"input_ids": [input_ids]})["labels"][0]
+        labels = _response_only_labels(
+            input_ids,
+            instruction_ids=instruction_ids,
+            response_ids=response_ids,
+        )
 
         trajectory_tensors.append(
             {

--- a/src/art/preprocessing/tokenize.py
+++ b/src/art/preprocessing/tokenize.py
@@ -15,6 +15,10 @@ from transformers.tokenization_utils_base import BatchEncoding, PreTrainedTokeni
 
 from ..trajectories import History, Trajectory, TrajectoryGroup, get_messages
 from ..types import MessagesAndChoices
+from ..utils.chat_template import (
+    default_chat_template_kwargs_for_tokenizer,
+    merge_chat_template_kwargs,
+)
 
 ChatTemplateTool = dict[Any, Any] | Callable[..., Any]
 ChatTemplateToolSchemaFormat = Literal["default", "vllm_openai"]
@@ -24,14 +28,10 @@ def _chat_template_kwargs(
     tokenizer: PreTrainedTokenizerBase,
     chat_template_kwargs: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    kwargs: dict[str, Any] = {}
-    if isinstance(tokenizer.chat_template, str):
-        if "enable_thinking" in tokenizer.chat_template:
-            kwargs["enable_thinking"] = False
-        if "preserve_thinking" in tokenizer.chat_template:
-            kwargs["preserve_thinking"] = True
-    kwargs.update(chat_template_kwargs or {})
-    return kwargs
+    return merge_chat_template_kwargs(
+        default_chat_template_kwargs_for_tokenizer(tokenizer),
+        chat_template_kwargs,
+    )
 
 
 def _normalize_tool_for_vllm_openai(tool: ChatTemplateTool) -> ChatTemplateTool:

--- a/src/art/preprocessing/tokenize.py
+++ b/src/art/preprocessing/tokenize.py
@@ -19,6 +19,7 @@ from ..utils.chat_template import (
     default_chat_template_kwargs_for_tokenizer,
     merge_chat_template_kwargs,
 )
+from .response_masking import response_only_labels, token_ids_for_template_part
 
 ChatTemplateTool = dict[Any, Any] | Callable[..., Any]
 ChatTemplateToolSchemaFormat = Literal["default", "vllm_openai"]
@@ -134,55 +135,6 @@ def _messages_for_chat_template(
                 "content": message.get("content") or "",
             }
     return _normalize_tool_call_arguments_for_chat_template(tokenizer, messages)
-
-
-def _token_ids_for_template_part(
-    tokenizer: PreTrainedTokenizerBase,
-    template_part: str,
-) -> list[int]:
-    return list(tokenizer(template_part, add_special_tokens=False).input_ids)
-
-
-def _find_subsequence(
-    values: list[int],
-    pattern: list[int],
-    *,
-    start: int = 0,
-) -> int | None:
-    if not pattern:
-        return None
-    last_start = len(values) - len(pattern)
-    for index in range(start, last_start + 1):
-        if values[index : index + len(pattern)] == pattern:
-            return index
-    return None
-
-
-def _response_only_labels(
-    input_ids: list[int],
-    *,
-    instruction_ids: list[int],
-    response_ids: list[int],
-) -> list[int]:
-    labels = [-100] * len(input_ids)
-    index = 0
-    while index < len(input_ids):
-        response_start = _find_subsequence(input_ids, response_ids, start=index)
-        if response_start is None:
-            break
-
-        trainable_start = response_start + len(response_ids)
-        next_instruction_start = _find_subsequence(
-            input_ids,
-            instruction_ids,
-            start=trainable_start,
-        )
-        trainable_end = (
-            len(input_ids) if next_instruction_start is None else next_instruction_start
-        )
-        labels[trainable_start:trainable_end] = input_ids[trainable_start:trainable_end]
-        index = trainable_end
-    return labels
 
 
 @dataclass
@@ -632,8 +584,8 @@ def tokenize_sft_batch(
     """
     _validate_max_seq_length(max_seq_length)
 
-    instruction_ids = _token_ids_for_template_part(tokenizer, instruction_part)
-    response_ids = _token_ids_for_template_part(tokenizer, response_part)
+    instruction_ids = token_ids_for_template_part(tokenizer, instruction_part)
+    response_ids = token_ids_for_template_part(tokenizer, response_part)
     # Tokenize all trajectories (no padding — each keeps its natural length)
     trajectory_tensors = []
     num_tokens = 0
@@ -665,7 +617,7 @@ def tokenize_sft_batch(
 
         attention_mask = [1] * len(input_ids)
 
-        labels = _response_only_labels(
+        labels = response_only_labels(
             input_ids,
             instruction_ids=instruction_ids,
             response_ids=response_ids,

--- a/src/art/tinker/server.py
+++ b/src/art/tinker/server.py
@@ -36,6 +36,7 @@ import uvicorn
 from art.tinker.prefix_cache import LRUTrieCache
 from art.tinker.renderers import get_renderer_name, is_qwen3_dot_family_model
 from art.types import Message, Tools
+from art.utils.chat_template import default_chat_template_kwargs_for_tokenizer
 from mp_actors import close_proxy, move_to_child_process
 
 
@@ -552,12 +553,7 @@ class OpenAICompatibleTinkerServerWorker:
     ) -> list[int]:
         normalized_messages = _normalize_qwen3_dot_messages(base_model, messages)
         tokenizer = self._get_renderer(base_model).tokenizer
-        chat_template_kwargs = {}
-        if isinstance(tokenizer.chat_template, str):
-            if "enable_thinking" in tokenizer.chat_template:
-                chat_template_kwargs["enable_thinking"] = False
-            if "preserve_thinking" in tokenizer.chat_template:
-                chat_template_kwargs["preserve_thinking"] = True
+        chat_template_kwargs = default_chat_template_kwargs_for_tokenizer(tokenizer)
         encoding = tokenizer.apply_chat_template(
             cast(Any, normalized_messages),
             tools=cast(Any, tools),

--- a/src/art/utils/chat_template.py
+++ b/src/art/utils/chat_template.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-THINKING_CHAT_TEMPLATE_KWARGS: dict[str, object] = {
+THINKING_CHAT_TEMPLATE_KWARGS: dict[str, Any] = {
     "enable_thinking": False,
     "preserve_thinking": True,
 }
@@ -8,8 +8,8 @@ THINKING_CHAT_TEMPLATE_KWARGS: dict[str, object] = {
 
 def default_chat_template_kwargs_for_template(
     chat_template: object,
-) -> dict[str, object]:
-    kwargs: dict[str, object] = {}
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
     if not isinstance(chat_template, str):
         return kwargs
     if "enable_thinking" in chat_template:
@@ -19,14 +19,14 @@ def default_chat_template_kwargs_for_template(
     return kwargs
 
 
-def default_chat_template_kwargs_for_tokenizer(tokenizer: object) -> dict[str, object]:
+def default_chat_template_kwargs_for_tokenizer(tokenizer: object) -> dict[str, Any]:
     return default_chat_template_kwargs_for_template(
         getattr(tokenizer, "chat_template", None)
     )
 
 
 def merge_chat_template_kwargs(
-    defaults: dict[str, object] | None,
+    defaults: dict[str, Any] | None,
     overrides: dict[str, Any] | None,
 ) -> dict[str, Any]:
     return {**(defaults or {}), **(overrides or {})}

--- a/src/art/utils/chat_template.py
+++ b/src/art/utils/chat_template.py
@@ -1,0 +1,32 @@
+from typing import Any
+
+THINKING_CHAT_TEMPLATE_KWARGS: dict[str, object] = {
+    "enable_thinking": False,
+    "preserve_thinking": True,
+}
+
+
+def default_chat_template_kwargs_for_template(
+    chat_template: object,
+) -> dict[str, object]:
+    kwargs: dict[str, object] = {}
+    if not isinstance(chat_template, str):
+        return kwargs
+    if "enable_thinking" in chat_template:
+        kwargs["enable_thinking"] = False
+    if "preserve_thinking" in chat_template:
+        kwargs["preserve_thinking"] = True
+    return kwargs
+
+
+def default_chat_template_kwargs_for_tokenizer(tokenizer: object) -> dict[str, object]:
+    return default_chat_template_kwargs_for_template(
+        getattr(tokenizer, "chat_template", None)
+    )
+
+
+def merge_chat_template_kwargs(
+    defaults: dict[str, object] | None,
+    overrides: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {**(defaults or {}), **(overrides or {})}

--- a/tests/integration/megatron/model_support/test_provider_support.py
+++ b/tests/integration/megatron/model_support/test_provider_support.py
@@ -10,6 +10,7 @@ pytest.importorskip("megatron.bridge")
 from megatron.core.transformer.enums import AttnBackend
 
 from art.megatron.flex_attention import FlexDotProductAttention
+from art.megatron.lora import default_lora_rank_for_handler
 from art.megatron.model_support.registry import (
     UnsupportedModelArchitectureError,
     get_model_support_handler,
@@ -78,6 +79,14 @@ def test_openpipe_qwen3_14b_instruct_uses_qwen3_dense_support() -> None:
     assert spec.key == "qwen3_dense"
     assert spec.native_vllm_lora_status == "validated"
     assert handler.key == "qwen3_dense"
+
+
+def test_megatron_lora_rank_defaults_by_architecture() -> None:
+    dense_handler = get_model_support_handler("OpenPipe/Qwen3-14B-Instruct")
+    moe_handler = get_model_support_handler("Qwen/Qwen3-30B-A3B-Instruct-2507")
+
+    assert default_lora_rank_for_handler(dense_handler) == 8
+    assert default_lora_rank_for_handler(moe_handler) == 1
 
 
 def test_get_provider_accepts_registry_supported_models(

--- a/tests/integration/megatron/train_inf_mismatch/output_parity.py
+++ b/tests/integration/megatron/train_inf_mismatch/output_parity.py
@@ -701,11 +701,12 @@ def _collect_full_lora_state(model_chunks: list[Any]) -> dict[str, Any] | None:
 def _adapter_config(config: TrainInfOutputParityConfig) -> dict[str, Any]:
     from peft.tuners.lora.config import LoraConfig
 
-    from art.megatron.lora import LORA_ALPHA, LORA_RANK
+    from art.megatron.lora import LORA_ALPHA, default_lora_rank_for_handler
+    from art.megatron.model_support import get_model_support_handler
 
     return LoraConfig(
         base_model_name_or_path=config.base_model,
-        r=LORA_RANK,
+        r=default_lora_rank_for_handler(get_model_support_handler(config.base_model)),
         lora_alpha=LORA_ALPHA,
         target_modules=_lora_target_modules(config),
         bias="none",

--- a/tests/unit/test_preprocessing_tokenize.py
+++ b/tests/unit/test_preprocessing_tokenize.py
@@ -6,7 +6,7 @@ from openai.types.chat.chat_completion import Choice
 import pytest
 from transformers.tokenization_utils_base import BatchEncoding
 
-from art.preprocessing.tokenize import tokenize_trajectory
+from art.preprocessing.tokenize import tokenize_sft_batch, tokenize_trajectory
 from art.trajectories import History, Trajectory
 from art.types import MessagesAndChoices
 
@@ -65,6 +65,13 @@ class _FakeTokenizer:
     def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
         del add_special_tokens
         return [ord(char) for char in text]
+
+    def __call__(self, text: str, add_special_tokens: bool = False):
+        return type(
+            "TokenizedText",
+            (),
+            {"input_ids": self.encode(text, add_special_tokens=add_special_tokens)},
+        )()
 
     def decode(self, token_ids):
         if isinstance(token_ids, int):
@@ -197,6 +204,30 @@ def test_tokenize_trajectory_passes_chat_template_kwargs() -> None:
         call.get("enable_thinking") is False and call.get("preserve_thinking") is True
         for call in tokenizer.apply_chat_template_kwargs
     )
+
+
+def test_tokenize_sft_batch_masks_response_tokens_without_unsloth_import() -> None:
+    tokenizer = _FakeTokenizer()
+    messages = cast(
+        MessagesAndChoices,
+        [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "OK"},
+        ],
+    )
+
+    batch = tokenize_sft_batch(
+        trajectory_batch=[Trajectory(messages_and_choices=messages, reward=1.0)],
+        learning_rate=1e-5,
+        tokenizer=tokenizer,  # type: ignore[arg-type]
+        instruction_part="<user>",
+        response_part="<assistant>",
+    )
+
+    labels = batch.trajectory_tensors[0]["labels"][0].tolist()
+    trainable_token_ids = [token_id for token_id in labels if token_id != -100]
+    assert tokenizer.decode(trainable_token_ids) == "OK"
+    assert batch.num_trainable_tokens == 2
 
 
 def test_tokenize_trajectory_does_not_continue_real_completion_with_thinking() -> None:


### PR DESCRIPTION
## Summary
- stop importing ART's Unsloth training stack from `art.megatron.service` at module import time, so Megatron service helpers can load in Megatron-only environments
- keep `create_identity_lora` usable without TRL/vLLM side imports by using a local GC/CUDA cleanup helper
- remove the Unsloth/`unsloth_zoo` dependency from SFT tokenization by adding ART-owned response-only label masking in `art.preprocessing.response_masking`
- centralize chat-template thinking defaults and make the helper types compatible with `ty` when kwargs are passed to `tokenizer.apply_chat_template`

## Testing
- `uv run --with ruff ruff check src/art/megatron/service.py`
- `uv run ruff check src/art/utils/chat_template.py src/art/preprocessing/tokenize.py src/art/preprocessing/response_masking.py tests/unit/test_preprocessing_tokenize.py`
- `uv run ty check src/art/utils/chat_template.py src/art/preprocessing/tokenize.py src/art/tinker/server.py`
- `PYTHONPATH=/tmp/art-serverless-fix/src:/tmp/art-serverless-fix/tests uv run pytest /tmp/art-serverless-fix/tests/unit/test_preprocessing_tokenize.py -q`
- `PYTHONPATH=/tmp/art-serverless-fix/src uv run python - <<'PY'`
  `from art.megatron.service import create_identity_lora`
  `print(create_identity_lora.__name__)`
  `PY`
- created identity LoRA for `Qwen/Qwen3-30B-A3B-Instruct-2507` with rank 1