### PR TITLE
Fix serverless auth headers for newer OpenAI SDKs

### DIFF
--- a/src/art/serverless/client.py
+++ b/src/art/serverless/client.py
@@ -316,6 +316,9 @@ class Client(AsyncAPIClient):
         api_key = self.api_key
         return {"Authorization": f"Bearer {api_key}"}
 
+    def _auth_headers(self, security: Any | None = None) -> dict[str, str]:  # noqa: ARG002
+        return self.auth_headers
+
     @property
     @override
     def default_headers(self) -> dict[str, str | Omit]:


### PR DESCRIPTION
## Summary

ART serverless registration can fail in fresh environments that resolve the latest OpenAI Python SDK.

`openpipe-art` currently allows `openai>=2.14.0` with no upper bound. Newer OpenAI SDK versions changed the internal request-auth path: auth headers are now built through `_auth_headers(options.security)` instead of relying on the older `auth_headers` property being merged into `default_headers`.

ART's serverless client only implemented the older `auth_headers` property, so with affected OpenAI SDK versions the `POST /preview/models` registration request can be sent without an `Authorization: Bearer ...` header. W&B Training then returns `401 {"detail": "Not authenticated"}` even though the supplied W&B API key is valid.

## Changes

- Add the `_auth_headers(security)` hook expected by newer OpenAI SDK request builders.
- Keep the existing `auth_headers` property for compatibility with older OpenAI SDK versions.
