### PR TITLE
Fix vLLM V1 unsupported engine args

### DIFF
--- a/src/art/dev/engine.py
+++ b/src/art/dev/engine.py
@@ -34,7 +34,6 @@ class EngineArgs(TypedDict, total=False):
     block_size: int | None
     enable_prefix_caching: bool | None
     disable_sliding_window: bool
-    use_v2_block_manager: bool
     swap_space: float  # GiB
     cpu_offload_gb: float  # GiB
     gpu_memory_utilization: float
@@ -78,8 +77,6 @@ class EngineArgs(TypedDict, total=False):
     lora_dtype: str | None
     max_cpu_loras: int | None
     device: str
-    num_scheduler_steps: int
-    multi_step_stream_outputs: bool
     ray_workers_use_nsight: bool
     num_gpu_blocks_override: int | None
     num_lookahead_slots: int

--- a/src/art/guided_completion.py
+++ b/src/art/guided_completion.py
@@ -42,8 +42,6 @@ def get_guided_completion_params(
     Given a completion from a teacher model, returns chat completion params that can be used to guide a student model's response.
     Useful for RL-based distillation.
 
-    When guiding the student model's completion, remember to set `num_scheduler_steps` to 1.
-
     Args:
         completion: The completion of a teacher model
         base_tools: The base tools available to the teacher model


### PR DESCRIPTION
## Summary

Closes #696
Closes #697

## Changes

- Ignore engine/server args that are not supported by the installed vLLM runtime parser instead of passing them through to `vllm serve` and crashing.
- Remove V0-only scheduler args from ART's `EngineArgs` type surface and stale guided-completion guidance for `num_scheduler_steps`.
- Add a regression test for ignoring `num_scheduler_steps` while preserving supported args.
- Confirmed #696 is already addressed on current main by the strict backend pin `torchao==0.16.0`; local `peft`/`torchao` compatibility check passes with the current lockfile.

## Test plan

- `uv run pytest tests/unit/test_vllm_runtime_args.py tests/unit/test_dedicated_config.py -q`
- `uv run ruff check vllm_runtime/src/art_vllm_runtime/dedicated_server.py src/art/dev/engine.py src/art/guided_completion.py tests/unit/test_vllm_runtime_args.py`
- `uv run ruff format --check vllm_runtime/src/art_vllm_runtime/dedicated_server.py src/art/dev/engine.py src/art/guided_completion.py tests/unit/test_vllm_runtime_args.py`
- `python -m py_compile vllm_runtime/src/art_vllm_runtime/dedicated_server.py tests/unit/test_vllm_runtime_args.py src/art/dev/engine.py src/art/guided_completion.py`
- `uv run ty check src/art/dev/engine.py src/art/guided_completion.py tests/unit/test_vllm_runtime_args.py`

Note: a full `ty check` including `vllm_runtime/src/art_vllm_runtime/dedicated_server.py` is not runnable from the root env because vLLM is intentionally isolated in the runtime project.