### PR TITLE
Use rank 8 LoRA for dense Megatron models

### DIFF
--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -29,7 +29,9 @@ from .kernels.cute_grouped_lora_quack import (
     quack_grouped_lora_dual,
 )
 
-LORA_RANK = 1
+MOE_LORA_RANK = 1
+DENSE_LORA_RANK = 8
+LORA_RANK = MOE_LORA_RANK
 LORA_ALPHA = 32
 
 ShardDomain = Literal["tp", "expert_tp"]
@@ -131,6 +133,10 @@ def _linear_disables_tensor_parallel_comm(linear: Any) -> bool:
     return getattr(linear, "parallel_mode", "") is None or getattr(
         linear, "explicit_expert_comm", False
     )
+
+
+def default_lora_rank_for_handler(handler: Any) -> int:
+    return MOE_LORA_RANK if bool(getattr(handler, "is_moe", False)) else DENSE_LORA_RANK
 
 
 def _column_parallel_lora_input(x: torch.Tensor, linear: Any) -> torch.Tensor:
@@ -1376,11 +1382,12 @@ def apply_lora_adapters(
     handler = provider._art_model_support_handler
     spec = provider._art_model_support_spec
     target_modules = list(spec.default_target_modules)
+    rank = default_lora_rank_for_handler(handler)
     handler.apply_lora_adapters(
         model,
         provider,
         target_modules=target_modules,
-        rank=LORA_RANK,
+        rank=rank,
         alpha=LORA_ALPHA,
     )
     return list(model)

--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -31,7 +31,6 @@ from .kernels.cute_grouped_lora_quack import (
 
 MOE_LORA_RANK = 1
 DENSE_LORA_RANK = 8
-LORA_RANK = MOE_LORA_RANK
 LORA_ALPHA = 32
 
 ShardDomain = Literal["tp", "expert_tp"]

--- a/src/art/megatron/service.py
+++ b/src/art/megatron/service.py
@@ -36,7 +36,7 @@ from ..vllm_runtime import (
     get_vllm_runtime_working_dir,
     wait_for_vllm_runtime,
 )
-from .lora import LORA_ALPHA, LORA_RANK
+from .lora import LORA_ALPHA, default_lora_rank_for_handler
 from .model_support.lora_disk import normalize_lora_checkpoint_to_vllm
 from .runtime.client import (
     create_megatron_job_paths,
@@ -64,7 +64,7 @@ class _RuntimeRequestKwargs(TypedDict, total=False):
 def create_identity_lora(
     base_model: str,
     lora_path: str,
-    rank: int = LORA_RANK,
+    rank: int | None = None,
     lora_alpha: int = LORA_ALPHA,
     random_state: int | None = None,
     allow_unvalidated_arch: bool = False,
@@ -78,7 +78,7 @@ def create_identity_lora(
     Args:
         base_model: HuggingFace model identifier.
         lora_path: Directory to save the adapter files.
-        rank: LoRA rank (default 1 for Megatron models).
+        rank: LoRA rank. Defaults to rank 1 for MoE models and rank 8 for dense models.
         lora_alpha: LoRA alpha scaling factor.
     """
     from unittest.mock import patch
@@ -96,6 +96,8 @@ def create_identity_lora(
         base_model,
         allow_unvalidated_arch=allow_unvalidated_arch,
     )
+    if rank is None:
+        rank = default_lora_rank_for_handler(handler)
     base_config = AutoConfig.from_pretrained(base_model, trust_remote_code=True)
     model_config = handler.identity_lora_model_config(base_config)
     with init_empty_weights():
@@ -317,9 +319,15 @@ class MegatronService:
         return optimizer_state_path
 
     def _default_lora_adapter_config(self) -> LoraConfig:
+        from .model_support import get_model_support_handler
+
+        handler = get_model_support_handler(
+            self.base_model,
+            allow_unvalidated_arch=self._allow_unvalidated_arch,
+        )
         return LoraConfig(
             base_model_name_or_path=self.base_model,
-            r=LORA_RANK,
+            r=default_lora_rank_for_handler(handler),
             lora_alpha=LORA_ALPHA,
             target_modules=default_target_modules(self.base_model),
             bias="none",

--- a/tests/integration/megatron/model_support/test_provider_support.py
+++ b/tests/integration/megatron/model_support/test_provider_support.py
@@ -10,6 +10,7 @@ pytest.importorskip("megatron.bridge")
 from megatron.core.transformer.enums import AttnBackend
 
 from art.megatron.flex_attention import FlexDotProductAttention
+from art.megatron.lora import default_lora_rank_for_handler
 from art.megatron.model_support.registry import (
     UnsupportedModelArchitectureError,
     get_model_support_handler,
@@ -78,6 +79,14 @@ def test_openpipe_qwen3_14b_instruct_uses_qwen3_dense_support() -> None:
     assert spec.key == "qwen3_dense"
     assert spec.native_vllm_lora_status == "validated"
     assert handler.key == "qwen3_dense"
+
+
+def test_megatron_lora_rank_defaults_by_architecture() -> None:
+    dense_handler = get_model_support_handler("OpenPipe/Qwen3-14B-Instruct")
+    moe_handler = get_model_support_handler("Qwen/Qwen3-30B-A3B-Instruct-2507")
+
+    assert default_lora_rank_for_handler(dense_handler) == 8
+    assert default_lora_rank_for_handler(moe_handler) == 1
 
 
 def test_get_provider_accepts_registry_supported_models(

--- a/tests/integration/megatron/train_inf_mismatch/output_parity.py
+++ b/tests/integration/megatron/train_inf_mismatch/output_parity.py
@@ -701,11 +701,12 @@ def _collect_full_lora_state(model_chunks: list[Any]) -> dict[str, Any] | None:
 def _adapter_config(config: TrainInfOutputParityConfig) -> dict[str, Any]:
     from peft.tuners.lora.config import LoraConfig
 
-    from art.megatron.lora import LORA_ALPHA, LORA_RANK
+    from art.megatron.lora import LORA_ALPHA, default_lora_rank_for_handler
+    from art.megatron.model_support import get_model_support_handler
 
     return LoraConfig(
         base_model_name_or_path=config.base_model,
-        r=LORA_RANK,
+        r=default_lora_rank_for_handler(get_model_support_handler(config.base_model)),
         lora_alpha=LORA_ALPHA,
         target_modules=_lora_target_modules(config),
         bias="none",


### PR DESCRIPTION
## Summary
- keep Megatron MoE LoRA defaults at rank 1
- use rank 8 for dense Megatron model handlers
- apply the architecture-aware rank to identity LoRA creation, adapter configs, runtime LoRA wrapping, and train/inference parity fixtures

## Testing
- uv run ruff check src/art/megatron/lora.py src/art/megatron/service.py tests/integration/megatron/train_inf_mismatch/output_parity.py tests/integration/megatron/model_support/test_provider_support.py
- uv run ty check src/art/megatron/lora.py src/art/megatron/service.py tests/integration/megatron/train_inf_mismatch/output_parity.py tests/integration/megatron/model_support/test_provider_support.py
- uv run pytest tests/integration/megatron/model_support/test_provider_support.py -q (skipped locally because megatron.bridge is not installed)