### PR TITLE
Security: Unsafe Pickle Usage in FileLogger

### DIFF
--- a/src/art/langgraph/logging.py
+++ b/src/art/langgraph/logging.py
@@ -1,30 +1,29 @@
+import json
 import os
-import pickle
 
 
 class FileLogger:
     def __init__(self, filepath):
         self.text_path = filepath
-        self.pickle_path = filepath + ".pkl"
+        self.jsonl_path = filepath + ".jsonl"
 
     def log(self, name, entry):
         # Log as readable text
         with open(self.text_path, "a") as f:
             f.write(f"{name}: {entry}\n")
 
-        # Append to pickle log
-        with open(self.pickle_path, "ab") as pf:
-            pickle.dump((name, entry), pf)
+        # Append to jsonl log
+        with open(self.jsonl_path, "a") as jf:
+            jf.write(json.dumps([name, entry]) + "\n")
 
     def load_logs(self):
-        """Load all logs from the pickle file."""
-        if not os.path.exists(self.pickle_path):
+        """Load all logs from the jsonl file."""
+        if not os.path.exists(self.jsonl_path):
             return []
         logs = []
-        with open(self.pickle_path, "rb") as pf:
-            try:
-                while True:
-                    logs.append(pickle.load(pf))
-            except EOFError:
-                pass
+        with open(self.jsonl_path, "r") as jf:
+            for line in jf:
+                line = line.strip()
+                if line:
+                    logs.append(tuple(json.loads(line)))
         return logs


### PR DESCRIPTION
## Problem

The FileLogger class in src/art/langgraph/logging.py uses pickle.dump and pickle.load to serialize and deserialize log entries. Pickle is unsafe for untrusted data as it can execute arbitrary code during deserialization. An attacker with write access to the pickle file or the ability to control log entries could achieve remote code execution.

**Severity**: `high`
**File**: `src/art/langgraph/logging.py`

## Solution

Replace pickle with a safe serialization format like JSON, msgpack, or protobuf. If pickle must be used, implement integrity verification (e.g., HMAC) and restrict file permissions. Consider using json.dump/json.load instead of pickle.dump/pickle.load.

## Changes

- `src/art/langgraph/logging.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
