### PR TITLE
Guard model config against eager Megatron imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,8 +237,12 @@ allowed-unresolved-imports = [
     "matplotlib.**",
     "seaborn.**",
     # megatron deps
+    "causal_conv1d.**",
+    "fla.**",
     "megatron.**",
     "quack.**",
+    "transformer_engine.**",
+    "triton.**",
 ]
 
 [dependency-groups]

--- a/tests/unit/test_model_support_import_boundary.py
+++ b/tests/unit/test_model_support_import_boundary.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+def test_get_model_config_qwen3_metadata_does_not_import_megatron() -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import builtins
+                import tempfile
+
+                real_import = builtins.__import__
+
+                def blocked_import(
+                    name, globals=None, locals=None, fromlist=(), level=0
+                ):
+                    if level == 0 and name.partition(".")[0] == "megatron":
+                        raise ModuleNotFoundError("No module named 'megatron'")
+                    return real_import(name, globals, locals, fromlist, level)
+
+                builtins.__import__ = blocked_import
+
+                from art.dev.get_model_config import get_model_config
+
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    config = get_model_config(
+                        "Qwen/Qwen3-30B-A3B-Instruct-2507",
+                        tmpdir,
+                        None,
+                    )
+                """
+            ),
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        check=True,
+    )


### PR DESCRIPTION
## Summary
- Add a subprocess regression test that blocks top-level `megatron` imports while building Qwen3 model config.
- Allow optional Megatron-adjacent dependencies in `ty` unresolved-import config so full `prek` checks pass without those extras installed locally.

## Test plan
- `uv run prek run --all-files`