### PR TITLE
Reduce tau-bench rollout request overhead

### DIFF
--- a/src/art/tau_bench/client.py
+++ b/src/art/tau_bench/client.py
@@ -19,7 +19,8 @@ DEFAULT_RETRY_MAX_DELAY = 5.0
 def _default_limits() -> httpx.Limits:
     return httpx.Limits(
         max_connections=512,
-        max_keepalive_connections=0,
+        max_keepalive_connections=512,
+        keepalive_expiry=60.0,
     )
 
 
@@ -211,11 +212,20 @@ class TauBenchClient:
         self,
         env_id: str,
         action: str,
+        *,
+        include_info: bool | None = None,
     ) -> StepEnvironmentResponse:
         response = await self._request(
             "POST",
             f"/environments/{env_id}/step",
-            json={"action": action},
+            json={
+                key: value
+                for key, value in {
+                    "action": action,
+                    "include_info": include_info,
+                }.items()
+                if value is not None
+            },
             headers=self._auth_headers(),
         )
         _raise_for_status(response)

--- a/src/art/tau_bench/client.py
+++ b/src/art/tau_bench/client.py
@@ -212,20 +212,11 @@ class TauBenchClient:
         self,
         env_id: str,
         action: str,
-        *,
-        include_info: bool | None = None,
     ) -> StepEnvironmentResponse:
         response = await self._request(
             "POST",
             f"/environments/{env_id}/step",
-            json={
-                key: value
-                for key, value in {
-                    "action": action,
-                    "include_info": include_info,
-                }.items()
-                if value is not None
-            },
+            json={"action": action},
             headers=self._auth_headers(),
         )
         _raise_for_status(response)

--- a/src/art/tau_bench/rollout.py
+++ b/src/art/tau_bench/rollout.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from typing import Any, overload
 
 from openai import AsyncOpenAI
@@ -71,6 +72,7 @@ async def rollout(
 ) -> Trajectory:
     client = _get_default_client(client)
     task_id = scenario.task.id
+    env_create_started_at = time.perf_counter()
     async with client.environment(
         domain=scenario.domain,
         task_id=task_id,
@@ -83,6 +85,7 @@ async def rollout(
         retrieval_config=retrieval_config,
         retrieval_config_kwargs=retrieval_config_kwargs,
     ) as env:
+        env_create_wait_seconds = time.perf_counter() - env_create_started_at
         chat_completion_kwargs = chat_completion_kwargs or {}
         openai_client, model_name, cost_model = _completion_client_and_model(
             base_url_or_model,
@@ -101,14 +104,25 @@ async def rollout(
                 "cost/tinker/prefill": 0.0,
                 "cost/tinker/sample": 0.0,
                 "cost/user": 0.0,
+                "time/policy_chat_completion": 0.0,
+                "time/tau_bench/env_create_wait": env_create_wait_seconds,
+                "time/tau_bench/env_step_wait": 0.0,
+                "time/tau_bench/env_wait": 0.0,
             },
             metadata={"scenario_id": task_id},
+        )
+        _record_environment_timing(
+            trajectory,
+            env.info,
+            env_create_wait_seconds,
+            is_step=False,
         )
         terminated = False
         num_turns = 0
         while not terminated:
             if max_turns is not None and num_turns >= max_turns:
                 break
+            policy_started_at = time.perf_counter()
             chat_completion = await openai_client.chat.completions.create(
                 messages=trajectory.messages(),
                 model=model_name,
@@ -116,6 +130,9 @@ async def rollout(
                 tool_choice="auto",
                 tools=trajectory.tools or [],
                 **chat_completion_kwargs,
+            )
+            trajectory.metrics["time/policy_chat_completion"] += (
+                time.perf_counter() - policy_started_at
             )
             _record_tinker_costs(
                 trajectory,
@@ -129,7 +146,19 @@ async def rollout(
             if tool_calls:
                 for tool_call in tool_calls:
                     action = _tool_call_action(tool_call)
-                    step = await client.step_environment(env.id, action)
+                    env_step_started_at = time.perf_counter()
+                    step = await client.step_environment(
+                        env.id,
+                        action,
+                        include_info=False,
+                    )
+                    env_step_wait_seconds = time.perf_counter() - env_step_started_at
+                    _record_environment_timing(
+                        trajectory,
+                        step.info,
+                        env_step_wait_seconds,
+                        is_step=True,
+                    )
                     trajectory.messages_and_choices.append(
                         {
                             "role": "tool",
@@ -140,9 +169,18 @@ async def rollout(
                     trajectory.reward += step.reward
                     terminated = step.terminated
             else:
+                env_step_started_at = time.perf_counter()
                 step = await client.step_environment(
                     env.id,
                     choice.message.content or "",
+                    include_info=False,
+                )
+                env_step_wait_seconds = time.perf_counter() - env_step_started_at
+                _record_environment_timing(
+                    trajectory,
+                    step.info,
+                    env_step_wait_seconds,
+                    is_step=True,
                 )
                 if "user_message_cost" in step.info:
                     trajectory.metrics["cost/user"] += step.info["user_message_cost"]
@@ -210,6 +248,28 @@ def _record_tinker_costs(
         getattr(usage, "completion_tokens", None) or 0,
         pricing.sample,
     )
+
+
+def _record_environment_timing(
+    trajectory: Trajectory,
+    info: dict[str, Any],
+    client_wait_seconds: float,
+    *,
+    is_step: bool,
+) -> None:
+    trajectory.metrics["time/tau_bench/env_wait"] += client_wait_seconds
+    if is_step:
+        trajectory.metrics["time/tau_bench/env_step_wait"] += client_wait_seconds
+    timing = info.get("timing")
+    if not isinstance(timing, dict):
+        return
+    for key, value in timing.items():
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            continue
+        metric_key = f"time/tau_bench/{key}"
+        trajectory.metrics[metric_key] = trajectory.metrics.get(
+            metric_key, 0.0
+        ) + float(value)
 
 
 def default_user_llm_args(user_model_name: str) -> dict[str, Any]:

--- a/src/art/tau_bench/rollout.py
+++ b/src/art/tau_bench/rollout.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import time
 from typing import Any, overload
 
 from openai import AsyncOpenAI
@@ -72,7 +71,6 @@ async def rollout(
 ) -> Trajectory:
     client = _get_default_client(client)
     task_id = scenario.task.id
-    env_create_started_at = time.perf_counter()
     async with client.environment(
         domain=scenario.domain,
         task_id=task_id,
@@ -85,7 +83,6 @@ async def rollout(
         retrieval_config=retrieval_config,
         retrieval_config_kwargs=retrieval_config_kwargs,
     ) as env:
-        env_create_wait_seconds = time.perf_counter() - env_create_started_at
         chat_completion_kwargs = chat_completion_kwargs or {}
         openai_client, model_name, cost_model = _completion_client_and_model(
             base_url_or_model,
@@ -104,25 +101,14 @@ async def rollout(
                 "cost/tinker/prefill": 0.0,
                 "cost/tinker/sample": 0.0,
                 "cost/user": 0.0,
-                "time/policy_chat_completion": 0.0,
-                "time/tau_bench/env_create_wait": env_create_wait_seconds,
-                "time/tau_bench/env_step_wait": 0.0,
-                "time/tau_bench/env_wait": 0.0,
             },
             metadata={"scenario_id": task_id},
-        )
-        _record_environment_timing(
-            trajectory,
-            env.info,
-            env_create_wait_seconds,
-            is_step=False,
         )
         terminated = False
         num_turns = 0
         while not terminated:
             if max_turns is not None and num_turns >= max_turns:
                 break
-            policy_started_at = time.perf_counter()
             chat_completion = await openai_client.chat.completions.create(
                 messages=trajectory.messages(),
                 model=model_name,
@@ -130,9 +116,6 @@ async def rollout(
                 tool_choice="auto",
                 tools=trajectory.tools or [],
                 **chat_completion_kwargs,
-            )
-            trajectory.metrics["time/policy_chat_completion"] += (
-                time.perf_counter() - policy_started_at
             )
             _record_tinker_costs(
                 trajectory,
@@ -146,18 +129,10 @@ async def rollout(
             if tool_calls:
                 for tool_call in tool_calls:
                     action = _tool_call_action(tool_call)
-                    env_step_started_at = time.perf_counter()
                     step = await client.step_environment(
                         env.id,
                         action,
                         include_info=False,
-                    )
-                    env_step_wait_seconds = time.perf_counter() - env_step_started_at
-                    _record_environment_timing(
-                        trajectory,
-                        step.info,
-                        env_step_wait_seconds,
-                        is_step=True,
                     )
                     trajectory.messages_and_choices.append(
                         {
@@ -169,18 +144,10 @@ async def rollout(
                     trajectory.reward += step.reward
                     terminated = step.terminated
             else:
-                env_step_started_at = time.perf_counter()
                 step = await client.step_environment(
                     env.id,
                     choice.message.content or "",
                     include_info=False,
-                )
-                env_step_wait_seconds = time.perf_counter() - env_step_started_at
-                _record_environment_timing(
-                    trajectory,
-                    step.info,
-                    env_step_wait_seconds,
-                    is_step=True,
                 )
                 if "user_message_cost" in step.info:
                     trajectory.metrics["cost/user"] += step.info["user_message_cost"]
@@ -248,28 +215,6 @@ def _record_tinker_costs(
         getattr(usage, "completion_tokens", None) or 0,
         pricing.sample,
     )
-
-
-def _record_environment_timing(
-    trajectory: Trajectory,
-    info: dict[str, Any],
-    client_wait_seconds: float,
-    *,
-    is_step: bool,
-) -> None:
-    trajectory.metrics["time/tau_bench/env_wait"] += client_wait_seconds
-    if is_step:
-        trajectory.metrics["time/tau_bench/env_step_wait"] += client_wait_seconds
-    timing = info.get("timing")
-    if not isinstance(timing, dict):
-        return
-    for key, value in timing.items():
-        if isinstance(value, bool) or not isinstance(value, int | float):
-            continue
-        metric_key = f"time/tau_bench/{key}"
-        trajectory.metrics[metric_key] = trajectory.metrics.get(
-            metric_key, 0.0
-        ) + float(value)
 
 
 def default_user_llm_args(user_model_name: str) -> dict[str, Any]:

--- a/src/art/tau_bench/rollout.py
+++ b/src/art/tau_bench/rollout.py
@@ -129,11 +129,7 @@ async def rollout(
             if tool_calls:
                 for tool_call in tool_calls:
                     action = _tool_call_action(tool_call)
-                    step = await client.step_environment(
-                        env.id,
-                        action,
-                        include_info=False,
-                    )
+                    step = await client.step_environment(env.id, action)
                     trajectory.messages_and_choices.append(
                         {
                             "role": "tool",
@@ -147,7 +143,6 @@ async def rollout(
                 step = await client.step_environment(
                     env.id,
                     choice.message.content or "",
-                    include_info=False,
                 )
                 if "user_message_cost" in step.info:
                     trajectory.metrics["cost/user"] += step.info["user_message_cost"]

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -20,7 +20,7 @@ from art.tau_bench.client import (
 )
 
 
-def test_client_uses_short_lived_connection_pool_by_default(
+def test_client_reuses_connections_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     seen: dict[str, Any] = {}
@@ -40,7 +40,7 @@ def test_client_uses_short_lived_connection_pool_by_default(
     limits = seen["transport_kwargs"]["limits"]
     assert isinstance(limits, httpx.Limits)
     assert limits.max_connections == 512
-    assert limits.max_keepalive_connections == 0
+    assert limits.max_keepalive_connections == 512
     assert seen["transport_kwargs"]["retries"] == 2
     assert isinstance(seen["timeout"], httpx.Timeout)
 
@@ -172,6 +172,36 @@ async def test_client_sends_create_environment_idle_timeout() -> None:
 
 
 @pytest.mark.asyncio
+async def test_client_sends_step_environment_compact_info_flag() -> None:
+    seen: dict[str, Any] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["json"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "env-1",
+                "observation": "user: hello",
+                "reward": 0.0,
+                "terminated": False,
+                "truncated": False,
+                "info": {},
+            },
+        )
+
+    http_client = httpx.AsyncClient(
+        base_url="http://tau.test",
+        transport=httpx.MockTransport(handler),
+    )
+    client = TauBenchClient(api_key="secret", http_client=http_client)
+    await client.step_environment("env-1", "done()", include_info=False)
+    await client.close()
+    await http_client.aclose()
+
+    assert seen["json"] == {"action": "done()", "include_info": False}
+
+
+@pytest.mark.asyncio
 async def test_module_default_client_can_be_replaced(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -231,8 +261,13 @@ class FakeTauBenchClient(TauBenchClient):
         )
 
     async def step_environment(
-        self, env_id: str, action: str
+        self,
+        env_id: str,
+        action: str,
+        *,
+        include_info: bool | None = None,
     ) -> StepEnvironmentResponse:
+        self.step_include_info = include_info
         return StepEnvironmentResponse(
             id=env_id,
             observation=f"user: saw {action}",
@@ -289,6 +324,7 @@ async def test_rollout_supports_string_model_args(
     assert trajectory.metrics["cost/user"] == 0.25
     assert client.deleted == ["env-1"]
     assert client.create_kwargs["user_llm"] == "gpt-4.1-2025-04-14"
+    assert client.step_include_info is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -141,23 +141,11 @@ async def test_client_retries_transport_errors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_client_sends_optional_request_fields() -> None:
+async def test_client_sends_create_environment_idle_timeout() -> None:
     seen: dict[str, Any] = {}
 
     async def handler(request: httpx.Request) -> httpx.Response:
-        seen[request.url.path] = json.loads(request.content)
-        if request.url.path.endswith("/step"):
-            return httpx.Response(
-                200,
-                json={
-                    "id": "env-1",
-                    "observation": "user: hello",
-                    "reward": 0.0,
-                    "terminated": False,
-                    "truncated": False,
-                    "info": {},
-                },
-            )
+        seen["json"] = json.loads(request.content)
         return httpx.Response(
             200,
             json={"id": "env-1", "observation": "user: hello", "info": {}},
@@ -173,18 +161,13 @@ async def test_client_sends_optional_request_fields() -> None:
         task_id="task_001",
         idle_timeout_seconds=120,
     )
-    await client.step_environment("env-1", "done()", include_info=False)
     await client.close()
     await http_client.aclose()
 
-    assert seen["/environments"] == {
+    assert seen["json"] == {
         "domain": "telecom",
         "task_id": "task_001",
         "idle_timeout_seconds": 120,
-    }
-    assert seen["/environments/env-1/step"] == {
-        "action": "done()",
-        "include_info": False,
     }
 
 
@@ -248,13 +231,8 @@ class FakeTauBenchClient(TauBenchClient):
         )
 
     async def step_environment(
-        self,
-        env_id: str,
-        action: str,
-        *,
-        include_info: bool | None = None,
+        self, env_id: str, action: str
     ) -> StepEnvironmentResponse:
-        self.step_include_info = include_info
         return StepEnvironmentResponse(
             id=env_id,
             observation=f"user: saw {action}",
@@ -311,7 +289,6 @@ async def test_rollout_supports_string_model_args(
     assert trajectory.metrics["cost/user"] == 0.25
     assert client.deleted == ["env-1"]
     assert client.create_kwargs["user_llm"] == "gpt-4.1-2025-04-14"
-    assert client.step_include_info is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -141,11 +141,23 @@ async def test_client_retries_transport_errors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_client_sends_create_environment_idle_timeout() -> None:
+async def test_client_sends_optional_request_fields() -> None:
     seen: dict[str, Any] = {}
 
     async def handler(request: httpx.Request) -> httpx.Response:
-        seen["json"] = json.loads(request.content)
+        seen[request.url.path] = json.loads(request.content)
+        if request.url.path.endswith("/step"):
+            return httpx.Response(
+                200,
+                json={
+                    "id": "env-1",
+                    "observation": "user: hello",
+                    "reward": 0.0,
+                    "terminated": False,
+                    "truncated": False,
+                    "info": {},
+                },
+            )
         return httpx.Response(
             200,
             json={"id": "env-1", "observation": "user: hello", "info": {}},
@@ -161,44 +173,19 @@ async def test_client_sends_create_environment_idle_timeout() -> None:
         task_id="task_001",
         idle_timeout_seconds=120,
     )
-    await client.close()
-    await http_client.aclose()
-
-    assert seen["json"] == {
-        "domain": "telecom",
-        "task_id": "task_001",
-        "idle_timeout_seconds": 120,
-    }
-
-
-@pytest.mark.asyncio
-async def test_client_sends_step_environment_compact_info_flag() -> None:
-    seen: dict[str, Any] = {}
-
-    async def handler(request: httpx.Request) -> httpx.Response:
-        seen["json"] = json.loads(request.content)
-        return httpx.Response(
-            200,
-            json={
-                "id": "env-1",
-                "observation": "user: hello",
-                "reward": 0.0,
-                "terminated": False,
-                "truncated": False,
-                "info": {},
-            },
-        )
-
-    http_client = httpx.AsyncClient(
-        base_url="http://tau.test",
-        transport=httpx.MockTransport(handler),
-    )
-    client = TauBenchClient(api_key="secret", http_client=http_client)
     await client.step_environment("env-1", "done()", include_info=False)
     await client.close()
     await http_client.aclose()
 
-    assert seen["json"] == {"action": "done()", "include_info": False}
+    assert seen["/environments"] == {
+        "domain": "telecom",
+        "task_id": "task_001",
+        "idle_timeout_seconds": 120,
+    }
+    assert seen["/environments/env-1/step"] == {
+        "action": "done()",
+        "include_info": False,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Reuse HTTP connections in the tau-bench client instead of forcing a new connection per request.
- Keep rollout step requests unchanged after profiling showed compact info responses only saved about 9-10ms/request and were not worth the added API/client complexity.

## Test plan
- `uv run --python 3.11 pytest tests/unit/test_tau_bench_client.py`
- Live validation with the paired tau-bench server branch: full 40-scenario x 2-rollout profile completed with 0 exceptions.