### PR TITLE
Security: Missing Input Validation in display_image_grid

### DIFF
--- a/src/art/utils/old_benchmarking/display_image_grid.py
+++ b/src/art/utils/old_benchmarking/display_image_grid.py
@@ -1,3 +1,5 @@
+import html
+
 from IPython.display import HTML, display
 
 
@@ -6,6 +8,7 @@ def display_image_grid(image_paths: list[str], images_per_row: int = 2):
     <div style='display: grid; grid-template-columns: repeat({images_per_row}, 1fr); gap: 10px;'>
     """
     for path in image_paths:
-        html += f"<img src='{path}' style='max-width: 100%; height: auto;'>"
+        escaped_path = html.escape(path)
+        html += f"<img src='{escaped_path}' style='max-width: 100%; height: auto;'>"
     html += "</div>"
     display(HTML(html))


### PR DESCRIPTION
## Problem

The display_image_grid function in src/art/utils/old_benchmarking/display_image_grid.py constructs HTML by directly interpolating image_paths into an HTML string without sanitization. If image_paths contains malicious input, it could lead to XSS in Jupyter notebook environments.

**Severity**: `medium`
**File**: `src/art/utils/old_benchmarking/display_image_grid.py`

## Solution

Escape or sanitize image_paths before embedding in HTML. Use html.escape() on path strings or use a proper templating engine with auto-escaping. Validate that paths are actual file paths and do not contain HTML/JavaScript.

## Changes

- `src/art/utils/old_benchmarking/display_image_grid.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
