### PR TITLE
Support tau-bench environment idle TTL

### DIFF
--- a/src/art/tau_bench/client.py
+++ b/src/art/tau_bench/client.py
@@ -184,6 +184,7 @@ class TauBenchClient:
         user_llm_args: dict[str, Any] | None = None,
         retrieval_config: str | None = None,
         retrieval_config_kwargs: dict[str, Any] | None = None,
+        idle_timeout_seconds: float | None = None,
     ) -> EnvironmentResponse:
         response = await self._request(
             "POST",
@@ -197,6 +198,7 @@ class TauBenchClient:
                     "user_llm_args": user_llm_args,
                     "retrieval_config": retrieval_config,
                     "retrieval_config_kwargs": retrieval_config_kwargs,
+                    "idle_timeout_seconds": idle_timeout_seconds,
                 }.items()
                 if value is not None
             },
@@ -238,6 +240,7 @@ class TauBenchClient:
         user_llm_args: dict[str, Any] | None = None,
         retrieval_config: str | None = None,
         retrieval_config_kwargs: dict[str, Any] | None = None,
+        idle_timeout_seconds: float | None = None,
     ) -> AsyncGenerator[EnvironmentResponse, None]:
         env = await self.create_environment(
             domain=domain,
@@ -246,6 +249,7 @@ class TauBenchClient:
             user_llm_args=user_llm_args,
             retrieval_config=retrieval_config,
             retrieval_config_kwargs=retrieval_config_kwargs,
+            idle_timeout_seconds=idle_timeout_seconds,
         )
         try:
             yield env

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -141,6 +141,37 @@ async def test_client_retries_transport_errors() -> None:
 
 
 @pytest.mark.asyncio
+async def test_client_sends_create_environment_idle_timeout() -> None:
+    seen: dict[str, Any] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["json"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"id": "env-1", "observation": "user: hello", "info": {}},
+        )
+
+    http_client = httpx.AsyncClient(
+        base_url="http://tau.test",
+        transport=httpx.MockTransport(handler),
+    )
+    client = TauBenchClient(api_key="secret", http_client=http_client)
+    await client.create_environment(
+        domain="telecom",
+        task_id="task_001",
+        idle_timeout_seconds=120,
+    )
+    await client.close()
+    await http_client.aclose()
+
+    assert seen["json"] == {
+        "domain": "telecom",
+        "task_id": "task_001",
+        "idle_timeout_seconds": 120,
+    }
+
+
+@pytest.mark.asyncio
 async def test_module_default_client_can_be_replaced(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -182,6 +213,7 @@ class FakeTauBenchClient(TauBenchClient):
         user_llm_args: dict[str, Any] | None = None,
         retrieval_config: str | None = None,
         retrieval_config_kwargs: dict[str, Any] | None = None,
+        idle_timeout_seconds: float | None = None,
     ) -> EnvironmentResponse:
         self.create_kwargs = {
             "domain": domain,
@@ -190,6 +222,7 @@ class FakeTauBenchClient(TauBenchClient):
             "user_llm_args": user_llm_args,
             "retrieval_config": retrieval_config,
             "retrieval_config_kwargs": retrieval_config_kwargs,
+            "idle_timeout_seconds": idle_timeout_seconds,
         }
         return EnvironmentResponse(
             id="env-1",


### PR DESCRIPTION
## Summary
- Add optional `idle_timeout_seconds` passthrough to `TauBenchClient.create_environment` and the environment context manager.
- Add a unit test covering the create payload sent to the tau-bench server.

## Test plan
- `uv run --no-sync pytest tests/unit/test_tau_bench_client.py`
- `uv run --no-sync ruff format --check src/art/tau_bench/client.py tests/unit/test_tau_bench_client.py`
- `uv run --no-sync ruff check src/art/tau_bench/client.py tests/unit/test_tau_bench_client.py`