### PR TITLE
Move LoRA config to TrainableModel

### DIFF
--- a/dev/profile.ipynb
+++ b/dev/profile.ipynb
@@ -28,9 +28,6 @@
     "            \"enforce_eager\": True,\n",
     "            \"gpu_memory_utilization\": 0.9,\n",
     "        },\n",
-    "        \"peft_args\": {\n",
-    "            # \"use_gradient_checkpointing\": False,\n",
-    "        },\n",
     "    },\n",
     ")\n",
     "state = ModelState(config)"

--- a/dev/yes-no-maybe-megatron.py
+++ b/dev/yes-no-maybe-megatron.py
@@ -190,6 +190,7 @@ async def main() -> None:
     max_tokens = int(os.environ.get("MAX_TOKENS", "100"))
     timeout = float(os.environ.get("TIMEOUT", "100"))
     learning_rate = float(os.environ.get("LEARNING_RATE", "1e-4"))
+    lora_rank = os.environ.get("LORA_RANK")
     packed_sequence_length = int(
         os.environ.get(
             "PACKED_SEQUENCE_LENGTH",
@@ -202,6 +203,9 @@ async def main() -> None:
         name=model_name,
         project=project,
         base_model=base_model,
+        lora_config=(
+            art.LoRAConfig(rank=int(lora_rank)) if lora_rank is not None else None
+        ),
         report_metrics=[],
         _internal_config=build_internal_config(),
     )

--- a/dev/yes-no-maybe.py
+++ b/dev/yes-no-maybe.py
@@ -51,9 +51,6 @@ async def main():
         #     # engine_args=art.dev.EngineArgs(
         #     #     max_lora_rank=1,
         #     # ),
-        #     # peft_args=art.dev.PeftArgs(
-        #     #     r=1,
-        #     # ),
         #     tinker_args=art.dev.TinkerArgs(
         #         renderer_name="qwen3_instruct",
         #         training_client_args=art.dev.TinkerTrainingClientArgs(

--- a/examples/hn_title_generator/train.py
+++ b/examples/hn_title_generator/train.py
@@ -239,12 +239,10 @@ async def main():
         name=MODEL_NAME,
         project=PROJECT,
         base_model=BASE_MODEL,
+        lora_config=art.LoRAConfig(alpha=8),
         _internal_config=art.dev.InternalModelConfig(
             init_args=art.dev.InitArgs(
                 gpu_memory_utilization=0.75,
-            ),
-            peft_args=art.dev.PeftArgs(
-                lora_alpha=8,
             ),
             trainer_args=art.dev.TrainerArgs(
                 max_grad_norm=0.1,

--- a/src/art/__init__.py
+++ b/src/art/__init__.py
@@ -58,6 +58,7 @@ from . import dev
 from .auto_trajectory import auto_trajectory, capture_auto_trajectory
 from .backend import Backend
 from .batches import trajectory_group_batches
+from .dev import LoRAConfig
 from .gather import gather_trajectories, gather_trajectory_groups
 from .model import Model, TrainableModel
 from .serverless import ServerlessBackend
@@ -85,6 +86,7 @@ __all__ = [
     "Backend",
     "LocalBackend",
     "LocalTrainResult",
+    "LoRAConfig",
     "ServerlessBackend",
     "ServerlessTrainResult",
     "Messages",

--- a/src/art/dev/__init__.py
+++ b/src/art/dev/__init__.py
@@ -1,7 +1,9 @@
 from .engine import EngineArgs
 from .model import (
+    BackendModelConfig,
     InitArgs,
     InternalModelConfig,
+    LoRAConfig,
     PeftArgs,
     TinkerArgs,
     TinkerNativeArgs,
@@ -14,8 +16,10 @@ from .validate import is_dedicated_mode, validate_dedicated_config
 
 __all__ = [
     "EngineArgs",
+    "BackendModelConfig",
     "InternalModelConfig",
     "InitArgs",
+    "LoRAConfig",
     "PeftArgs",
     "TinkerArgs",
     "TinkerNativeArgs",

--- a/src/art/dev/get_model_config.py
+++ b/src/art/dev/get_model_config.py
@@ -1,9 +1,11 @@
 from ..megatron.model_support import default_target_modules_for_model
 from .engine import EngineArgs
 from .model import (
+    PEFT_ARGS_MIGRATION_MESSAGE,
+    BackendModelConfig,
     InitArgs,
     InternalModelConfig,
-    PeftArgs,
+    LoRAConfig,
     TrainerArgs,
 )
 from .validate import is_dedicated_mode
@@ -17,11 +19,14 @@ def get_model_config(
     base_model: str,
     output_dir: str,
     config: "InternalModelConfig | None",
-) -> "InternalModelConfig":
+    lora_config: "LoRAConfig | None" = None,
+) -> "BackendModelConfig":
     from ..local.checkpoints import get_last_checkpoint_dir
 
     if config is None:
         config = InternalModelConfig()
+    if "peft_args" in config:
+        raise ValueError(PEFT_ARGS_MIGRATION_MESSAGE)
 
     dedicated = is_dedicated_mode(config)
     rollout_weights_mode = config.get("rollout_weights_mode", "lora")
@@ -36,7 +41,6 @@ def get_model_config(
         max_seq_length=32768,
         model_name=base_model,
     )
-    target_modules = default_target_modules(base_model)
     engine_args = EngineArgs(
         allowed_local_media_path="/tmp",
         enable_sleep_mode=enable_sleep_mode,
@@ -47,18 +51,17 @@ def get_model_config(
     init_args.update(config.get("init_args", {}))
     if last_checkpoint_dir := get_last_checkpoint_dir(output_dir):
         init_args["model_name"] = last_checkpoint_dir
-    peft_args = PeftArgs(
-        lora_alpha=16,
-        r=8,
+    merged_lora_config = LoRAConfig(
         random_state=3407,
-        target_modules=target_modules,
+        target_modules=default_target_modules(base_model),
         use_gradient_checkpointing="unsloth",
     )
-    peft_args.update(config.get("peft_args", {}))
+    if lora_config:
+        merged_lora_config.update(lora_config)
     if rollout_weights_mode == "lora" and "lora_target_modules" not in config.get(
         "engine_args", {}
     ):
-        engine_args["lora_target_modules"] = peft_args["target_modules"]
+        engine_args["lora_target_modules"] = merged_lora_config["target_modules"]
     trainer_args = TrainerArgs(
         adam_beta1=0.9,
         adam_beta2=0.99,
@@ -78,10 +81,10 @@ def get_model_config(
         weight_decay=0.1,
     )
     trainer_args.update(config.get("trainer_args", {}))
-    result = InternalModelConfig(
+    result = BackendModelConfig(
         init_args=init_args,
         engine_args=engine_args,
-        peft_args=peft_args,
+        lora_config=merged_lora_config,
         rollout_weights_mode=rollout_weights_mode,
         tinker_args=config.get("tinker_args"),
         trainer_args=trainer_args,

--- a/src/art/dev/model.py
+++ b/src/art/dev/model.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Literal
+from typing import Literal, NoReturn
 
 from typing_extensions import Required, TypedDict
 
@@ -115,7 +115,6 @@ class InternalModelConfig(TypedDict, total=False):
     Args:
         init: Arguments for initializing an Unsloth FastLanguageModel.
         engine: Arguments for the vLLM engine.
-        peft: Arguments for creating an Unsloth PEFT model wrapper.
         tinker: Arguments for the Tinker training client.
         trainer: Arguments for the GRPO trainer.
         trainer_gpu_ids: GPU IDs for training (e.g., [0]). When set with
@@ -142,7 +141,6 @@ class InternalModelConfig(TypedDict, total=False):
 
     init_args: "InitArgs"
     engine_args: "EngineArgs"
-    peft_args: "PeftArgs"
     tinker_args: "TinkerArgs | None"
     tinker_native_args: "TinkerNativeArgs | None"
     trainer_args: "TrainerArgs"
@@ -155,6 +153,10 @@ class InternalModelConfig(TypedDict, total=False):
     chat_template_content_format: str
     chat_template_tool_schema_format: Literal["default", "vllm_openai"]
     allow_unvalidated_arch: bool
+
+
+class BackendModelConfig(InternalModelConfig, total=False):
+    lora_config: "LoRAConfig"
 
 
 class TinkerArgs(TypedDict, total=False):
@@ -203,11 +205,11 @@ class InitArgs(TypedDict, total=False):
     use_async: bool
 
 
-class PeftArgs(TypedDict, total=False):
-    r: int
+class LoRAConfig(TypedDict, total=False):
+    rank: int
     target_modules: list[str]
-    lora_alpha: int
-    lora_dropout: int
+    alpha: int
+    dropout: float
     bias: str
     layers_to_transform: list[int] | None
     layers_pattern: str | None
@@ -216,9 +218,16 @@ class PeftArgs(TypedDict, total=False):
     max_seq_length: int
     use_rslora: bool
     modules_to_save: list[str] | None
-    init_lora_weights: bool
+    init_weights: bool
     loftq_config: dict
     temporary_location: str
+
+
+PEFT_ARGS_MIGRATION_MESSAGE = "`peft_args` has been replaced by top-level `TrainableModel(lora_config=...)`. Rename keys: r->rank, lora_alpha->alpha, lora_dropout->dropout, init_lora_weights->init_weights. Keep these keys under lora_config: target_modules, bias, layers_to_transform, layers_pattern, use_gradient_checkpointing, random_state, max_seq_length, use_rslora, modules_to_save, loftq_config, temporary_location."
+
+
+def PeftArgs(*_: object, **__: object) -> NoReturn:
+    raise ValueError(PEFT_ARGS_MIGRATION_MESSAGE)
 
 
 class TrainerArgs(TypedDict, total=False):

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -410,6 +410,7 @@ class LocalBackend(Backend):
                 base_model=model.base_model,
                 output_dir=get_model_dir(model=model, art_path=self._path),
                 config=model._internal_config,
+                lora_config=model.lora_config,
             )
             validate_dedicated_config(config)
             dedicated = is_dedicated_mode(config)

--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 import math
 from typing import Any, Literal, cast
 
@@ -1376,17 +1376,20 @@ def wrap_shared_experts_mlp(
 def apply_lora_adapters(
     model: Sequence[torch.nn.Module],
     provider: GPTModelProvider,
+    lora_config: Mapping[str, Any] | None = None,
 ) -> list[torch.nn.Module]:
+    lora_config = lora_config or {}
     provider = cast(Any, provider)
     handler = provider._art_model_support_handler
     spec = provider._art_model_support_spec
-    target_modules = list(spec.default_target_modules)
-    rank = default_lora_rank_for_handler(handler)
+    target_modules = list(
+        lora_config.get("target_modules", spec.default_target_modules)
+    )
     handler.apply_lora_adapters(
         model,
         provider,
         target_modules=target_modules,
-        rank=rank,
-        alpha=LORA_ALPHA,
+        rank=lora_config.get("rank", default_lora_rank_for_handler(handler)),
+        alpha=lora_config.get("alpha", LORA_ALPHA),
     )
     return list(model)

--- a/src/art/megatron/runtime/backend.py
+++ b/src/art/megatron/runtime/backend.py
@@ -28,6 +28,7 @@ class MegatronBackend(LocalBackend):
                 base_model=model.base_model,
                 output_dir=get_model_dir(model=model, art_path=self._path),
                 config=model._internal_config,
+                lora_config=model.lora_config,
             )
             self._services[model.name] = MegatronService(
                 model_name=model.name,

--- a/src/art/megatron/service.py
+++ b/src/art/megatron/service.py
@@ -2,6 +2,7 @@ import asyncio
 from dataclasses import dataclass, field
 import gc
 import importlib
+import json
 import os
 from pathlib import Path
 import shutil
@@ -71,8 +72,7 @@ class _RuntimeRequestKwargs(TypedDict, total=False):
 def create_identity_lora(
     base_model: str,
     lora_path: str,
-    rank: int | None = None,
-    lora_alpha: int = LORA_ALPHA,
+    lora_config: dev.LoRAConfig | None = None,
     random_state: int | None = None,
     allow_unvalidated_arch: bool = False,
 ) -> None:
@@ -85,8 +85,7 @@ def create_identity_lora(
     Args:
         base_model: HuggingFace model identifier.
         lora_path: Directory to save the adapter files.
-        rank: LoRA rank. Defaults to rank 1 for MoE models and rank 8 for dense models.
-        lora_alpha: LoRA alpha scaling factor.
+        lora_config: Normalized ART LoRA configuration.
     """
     from unittest.mock import patch
 
@@ -98,13 +97,16 @@ def create_identity_lora(
 
     if random_state is not None:
         torch.manual_seed(random_state)
-    target_modules = default_target_modules(base_model)
+    resolved_lora_config = lora_config or dev.LoRAConfig()
+    target_modules = resolved_lora_config.get(
+        "target_modules", default_target_modules(base_model)
+    )
     handler = get_model_support_handler(
         base_model,
         allow_unvalidated_arch=allow_unvalidated_arch,
     )
-    if rank is None:
-        rank = default_lora_rank_for_handler(handler)
+    rank = resolved_lora_config.get("rank", default_lora_rank_for_handler(handler))
+    alpha = resolved_lora_config.get("alpha", LORA_ALPHA)
     base_config = AutoConfig.from_pretrained(base_model, trust_remote_code=True)
     model_config = handler.identity_lora_model_config(base_config)
     with init_empty_weights():
@@ -113,10 +115,10 @@ def create_identity_lora(
         )
     model.name_or_path = base_model
 
-    lora_config = LoraConfig(
+    peft_lora_config = LoraConfig(
         base_model_name_or_path=base_model,
         r=rank,
-        lora_alpha=lora_alpha,
+        lora_alpha=alpha,
         target_modules=[],
         target_parameters=handler.identity_lora_target_parameters(
             model,
@@ -137,7 +139,7 @@ def create_identity_lora(
         return orig_to(module, *args, **kwargs)
 
     with patch.object(torch.nn.Module, "to", _skip_meta_to):
-        peft_model = get_peft_model(model, lora_config)
+        peft_model = get_peft_model(model, peft_lora_config)
 
     os.makedirs(lora_path, exist_ok=True)
     peft_model.save_pretrained(lora_path)
@@ -146,7 +148,7 @@ def create_identity_lora(
     final_config = LoraConfig(
         base_model_name_or_path=base_model,
         r=rank,
-        lora_alpha=lora_alpha,
+        lora_alpha=alpha,
         target_modules=target_modules,
         bias="none",
     ).to_dict()
@@ -217,11 +219,16 @@ class MegatronService:
         return f"http://{self._vllm_host}:{self._vllm_port}"
 
     def _megatron_random_state(self) -> int | None:
-        for config_key in ("peft_args", "init_args"):
-            random_state = self.config.get(config_key, {}).get("random_state")
-            if random_state is not None:
-                return int(random_state)
+        random_state = self._lora_config.get("random_state") or self.config.get(
+            "init_args", {}
+        ).get("random_state")
+        if random_state is not None:
+            return int(random_state)
         return None
+
+    @property
+    def _lora_config(self) -> dev.LoRAConfig:
+        return cast(dev.BackendModelConfig, self.config).get("lora_config", {})
 
     @property
     def _allow_unvalidated_arch(self) -> bool:
@@ -332,11 +339,14 @@ class MegatronService:
             self.base_model,
             allow_unvalidated_arch=self._allow_unvalidated_arch,
         )
+        lora_config = self._lora_config
         return LoraConfig(
             base_model_name_or_path=self.base_model,
-            r=default_lora_rank_for_handler(handler),
-            lora_alpha=LORA_ALPHA,
-            target_modules=default_target_modules(self.base_model),
+            r=lora_config.get("rank", default_lora_rank_for_handler(handler)),
+            lora_alpha=lora_config.get("alpha", LORA_ALPHA),
+            target_modules=lora_config.get(
+                "target_modules", default_target_modules(self.base_model)
+            ),
             bias="none",
         )
 
@@ -356,6 +366,7 @@ class MegatronService:
         create_identity_lora(
             self.base_model,
             lora_path,
+            lora_config=self._lora_config,
             random_state=self._megatron_random_state(),
             allow_unvalidated_arch=self._allow_unvalidated_arch,
         )
@@ -670,6 +681,7 @@ class MegatronService:
             num_gpus = torch.cuda.device_count()
         jobs_dir, _training_log_dir, wake_lock_path = self._megatron_runtime_paths()
         env["MODEL_IDENTIFIER"] = self.base_model
+        env["ART_MEGATRON_LORA_CONFIG"] = json.dumps(self._lora_config)
         if self._allow_unvalidated_arch:
             env["ART_MEGATRON_ALLOW_UNVALIDATED_ARCH"] = "1"
         env["ART_MEGATRON_JOBS_DIR"] = jobs_dir

--- a/src/art/megatron/train.py
+++ b/src/art/megatron/train.py
@@ -160,11 +160,12 @@ def _register_trainable_parameter_mode(
     provider: Any,
     *,
     trainable_parameter_mode: Literal["lora", "base_model"],
+    lora_config: dev.LoRAConfig | None,
 ) -> None:
     if trainable_parameter_mode == "lora":
         provider.register_pre_wrap_hook(freeze_model)
         provider.register_pre_wrap_hook(
-            lambda chunks: apply_lora_adapters(chunks, provider)
+            lambda chunks: apply_lora_adapters(chunks, provider, lora_config)
         )
         return
     if trainable_parameter_mode == "base_model":
@@ -323,6 +324,7 @@ def build_training_runtime(
     print_env: bool = True,
     build_optimizer: bool = True,
     trainable_parameter_mode: Literal["lora", "base_model"] = "lora",
+    lora_config: dev.LoRAConfig | None = None,
     allow_unvalidated_arch: bool = False,
 ) -> TrainingRuntime:
     if random_state := os.environ.get("ART_MEGATRON_RANDOM_STATE"):
@@ -347,6 +349,7 @@ def build_training_runtime(
     _register_trainable_parameter_mode(
         provider,
         trainable_parameter_mode=trainable_parameter_mode,
+        lora_config=lora_config,
     )
 
     model = cast(
@@ -1436,6 +1439,9 @@ def main() -> None:
     runtime = build_training_runtime(
         model_identifier=os.environ.get("MODEL_IDENTIFIER", DEFAULT_MODEL_IDENTIFIER),
         build_optimizer=False,
+        lora_config=cast(
+            dev.LoRAConfig, json.loads(os.environ.get("ART_MEGATRON_LORA_CONFIG", "{}"))
+        ),
         allow_unvalidated_arch=os.environ.get(
             "ART_MEGATRON_ALLOW_UNVALIDATED_ARCH", ""
         ).lower()

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -1012,6 +1012,7 @@ class Model(
 
 class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateType]):
     base_model: str
+    lora_config: dev.LoRAConfig | None = None
     # Override discriminator field for FastAPI serialization
     trainable: bool = True
 
@@ -1029,6 +1030,7 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
         run_id: str | None = None,
         config: ModelConfig | None = None,
         base_model: str,
+        lora_config: dev.LoRAConfig | None = None,
         base_path: str = ".art",
         report_metrics: list[str] | None = None,
         _internal_config: dev.InternalModelConfig | None = None,
@@ -1042,6 +1044,7 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
             id=id,
             config=config,
             base_model=base_model,
+            lora_config=lora_config,
             base_path=base_path,
             report_metrics=report_metrics,
             **kwargs,
@@ -1109,6 +1112,7 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
         id: str | None = None,
         config: None = None,
         base_model: str,
+        lora_config: dev.LoRAConfig | None = None,
         base_path: str = ".art",
         report_metrics: list[str] | None = None,
         _internal_config: dev.InternalModelConfig | None = None,
@@ -1124,6 +1128,7 @@ class TrainableModel(Model[ModelConfig, StateType], Generic[ModelConfig, StateTy
         id: str | None = None,
         config: ModelConfig,
         base_model: str,
+        lora_config: dev.LoRAConfig | None = None,
         base_path: str = ".art",
         report_metrics: list[str] | None = None,
         _internal_config: dev.InternalModelConfig | None = None,

--- a/src/art/tinker/backend.py
+++ b/src/art/tinker/backend.py
@@ -51,6 +51,7 @@ class TinkerBackend(LocalBackend):
                 base_model=model.base_model,
                 output_dir=get_model_dir(model=model, art_path=self._path),
                 config=model._internal_config,
+                lora_config=model.lora_config,
             )
             config["tinker_args"] = config.get("tinker_args") or TinkerArgs(
                 renderer_name=get_renderer_name(model.base_model)

--- a/src/art/unsloth/service.py
+++ b/src/art/unsloth/service.py
@@ -51,6 +51,20 @@ from .train import (
 logger = logging.getLogger(__name__)
 
 
+def _peft_args_from_lora_config(lora_config: dev.LoRAConfig) -> dict[str, Any]:
+    aliases = {
+        "rank": "r",
+        "alpha": "lora_alpha",
+        "dropout": "lora_dropout",
+        "init_weights": "init_lora_weights",
+    }
+    return {
+        "r": 8,
+        "lora_alpha": 16,
+        **{aliases.get(k, k): v for k, v in lora_config.items()},
+    }
+
+
 class _RuntimeRequestKwargs(TypedDict, total=False):
     headers: dict[str, str]
 
@@ -874,6 +888,8 @@ class UnslothService:
         init_args["model_name"] = checkpoint_dir or self.base_model
         return create_unsloth_train_context(
             init_args=init_args,
-            peft_args=cast(dict[str, Any], self.config.get("peft_args", {})),
+            peft_args=_peft_args_from_lora_config(
+                cast(dev.BackendModelConfig, self.config).get("lora_config", {})
+            ),
             trainer_args=cast(dict[str, Any], self.config.get("trainer_args", {})),
         )

--- a/tests/unit/test_dedicated_config.py
+++ b/tests/unit/test_dedicated_config.py
@@ -4,7 +4,8 @@ import tempfile
 
 import pytest
 
-from art.dev.model import InternalModelConfig
+from art.dev.get_model_config import get_model_config
+from art.dev.model import InternalModelConfig, LoRAConfig, PeftArgs
 from art.dev.validate import is_dedicated_mode, validate_dedicated_config
 
 
@@ -134,8 +135,6 @@ def test_dedicated_rejects_fast_inference_false():
 
 
 def test_get_model_config_shared_mode():
-    from art.dev.get_model_config import get_model_config
-
     with tempfile.TemporaryDirectory() as tmpdir:
         result = get_model_config("test-model", tmpdir, None)
         assert "trainer_gpu_ids" not in result
@@ -143,7 +142,7 @@ def test_get_model_config_shared_mode():
         assert result["engine_args"]["enable_sleep_mode"] is True
         assert "fast_inference" not in result["init_args"]
         assert result["rollout_weights_mode"] == "lora"
-        assert result["peft_args"]["target_modules"] == [
+        assert result["lora_config"]["target_modules"] == [
             "q_proj",
             "k_proj",
             "v_proj",
@@ -159,11 +158,9 @@ def test_get_model_config_shared_mode():
     ["Qwen/Qwen3.5-35B-A3B", "Qwen/Qwen3.5-397B-A17B"],
 )
 def test_get_model_config_qwen3_5_moe_target_modules(base_model: str):
-    from art.dev.get_model_config import get_model_config
-
     with tempfile.TemporaryDirectory() as tmpdir:
         result = get_model_config(base_model, tmpdir, None)
-        assert result["peft_args"]["target_modules"] == [
+        assert result["lora_config"]["target_modules"] == [
             "q_proj",
             "k_proj",
             "v_proj",
@@ -175,23 +172,29 @@ def test_get_model_config_qwen3_5_moe_target_modules(base_model: str):
         ]
 
 
-def test_get_model_config_preserves_user_target_modules():
-    from art.dev.get_model_config import get_model_config
-
+def test_get_model_config_preserves_user_lora_config_target_modules():
     with tempfile.TemporaryDirectory() as tmpdir:
         result = get_model_config(
             "Qwen/Qwen3.5-35B-A3B",
             tmpdir,
-            InternalModelConfig(
-                peft_args={"target_modules": ["custom_proj"]},  # type: ignore[typeddict-item]
-            ),
+            InternalModelConfig(),
+            lora_config=LoRAConfig(target_modules=["custom_proj"]),
         )
-        assert result["peft_args"]["target_modules"] == ["custom_proj"]
+        assert result["lora_config"]["target_modules"] == ["custom_proj"]
+
+
+def test_get_model_config_rejects_peft_args_with_migration_message():
+    with pytest.raises(ValueError, match="r->rank"):
+        PeftArgs(r=4)
+    with pytest.raises(ValueError, match="TrainableModel\\(lora_config"):
+        get_model_config(
+            "test-model",
+            "",
+            InternalModelConfig(peft_args={"r": 4}),  # type: ignore[typeddict-item]
+        )
 
 
 def test_get_model_config_dedicated_mode():
-    from art.dev.get_model_config import get_model_config
-
     with tempfile.TemporaryDirectory() as tmpdir:
         config = InternalModelConfig(
             trainer_gpu_ids=[0],
@@ -206,8 +209,6 @@ def test_get_model_config_dedicated_mode():
 
 
 def test_get_model_config_dedicated_preserves_user_engine_args():
-    from art.dev.get_model_config import get_model_config
-
     with tempfile.TemporaryDirectory() as tmpdir:
         config = InternalModelConfig(
             trainer_gpu_ids=[0],
@@ -221,8 +222,6 @@ def test_get_model_config_dedicated_preserves_user_engine_args():
 
 
 def test_get_model_config_preserves_rollout_weights_mode():
-    from art.dev.get_model_config import get_model_config
-
     with tempfile.TemporaryDirectory() as tmpdir:
         config = InternalModelConfig(
             trainer_gpu_ids=[0],


### PR DESCRIPTION
## Summary
- Add top-level `TrainableModel.lora_config` and public `art.LoRAConfig` with normalized LoRA field names.
- Replace `_internal_config.peft_args` with normalized internal `lora_config`, and raise a descriptive migration error for legacy `peft_args` / `art.dev.PeftArgs(...)` usage.
- Wire normalized LoRA config through the Megatron trainer, keeping PEFT-shaped names only at PEFT/Unsloth adapter boundaries, and update repo examples/tests.

## Tests
- `uv run ruff check src/art/dev/get_model_config.py src/art/dev/model.py src/art/model.py src/art/megatron/lora.py src/art/megatron/service.py src/art/megatron/train.py src/art/unsloth/service.py tests/unit/test_dedicated_config.py examples/hn_title_generator/train.py dev/yes-no-maybe.py`
- `uv run pytest tests/unit/test_dedicated_config.py -q`
- `uv run ty check src/art/dev/get_model_config.py src/art/dev/model.py src/art/model.py src/art/megatron/lora.py src/art/megatron/service.py src/art/megatron/train.py src/art/unsloth/service.py tests/unit/test_dedicated_config.py`
- commit hooks: `ruff`, `ruff format`, `ty check src tests`, `uv lock --check`