### PR TITLE
chore: Improve Megatron runtime typing

### DIFF
--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -229,7 +229,9 @@ def _set_lora_shard_strategy_metadata(
 
 def _exported_shard_dim(param: torch.nn.Parameter) -> int:
     assert hasattr(param, "lora_tp_shard_dim")
-    axis = _normalize_axis(getattr(param, "lora_tp_shard_dim"), param.ndim)  # ty: ignore[unresolved-attribute]
+    axis = _normalize_axis(
+        getattr(param, "lora_tp_shard_dim"), param.ndim
+    )  # ty: ignore[unresolved-attribute]
     # LoRA exports always serialize a 2D tensor:
     # - non-expert params export `param.T`
     # - expert params export `param[expert].T`
@@ -260,9 +262,9 @@ class LoRA(torch.nn.Module):
         allreduce: bool = True,
     ) -> None:
         super().__init__()
-        assert num_local_experts == 1 or "{expert}" in adapter_model_prefix, (
-            "adapter_model_prefix must contain the '{expert}' format placeholder if num_local_experts > 1"
-        )
+        assert (
+            num_local_experts == 1 or "{expert}" in adapter_model_prefix
+        ), "adapter_model_prefix must contain the '{expert}' format placeholder if num_local_experts > 1"
         self.adapter_model_prefix = adapter_model_prefix
         self.scale = alpha / rank
         self.A_T = torch.nn.Parameter(
@@ -293,9 +295,9 @@ class LoRA(torch.nn.Module):
         return self.A_T.shape[0] if self.A_T.ndim == 3 else 1
 
     def _broadcast_if_replicated(self, param: torch.nn.Parameter) -> None:
-        if not getattr(param, "lora_tp_replicated"):
+        if not param.lora_tp_replicated:  # type: ignore[unresolved-attribute]
             return
-        domain = getattr(param, "lora_shard_domain")
+        domain: ShardDomain = param.lora_shard_domain  # type: ignore[unresolved-attribute]
         world_size = _get_shard_world_size(domain)
         if world_size <= 1:
             return
@@ -304,8 +306,10 @@ class LoRA(torch.nn.Module):
             raise RuntimeError(
                 f"{self.adapter_model_prefix}: missing process group for replicated parameter domain={domain}"
             )
-        src = torch.distributed.get_global_rank(  # ty: ignore[possibly-missing-attribute]
-            group, 0
+        src = (
+            torch.distributed.get_global_rank(  # ty: ignore[possibly-missing-attribute]
+                group, 0
+            )
         )
         torch.distributed.broadcast(  # ty: ignore[possibly-missing-attribute]
             param.data,
@@ -369,9 +373,9 @@ class LoRA(torch.nn.Module):
         self.load_weight(weight, into=into)
 
     def load_weight(self, weight: torch.Tensor, *, into: torch.nn.Parameter) -> None:
-        domain: ShardDomain = getattr(into, "lora_shard_domain")
-        if getattr(into, "lora_tp_sharded"):
-            axis: int = getattr(into, "lora_tp_shard_dim")
+        domain: ShardDomain = into.lora_shard_domain  # type: ignore[unresolved-attribute]
+        if into.lora_tp_sharded:  # type: ignore[unresolved-attribute]
+            axis: int = into.lora_tp_shard_dim  # type: ignore[unresolved-attribute]
             axis = _normalize_axis(axis, weight.ndim)
             world_size = _get_shard_world_size(domain)
             rank = _get_shard_rank(domain)
@@ -513,11 +517,11 @@ class LoRA(torch.nn.Module):
                 raise RuntimeError(
                     f"LoRA param missing main_grad attribute for key '{key}'"
                 )
-            grad: torch.Tensor | None = getattr(param, "main_grad")
+            grad: torch.Tensor | None = param.main_grad  # type: ignore[unresolved-attribute]
             if grad is None:
                 raise RuntimeError(f"LoRA param main_grad is None for key '{key}'")
             if hasattr(grad, "_local_tensor"):
-                grad = cast(torch.Tensor, getattr(grad, "_local_tensor"))
+                grad = cast(torch.Tensor, grad._local_tensor)  # type: ignore[unresolved-attribute]
             local_grad = grad[expert] if expert is not None else grad
             grads[key] = local_grad.T
         return grads
@@ -526,9 +530,9 @@ class LoRA(torch.nn.Module):
         self, x: torch.Tensor, tokens_per_expert: list[int] | torch.Tensor | None = None
     ) -> torch.Tensor:
         if tokens_per_expert is not None:
-            assert self.num_local_experts > 1, (
-                "tokens_per_expert is only supported if num_local_experts > 1"
-            )
+            assert (
+                self.num_local_experts > 1
+            ), "tokens_per_expert is only supported if num_local_experts > 1"
             bsz = tokens_per_expert
             if isinstance(bsz, list):
                 bsz = torch.tensor(bsz, dtype=torch.int64, device="cpu")
@@ -627,13 +631,13 @@ class SelfAttentionLinearQKVLoRA(torch.nn.Module):
         total_out_features_per_rank = int(weight.shape[0])
         kv_out_features = self.provider.kv_channels * self.provider.num_query_groups
         tp_world_size = ps.get_tensor_model_parallel_world_size()
-        assert kv_out_features % tp_world_size == 0, (
-            "kv_out_features must be divisible by tensor parallel size"
-        )
+        assert (
+            kv_out_features % tp_world_size == 0
+        ), "kv_out_features must be divisible by tensor parallel size"
         q_out_features = self.provider.kv_channels * self.provider.num_attention_heads
-        assert q_out_features % tp_world_size == 0, (
-            "q_out_features must be divisible by tensor parallel size"
-        )
+        assert (
+            q_out_features % tp_world_size == 0
+        ), "q_out_features must be divisible by tensor parallel size"
         q_out_features_per_rank = q_out_features // tp_world_size
         kv_out_features_per_rank = kv_out_features // tp_world_size
         self.attention_output_gate = bool(
@@ -645,9 +649,9 @@ class SelfAttentionLinearQKVLoRA(torch.nn.Module):
         expected_q_out_features_per_rank = q_out_features_per_rank * (
             2 if self.attention_output_gate else 1
         )
-        assert q_and_gate_out_features_per_rank == expected_q_out_features_per_rank, (
-            "Unexpected per-rank QKV packing for this attention layout"
-        )
+        assert (
+            q_and_gate_out_features_per_rank == expected_q_out_features_per_rank
+        ), "Unexpected per-rank QKV packing for this attention layout"
         self.num_query_groups_per_partition = (
             self.provider.num_query_groups // tp_world_size
         )

--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -18,6 +18,7 @@ from megatron.core.tensor_parallel.mappings import (
     reduce_scatter_to_sequence_parallel_region,
 )
 from megatron.core.transformer.attention import SelfAttention
+from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.moe.experts import TEGroupedMLP
 from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
 from megatron.core.transformer.transformer_layer import TransformerLayer
@@ -25,9 +26,14 @@ from pydantic import BaseModel, ConfigDict
 import torch
 
 from .kernels.cute_grouped_lora_quack import (
-    quack_grouped_lora,
-    quack_grouped_lora_dual,
+    quack_grouped_lora as _quack_grouped_lora,
 )
+from .kernels.cute_grouped_lora_quack import (
+    quack_grouped_lora_dual as _quack_grouped_lora_dual,
+)
+
+quack_grouped_lora = cast(Any, _quack_grouped_lora)
+quack_grouped_lora_dual = cast(Any, _quack_grouped_lora_dual)
 
 MOE_LORA_RANK = 1
 DENSE_LORA_RANK = 8
@@ -73,6 +79,7 @@ def _get_shard_world_size(domain: ShardDomain) -> int:
     group = ps.get_expert_tensor_parallel_group(check_initialized=False)
     if group is None:
         return 1
+    assert isinstance(group, torch.distributed.ProcessGroup)
     return group.size()
 
 
@@ -84,6 +91,7 @@ def _get_shard_rank(domain: ShardDomain) -> int:
     group = ps.get_expert_tensor_parallel_group(check_initialized=False)
     if group is None:
         return 0
+    assert isinstance(group, torch.distributed.ProcessGroup)
     return group.rank()
 
 
@@ -138,6 +146,12 @@ def default_lora_rank_for_handler(handler: Any) -> int:
     return MOE_LORA_RANK if bool(getattr(handler, "is_moe", False)) else DENSE_LORA_RANK
 
 
+def _forward_backward_dw(linear: Any) -> None:
+    backward_dw = getattr(linear, "backward_dw", None)
+    if callable(backward_dw):
+        backward_dw()
+
+
 def _column_parallel_lora_input(x: torch.Tensor, linear: Any) -> torch.Tensor:
     if _linear_disables_tensor_parallel_comm(linear):
         return x
@@ -145,7 +159,9 @@ def _column_parallel_lora_input(x: torch.Tensor, linear: Any) -> torch.Tensor:
         bool(getattr(linear, "sequence_parallel", False))
         and int(getattr(linear, "tp_size", 1)) > 1
     ):
-        return gather_from_sequence_parallel_region(x)
+        gathered_x = gather_from_sequence_parallel_region(x)
+        assert isinstance(gathered_x, torch.Tensor)
+        return gathered_x
     return x
 
 
@@ -212,7 +228,8 @@ def _set_lora_shard_strategy_metadata(
 
 
 def _exported_shard_dim(param: torch.nn.Parameter) -> int:
-    axis = _normalize_axis(param.lora_tp_shard_dim, param.ndim)  # ty: ignore[unresolved-attribute]
+    assert hasattr(param, "lora_tp_shard_dim")
+    axis = _normalize_axis(getattr(param, "lora_tp_shard_dim"), param.ndim)  # ty: ignore[unresolved-attribute]
     # LoRA exports always serialize a 2D tensor:
     # - non-expert params export `param.T`
     # - expert params export `param[expert].T`
@@ -276,9 +293,9 @@ class LoRA(torch.nn.Module):
         return self.A_T.shape[0] if self.A_T.ndim == 3 else 1
 
     def _broadcast_if_replicated(self, param: torch.nn.Parameter) -> None:
-        if not param.lora_tp_replicated:  # ty: ignore[unresolved-attribute]
+        if not getattr(param, "lora_tp_replicated"):
             return
-        domain = param.lora_shard_domain  # ty: ignore[unresolved-attribute]
+        domain = getattr(param, "lora_shard_domain")
         world_size = _get_shard_world_size(domain)
         if world_size <= 1:
             return
@@ -352,9 +369,9 @@ class LoRA(torch.nn.Module):
         self.load_weight(weight, into=into)
 
     def load_weight(self, weight: torch.Tensor, *, into: torch.nn.Parameter) -> None:
-        domain = into.lora_shard_domain  # ty: ignore[unresolved-attribute]
-        if into.lora_tp_sharded:  # ty: ignore[unresolved-attribute]
-            axis = into.lora_tp_shard_dim  # ty: ignore[unresolved-attribute]
+        domain: ShardDomain = getattr(into, "lora_shard_domain")
+        if getattr(into, "lora_tp_sharded"):
+            axis: int = getattr(into, "lora_tp_shard_dim")
             axis = _normalize_axis(axis, weight.ndim)
             world_size = _get_shard_world_size(domain)
             rank = _get_shard_rank(domain)
@@ -417,24 +434,34 @@ class LoRA(torch.nn.Module):
                 return False
 
         # this param is fully sharded, all shard ranks participate
-        if param.lora_tp_sharded:  # ty: ignore[unresolved-attribute]
+        if param.lora_tp_sharded:  # type: ignore[unresolved-attribute]
             return True
         # param is replicated, tp rank 0 or etp rank 0 participates
-        return _get_shard_rank(param.lora_shard_domain) == 0  # ty: ignore[unresolved-attribute]
+        return (
+            _get_shard_rank(param.lora_shard_domain) == 0  # type: ignore[unresolved-attribute]
+        )
 
     def _manifest_for_param(self, param: torch.nn.Parameter) -> dict[str, Any]:
         manifest = {
-            "domain": param.lora_shard_domain,  # ty: ignore[unresolved-attribute]
-            "sharded": param.lora_tp_sharded,  # ty: ignore[unresolved-attribute]
-            "shard_dim": param.lora_tp_shard_dim,  # ty: ignore[unresolved-attribute]
-            "shard_world_size": _get_shard_world_size(param.lora_shard_domain)  # ty: ignore[unresolved-attribute]
-            if param.lora_tp_sharded  # ty: ignore[unresolved-attribute]
-            else 1,
-            "shard_rank": _get_shard_rank(param.lora_shard_domain)  # ty: ignore[unresolved-attribute]
-            if param.lora_tp_sharded  # ty: ignore[unresolved-attribute]
-            else 0,
+            "domain": param.lora_shard_domain,  # type: ignore[unresolved-attribute]
+            "sharded": param.lora_tp_sharded,  # type: ignore[unresolved-attribute]
+            "shard_dim": param.lora_tp_shard_dim,  # type: ignore[unresolved-attribute]
+            "shard_world_size": (
+                _get_shard_world_size(
+                    param.lora_shard_domain  # type: ignore[unresolved-attribute]
+                )
+                if param.lora_tp_sharded  # type: ignore[unresolved-attribute]
+                else 1
+            ),
+            "shard_rank": (
+                _get_shard_rank(
+                    param.lora_shard_domain  # type: ignore[unresolved-attribute]
+                )
+                if param.lora_tp_sharded  # type: ignore[unresolved-attribute]
+                else 0
+            ),
         }
-        if param.lora_tp_sharded:  # ty: ignore[unresolved-attribute]
+        if param.lora_tp_sharded:  # type: ignore[unresolved-attribute]
             manifest["export_shard_dim"] = _exported_shard_dim(param)
             manifest["export_shard_strategy"] = getattr(
                 param,
@@ -486,11 +513,11 @@ class LoRA(torch.nn.Module):
                 raise RuntimeError(
                     f"LoRA param missing main_grad attribute for key '{key}'"
                 )
-            grad = cast(torch.Tensor, param.main_grad)
+            grad: torch.Tensor | None = getattr(param, "main_grad")
             if grad is None:
                 raise RuntimeError(f"LoRA param main_grad is None for key '{key}'")
             if hasattr(grad, "_local_tensor"):
-                grad = cast(Any, grad)._local_tensor
+                grad = cast(torch.Tensor, getattr(grad, "_local_tensor"))
             local_grad = grad[expert] if expert is not None else grad
             grads[key] = local_grad.T
         return grads
@@ -561,14 +588,17 @@ class SelfAttentionLinearProjLoRA(torch.nn.Module):
         base_output, bias_output = self.linear_proj(x)
         assert isinstance(base_output, torch.Tensor)
         assert isinstance(bias_output, (torch.Tensor, type(None)))
-
         lora_output = self.lora(x)
         if self.reduce_output and self.provider.tensor_model_parallel_size > 1:
             if self.provider.sequence_parallel:
                 lora_output = reduce_scatter_to_sequence_parallel_region(lora_output)
             else:
                 lora_output = reduce_from_tensor_model_parallel_region(lora_output)
+        assert isinstance(lora_output, torch.Tensor)
         return base_output + lora_output, bias_output
+
+    def backward_dw(self) -> None:
+        _forward_backward_dw(self.linear_proj)
 
 
 class SelfAttentionLinearQKVLoRA(torch.nn.Module):
@@ -725,6 +755,9 @@ class SelfAttentionLinearQKVLoRA(torch.nn.Module):
 
         return linear_output + adapter_output, bias
 
+    def backward_dw(self) -> None:
+        _forward_backward_dw(self.linear_qkv)
+
 
 class GatedDeltaNetInProjLoRA(torch.nn.Module):
     def __init__(
@@ -739,6 +772,7 @@ class GatedDeltaNetInProjLoRA(torch.nn.Module):
         in_proj.return_layernorm_output = True
         in_proj.return_layernorm_output_gathered = True
         self.in_proj = in_proj
+        assert gated_delta_net.num_value_heads is not None
         self.num_value_heads_per_partition = (
             gated_delta_net.num_value_heads // ps.get_tensor_model_parallel_world_size()
         )
@@ -827,6 +861,9 @@ class GatedDeltaNetInProjLoRA(torch.nn.Module):
         alpha = beta.clone()
         adapter_output = torch.cat([qkv, z, beta, alpha], dim=-1)
         return linear_output + adapter_output, bias
+
+    def backward_dw(self) -> None:
+        _forward_backward_dw(self.in_proj)
 
 
 class MLPExpertsLinearFC1LoRA(torch.nn.Module):
@@ -920,6 +957,9 @@ class MLPExpertsLinearFC1LoRA(torch.nn.Module):
             )
         return base_out + adapter_out, bias_out
 
+    def backward_dw(self) -> None:
+        _forward_backward_dw(self.linear_fc1)
+
 
 class MLPExpertsLinearFC1FusedLoRA(torch.nn.Module):
     def __init__(
@@ -978,6 +1018,9 @@ class MLPExpertsLinearFC1FusedLoRA(torch.nn.Module):
         adapter_out = self.lora(x, tokens_per_expert=tokens_per_expert)
         return base_out + adapter_out, bias_out
 
+    def backward_dw(self) -> None:
+        _forward_backward_dw(self.linear_fc1)
+
 
 class MLPExpertsLinearFC2LoRA(torch.nn.Module):
     def __init__(
@@ -1030,6 +1073,9 @@ class MLPExpertsLinearFC2LoRA(torch.nn.Module):
         # the reason there is no TP comm here is because the MoE token routing handles
         # expert TP comm externally
         return base_out + adapter_out, bias_out
+
+    def backward_dw(self) -> None:
+        _forward_backward_dw(self.linear_fc2)
 
 
 class SharedExpertsLinearFC1LoRA(torch.nn.Module):
@@ -1114,6 +1160,9 @@ class SharedExpertsLinearFC1LoRA(torch.nn.Module):
             )
         return base_out + adapter_out, bias_out
 
+    def backward_dw(self) -> None:
+        _forward_backward_dw(self.linear_fc1)
+
 
 class SharedExpertsLinearFC2LoRA(torch.nn.Module):
     def __init__(
@@ -1136,6 +1185,9 @@ class SharedExpertsLinearFC2LoRA(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor | None]:
         return self.row_parallel_lora(x)
+
+    def backward_dw(self) -> None:
+        self.row_parallel_lora.backward_dw()
 
 
 def _unwrap_attr(
@@ -1382,14 +1434,14 @@ def wrap_shared_experts_mlp(
 
 
 def apply_lora_adapters(
-    model: Sequence[torch.nn.Module],
+    model: Sequence[MegatronModule],
     provider: GPTModelProvider,
     lora_config: Mapping[str, Any] | None = None,
-) -> list[torch.nn.Module]:
+) -> list[MegatronModule]:
     lora_config = lora_config or {}
-    provider = cast(Any, provider)
-    handler = provider._art_model_support_handler
-    spec = provider._art_model_support_spec
+    provider_with_art_attrs = cast(Any, provider)
+    handler = provider_with_art_attrs._art_model_support_handler
+    spec = provider_with_art_attrs._art_model_support_spec
     target_modules = list(
         lora_config.get("target_modules", spec.default_target_modules)
     )

--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -229,9 +229,7 @@ def _set_lora_shard_strategy_metadata(
 
 def _exported_shard_dim(param: torch.nn.Parameter) -> int:
     assert hasattr(param, "lora_tp_shard_dim")
-    axis = _normalize_axis(
-        getattr(param, "lora_tp_shard_dim"), param.ndim
-    )  # ty: ignore[unresolved-attribute]
+    axis = _normalize_axis(getattr(param, "lora_tp_shard_dim"), param.ndim)  # ty: ignore[unresolved-attribute]
     # LoRA exports always serialize a 2D tensor:
     # - non-expert params export `param.T`
     # - expert params export `param[expert].T`
@@ -262,9 +260,9 @@ class LoRA(torch.nn.Module):
         allreduce: bool = True,
     ) -> None:
         super().__init__()
-        assert (
-            num_local_experts == 1 or "{expert}" in adapter_model_prefix
-        ), "adapter_model_prefix must contain the '{expert}' format placeholder if num_local_experts > 1"
+        assert num_local_experts == 1 or "{expert}" in adapter_model_prefix, (
+            "adapter_model_prefix must contain the '{expert}' format placeholder if num_local_experts > 1"
+        )
         self.adapter_model_prefix = adapter_model_prefix
         self.scale = alpha / rank
         self.A_T = torch.nn.Parameter(
@@ -306,10 +304,8 @@ class LoRA(torch.nn.Module):
             raise RuntimeError(
                 f"{self.adapter_model_prefix}: missing process group for replicated parameter domain={domain}"
             )
-        src = (
-            torch.distributed.get_global_rank(  # ty: ignore[possibly-missing-attribute]
-                group, 0
-            )
+        src = torch.distributed.get_global_rank(  # ty: ignore[possibly-missing-attribute]
+            group, 0
         )
         torch.distributed.broadcast(  # ty: ignore[possibly-missing-attribute]
             param.data,
@@ -530,9 +526,9 @@ class LoRA(torch.nn.Module):
         self, x: torch.Tensor, tokens_per_expert: list[int] | torch.Tensor | None = None
     ) -> torch.Tensor:
         if tokens_per_expert is not None:
-            assert (
-                self.num_local_experts > 1
-            ), "tokens_per_expert is only supported if num_local_experts > 1"
+            assert self.num_local_experts > 1, (
+                "tokens_per_expert is only supported if num_local_experts > 1"
+            )
             bsz = tokens_per_expert
             if isinstance(bsz, list):
                 bsz = torch.tensor(bsz, dtype=torch.int64, device="cpu")
@@ -631,13 +627,13 @@ class SelfAttentionLinearQKVLoRA(torch.nn.Module):
         total_out_features_per_rank = int(weight.shape[0])
         kv_out_features = self.provider.kv_channels * self.provider.num_query_groups
         tp_world_size = ps.get_tensor_model_parallel_world_size()
-        assert (
-            kv_out_features % tp_world_size == 0
-        ), "kv_out_features must be divisible by tensor parallel size"
+        assert kv_out_features % tp_world_size == 0, (
+            "kv_out_features must be divisible by tensor parallel size"
+        )
         q_out_features = self.provider.kv_channels * self.provider.num_attention_heads
-        assert (
-            q_out_features % tp_world_size == 0
-        ), "q_out_features must be divisible by tensor parallel size"
+        assert q_out_features % tp_world_size == 0, (
+            "q_out_features must be divisible by tensor parallel size"
+        )
         q_out_features_per_rank = q_out_features // tp_world_size
         kv_out_features_per_rank = kv_out_features // tp_world_size
         self.attention_output_gate = bool(
@@ -649,9 +645,9 @@ class SelfAttentionLinearQKVLoRA(torch.nn.Module):
         expected_q_out_features_per_rank = q_out_features_per_rank * (
             2 if self.attention_output_gate else 1
         )
-        assert (
-            q_and_gate_out_features_per_rank == expected_q_out_features_per_rank
-        ), "Unexpected per-rank QKV packing for this attention layout"
+        assert q_and_gate_out_features_per_rank == expected_q_out_features_per_rank, (
+            "Unexpected per-rank QKV packing for this attention layout"
+        )
         self.num_query_groups_per_partition = (
             self.provider.num_query_groups // tp_world_size
         )

--- a/src/art/megatron/model_support/lora_disk.py
+++ b/src/art/megatron/model_support/lora_disk.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import torch
 
+from art.megatron.model_support.spec import ModelSupportHandler
+
 safetensors = importlib.import_module("safetensors")
 safetensors_torch = importlib.import_module("safetensors.torch")
 safe_open = safetensors.safe_open
@@ -44,10 +46,10 @@ def save_adapter_config(lora_path: str | Path, adapter_config: dict[str, Any]) -
 
 def resolve_lora_handler(
     lora_path: str | Path,
-    handler: Any | None = None,
+    handler: ModelSupportHandler | None = None,
     *,
     allow_unvalidated_arch: bool = False,
-) -> Any:
+) -> ModelSupportHandler:
     if handler is not None:
         return handler
     base_model = load_adapter_config(lora_path).get("base_model_name_or_path")
@@ -83,7 +85,7 @@ def save_vllm_lora_tensors(
 def normalize_lora_checkpoint_to_vllm(
     lora_path: str | Path,
     *,
-    handler: Any | None = None,
+    handler: ModelSupportHandler | None = None,
     adapter_config: dict[str, Any] | None = None,
     allow_unvalidated_arch: bool = False,
 ) -> None:
@@ -108,7 +110,7 @@ def normalize_lora_checkpoint_to_vllm(
 def load_lora_tensors_for_megatron(
     lora_path: str | Path,
     *,
-    handler: Any | None = None,
+    handler: ModelSupportHandler | None = None,
     allow_unvalidated_arch: bool = False,
 ) -> dict[str, torch.Tensor]:
     resolved_handler = resolve_lora_handler(

--- a/src/art/megatron/model_support/spec.py
+++ b/src/art/megatron/model_support/spec.py
@@ -1,6 +1,10 @@
-from typing import Any, Literal, Protocol, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Protocol, Sequence, runtime_checkable
 
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from megatron.bridge import AutoBridge
+    from megatron.bridge.models.gpt_provider import GPTModelProvider
 
 RolloutWeightsMode = Literal["lora", "merged"]
 NativeVllmLoraStatus = Literal["disabled", "wip", "validated"]
@@ -76,6 +80,7 @@ class ModelSupportSpec(BaseModel):
     dependency_floor: DependencyFloor = Field(default_factory=DependencyFloor)
 
 
+@runtime_checkable
 class ModelSupportHandler(Protocol):
     key: str
     is_moe: bool
@@ -90,20 +95,27 @@ class ModelSupportHandler(Protocol):
         target_modules: list[str],
     ) -> list[str]: ...
 
-    def patch_bridge(self, bridge: Any) -> None: ...
+    def patch_bridge(self, bridge: "AutoBridge") -> None: ...
 
-    def patch_provider(self, provider: Any, bridge: Any) -> None: ...
+    def patch_provider(
+        self,
+        provider: "GPTModelProvider",
+        bridge: "AutoBridge",
+    ) -> None: ...
 
-    def configure_provider_for_runtime(self, provider: Any) -> None: ...
+    def configure_provider_for_runtime(self, provider: "GPTModelProvider") -> None: ...
 
     def install_preprocess_patch(self, model_chunks: Sequence[Any]) -> None: ...
 
-    def collect_layer_families(self, provider: Any) -> list[LayerFamilyInstance]: ...
+    def collect_layer_families(
+        self,
+        provider: "GPTModelProvider",
+    ) -> list[LayerFamilyInstance]: ...
 
     def apply_lora_adapters(
         self,
         model_chunks: Sequence[Any],
-        provider: Any,
+        provider: "GPTModelProvider",
         *,
         target_modules: list[str],
         rank: int,
@@ -147,7 +159,7 @@ class ModelSupportHandler(Protocol):
 
     def compile_workaround_config(
         self,
-        provider: Any,
+        provider: "GPTModelProvider",
     ) -> CompileWorkaroundConfig: ...
 
     def get_forward_kwargs(self, model: Any, **kwargs: Any) -> dict[str, Any]: ...

--- a/src/art/megatron/provider.py
+++ b/src/art/megatron/provider.py
@@ -293,7 +293,7 @@ def prepare_provider_bundle(
 
 
 def finalize_provider_bundle(provider_bundle: ProviderBundle) -> ProviderBundle:
-    provider = cast(GPTModelProvider, provider_bundle.provider)
+    provider = provider_bundle.provider
     _apply_art_training_runtime_finalize_defaults(provider)
     provider.finalize()
     return provider_bundle

--- a/src/art/megatron/provider_common.py
+++ b/src/art/megatron/provider_common.py
@@ -1,19 +1,21 @@
 import copy
 import inspect
-from typing import Any, Callable
+from typing import Any
 
+from megatron.bridge import AutoBridge
+from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.core.transformer.spec_utils import ModuleSpec
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, SkipValidation
 
-from art.megatron.model_support.spec import ModelSupportSpec
+from art.megatron.model_support.spec import ModelSupportHandler, ModelSupportSpec
 
 
 class ProviderBundle(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    provider: Any
-    bridge: Any
-    handler: Any
+    provider: SkipValidation[GPTModelProvider]
+    bridge: SkipValidation[AutoBridge]
+    handler: SkipValidation[ModelSupportHandler]
     spec: ModelSupportSpec
 
 

--- a/src/art/megatron/train.py
+++ b/src/art/megatron/train.py
@@ -12,6 +12,7 @@ Public cross-repo API consumed by serverless-training:
 - merge_lora_adapter
 """
 
+from collections.abc import Iterator, Sequence
 import gc
 import importlib
 import json
@@ -22,12 +23,18 @@ import shutil
 import time
 from typing import Any, Callable, Literal, cast
 
+from megatron.bridge import AutoBridge
+from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.core import parallel_state as ps
 from megatron.core.distributed import DistributedDataParallelConfig
-from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+from megatron.core.optimizer import (
+    MegatronOptimizer,
+    OptimizerConfig,
+    get_megatron_optimizer,
+)
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_layer import TransformerLayer
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, SkipValidation, field_validator
 import torch
 from torch._inductor.runtime.cache_dir_utils import cache_dir as inductor_cache_dir
 
@@ -40,6 +47,7 @@ install_art_bridge_runtime_patches()
 from art.megatron.compile_workarounds import install_torch_compile_workarounds
 from art.megatron.flex_attention import create_shared_prefix_attention_state
 from art.megatron.lora import apply_lora_adapters
+from art.megatron.model_support.spec import ModelSupportHandler, ModelSupportSpec
 from art.megatron.provider import finalize_provider_bundle, prepare_provider_bundle
 from art.megatron.provider_common import ProviderBundle
 from art.megatron.routing_replay import (
@@ -79,6 +87,7 @@ from art.preprocessing.pack import (
     PackedTensors,
     packed_tensors_from_dir,
 )
+from art.weight_transfer import TrainerNcclCommunicator
 
 safetensors = importlib.import_module("safetensors")
 safetensors_torch = importlib.import_module("safetensors.torch")
@@ -104,14 +113,14 @@ class TrainingRuntime(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     provider_bundle: ProviderBundle
-    provider: Any
-    model: ModelChunks
-    optimizer: Any | None
+    provider: SkipValidation[GPTModelProvider]
+    model: SkipValidation[ModelChunks]
+    optimizer: SkipValidation[MegatronOptimizer | None]
     optimizer_config: OptimizerConfig
     rank: int
     world_size: int
     moe_routing_replay_controller: MoeRoutingReplayController | None = None
-    merged_weight_transfer_group: Any | None = None
+    merged_weight_transfer_group: SkipValidation[TrainerNcclCommunicator | None] = None
     merged_weight_transfer_init_info: MergedWeightTransferInitInfo | None = None
 
     @field_validator("model")
@@ -121,15 +130,15 @@ class TrainingRuntime(BaseModel):
         return value
 
     @property
-    def bridge(self) -> Any:
+    def bridge(self) -> AutoBridge:
         return self.provider_bundle.bridge
 
     @property
-    def model_support_handler(self) -> Any:
+    def model_support_handler(self) -> ModelSupportHandler:
         return self.provider_bundle.handler
 
     @property
-    def model_support_spec(self) -> Any:
+    def model_support_spec(self) -> ModelSupportSpec:
         return self.provider_bundle.spec
 
 
@@ -157,7 +166,7 @@ def freeze_model(model_chunks: list[MegatronModule]) -> list[MegatronModule]:
 
 
 def _register_trainable_parameter_mode(
-    provider: Any,
+    provider: GPTModelProvider,
     *,
     trainable_parameter_mode: Literal["lora", "base_model"],
     lora_config: dev.LoRAConfig | None,
@@ -207,10 +216,10 @@ def _install_fast_frozen_output_backward() -> None:
         return grad_input, None, None, None, None
 
     setattr(_fast_backward, "__art_fast_output_backward__", True)
-    LinearWithFrozenWeight.backward = staticmethod(_fast_backward)
+    cast(Any, LinearWithFrozenWeight).backward = staticmethod(_fast_backward)
 
 
-def _eager_initialize_optimizer_state(optimizer: Any) -> None:
+def _eager_initialize_optimizer_state(optimizer: MegatronOptimizer) -> None:
     chained_optimizers = getattr(optimizer, "chained_optimizers", None)
     if chained_optimizers is not None:
         for child_optimizer in chained_optimizers:
@@ -243,7 +252,7 @@ def _default_optimizer_config() -> OptimizerConfig:
 
 
 def _maybe_print_optimizer_stats(
-    optimizer: Any,
+    optimizer: MegatronOptimizer,
     model: ModelChunks,
 ) -> None:
     global _optimizer_stats_printed
@@ -269,7 +278,7 @@ def _maybe_print_optimizer_stats(
 def _build_optimizer(
     model: ModelChunks,
     optimizer_config: OptimizerConfig,
-) -> Any:
+) -> MegatronOptimizer:
     optimizer = get_megatron_optimizer(
         config=optimizer_config,
         model_chunks=as_megatron_api_chunks(model),
@@ -329,7 +338,7 @@ def _moe_routing_replay_requested(
     }
 
 
-def _enable_native_moe_routing_replay(provider: Any) -> None:
+def _enable_native_moe_routing_replay(provider: GPTModelProvider) -> None:
     if bool(getattr(provider, "moe_router_fusion", False)):
         raise RuntimeError(
             "MoE routing replay requires provider.moe_router_fusion=False because "
@@ -346,7 +355,7 @@ def build_training_runtime(
     model_identifier: str | None = None,
     provider_torch_dtype: torch.dtype = torch.bfloat16,
     provider_bundle_configure: Callable[[ProviderBundle], None] | None = None,
-    provider_configure: Callable[[Any], None] | None = None,
+    provider_configure: Callable[[GPTModelProvider], None] | None = None,
     optimizer_config: OptimizerConfig | None = None,
     moe_routing_replay_path: str | None = None,
     moe_routing_replay_bundle: MoeRoutingReplayBundle | None = None,
@@ -505,6 +514,7 @@ def run_megatron_rl_job(
             lora_path=job.lora_path,
             optimizer_state_path=job.optimizer_state_path,
         )
+        assert runtime.optimizer is not None
 
         print0(
             runtime.rank,
@@ -598,7 +608,7 @@ def _flush_param_grads_to_main_grads(model_chunks: ModelChunks) -> None:
                 continue
             if not hasattr(param, "main_grad"):
                 continue
-            main_grad = cast(torch.Tensor, param.main_grad)
+            main_grad = cast(torch.Tensor, getattr(param, "main_grad"))
             if not getattr(param, "grad_added_to_main_grad", False) or getattr(
                 param, "zero_out_wgrad", False
             ):
@@ -810,8 +820,8 @@ def _load_adapter_into_model(
     lora_path: str,
     rank: int,
     *,
-    handler: Any | None = None,
-    optimizer: Any | None = None,
+    handler: ModelSupportHandler | None = None,
+    optimizer: MegatronOptimizer | None = None,
 ) -> dict[str, torch.Tensor]:
     print0(rank, "Loading adapter model from", lora_path)
     adapter_model = load_lora_adapter_state_dict(lora_path, handler=handler)
@@ -907,14 +917,14 @@ def _compile_transformer_layers(module: torch.nn.Module) -> None:
         _compile_transformer_layers(child)
 
 
-def iter_modules(model_chunks: ModelChunks) -> Any:
+def iter_modules(model_chunks: Sequence[torch.nn.Module]) -> Iterator[torch.nn.Module]:
     for chunk in model_chunks:
         for module in chunk.modules():
             yield module
 
 
 def load_adapter_into_model(
-    model_chunks: ModelChunks,
+    model_chunks: Sequence[torch.nn.Module],
     adapter_model: dict[str, torch.Tensor],
     optimizer: Any | None = None,
 ) -> None:
@@ -954,27 +964,35 @@ def collect_sharded_lora_state(
 
 @torch.no_grad()
 def select_indexed_inputs(packed_tensors: PackedTensors, index: int) -> PackedTensors:
-    return PackedTensors(  # type: ignore[call-arg]
-        **{
-            key: value[index : index + 1]
-            for key, value in packed_tensors.items()
-            if isinstance(value, torch.Tensor)
+    return cast(
+        PackedTensors,
+        {
+            **{
+                key: value[index : index + 1]
+                for key, value in packed_tensors.items()
+                if isinstance(value, torch.Tensor)
+            },
+            "pixel_values": [None],
+            "image_grid_thw": [None],
+            "moe_routing_replay": None,
         },
-        pixel_values=[None],
-        image_grid_thw=[None],
     )
 
 
 @torch.no_grad()
 def _clone_packed_tensors(inputs: PackedTensors) -> PackedTensors:
-    return PackedTensors(  # type: ignore[call-arg]
-        **{
-            key: value.clone()
-            for key, value in inputs.items()
-            if isinstance(value, torch.Tensor)
+    return cast(
+        PackedTensors,
+        {
+            **{
+                key: value.clone()
+                for key, value in inputs.items()
+                if isinstance(value, torch.Tensor)
+            },
+            "pixel_values": [None],
+            "image_grid_thw": [None],
+            "moe_routing_replay": None,
         },
-        pixel_values=[None],
-        image_grid_thw=[None],
     )
 
 
@@ -1065,9 +1083,11 @@ def select_micro_inputs(
     zero_template: PackedTensors,
 ) -> list[PackedTensors]:
     return [
-        _clone_packed_tensors(zero_template)
-        if sample_index is None
-        else select_indexed_inputs(packed_tensors, sample_index)
+        (
+            _clone_packed_tensors(zero_template)
+            if sample_index is None
+            else select_indexed_inputs(packed_tensors, sample_index)
+        )
         for sample_index in sample_indices
     ]
 
@@ -1078,9 +1098,11 @@ def select_sft_micro_inputs(
     zero_template: dict[str, torch.Tensor],
 ) -> list[dict[str, torch.Tensor]]:
     return [
-        _clone_sft_tensors(zero_template)
-        if sample_index is None
-        else _clone_sft_tensors(trajectory_tensors[sample_index])
+        (
+            _clone_sft_tensors(zero_template)
+            if sample_index is None
+            else _clone_sft_tensors(trajectory_tensors[sample_index])
+        )
         for sample_index in sample_indices
     ]
 
@@ -1092,7 +1114,7 @@ def _move_inputs_to_device(inputs: PackedTensors, device: torch.device) -> None:
 
 
 def _optimizer_step(
-    optimizer: Any,
+    optimizer: MegatronOptimizer,
     learning_rate: float,
 ) -> tuple[bool, float, int | None]:
     for param_group in optimizer.param_groups:
@@ -1169,8 +1191,8 @@ def _prepare_sft_micro_inputs(
 def run_megatron_sft_step(
     *,
     model_chunks: ModelChunks,
-    model_support_handler: Any,
-    optimizer: Any,
+    model_support_handler: ModelSupportHandler,
+    optimizer: MegatronOptimizer,
     learning_rate: float,
     inputs: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
     step_index: int,
@@ -1188,7 +1210,7 @@ def run_megatron_sft_step(
                 "sample_index list length must match number of micro inputs: "
                 f"{len(sample_index)} != {len(micro_inputs)}"
             )
-        micro_sample_indices = sample_index
+        micro_sample_indices: list[int | None] = sample_index
     else:
         assert len(micro_inputs) == 1
         micro_sample_indices = [sample_index]
@@ -1208,7 +1230,7 @@ def run_megatron_sft_step(
     device = next(model_chunks[0].parameters()).device
 
     for chunk in model_chunks:
-        chunk.zero_grad_buffer()  # ty: ignore[call-non-callable]
+        chunk.zero_grad_buffer()  # type: ignore[call-non-callable]
 
     raw_loss_sum: torch.Tensor | None = None
     num_tokens = _local_trainable_sft_token_count_tensor(micro_inputs, device=device)
@@ -1274,8 +1296,8 @@ def run_megatron_sft_step(
 def run_training_step(
     *,
     model_chunks: ModelChunks,
-    model_support_handler: Any,
-    optimizer: Any,
+    model_support_handler: ModelSupportHandler,
+    optimizer: MegatronOptimizer,
     learning_rate: float,
     inputs: PackedTensors | list[PackedTensors],
     config: types.TrainConfig,
@@ -1295,7 +1317,7 @@ def run_training_step(
                 "sample_index list length must match number of micro inputs: "
                 f"{len(sample_index)} != {len(micro_inputs)}"
             )
-        micro_sample_indices = sample_index
+        micro_sample_indices: list[int | None] = sample_index
     else:
         assert len(micro_inputs) == 1
         micro_sample_indices = [sample_index]
@@ -1315,7 +1337,7 @@ def run_training_step(
     device = next(model_chunks[0].parameters()).device
 
     for chunk in model_chunks:
-        chunk.zero_grad_buffer()  # ty: ignore[call-non-callable]
+        chunk.zero_grad_buffer()  # type: ignore[call-non-callable]
 
     micro_count = len(micro_inputs)
     raw_loss_sum: torch.Tensor | None = None
@@ -1355,7 +1377,7 @@ def run_training_step(
         )
 
         loss_info = loss_fn(
-            micro,  # ty: ignore[invalid-argument-type]
+            micro,  # type: ignore[invalid-argument-type]
             new_logprobs,
             ref_logprobs,
             None,

--- a/src/art/megatron/training/model_chunks.py
+++ b/src/art/megatron/training/model_chunks.py
@@ -1,14 +1,14 @@
 from collections.abc import Sequence
-from typing import Any, cast
+from typing import Any, TypeAlias
 
 from megatron.core.transformer.module import MegatronModule
 import torch
 
-ModelChunk = torch.nn.Module
-ModelChunks = list[ModelChunk]
+ModelChunk: TypeAlias = MegatronModule
+ModelChunks: TypeAlias = list[ModelChunk]
 
 
-def unwrap_megatron_chunk(module: ModelChunk) -> MegatronModule:
+def unwrap_megatron_chunk(module: torch.nn.Module) -> MegatronModule:
     current: Any = module
     seen: set[int] = set()
     while True:
@@ -29,7 +29,7 @@ def unwrap_megatron_chunk(module: ModelChunk) -> MegatronModule:
     )
 
 
-def validate_model_chunks(model_chunks: Sequence[ModelChunk]) -> None:
+def validate_model_chunks(model_chunks: Sequence[torch.nn.Module]) -> None:
     for chunk in model_chunks:
         try:
             unwrap_megatron_chunk(chunk)
@@ -39,4 +39,4 @@ def validate_model_chunks(model_chunks: Sequence[ModelChunk]) -> None:
 
 def as_megatron_api_chunks(model_chunks: Sequence[ModelChunk]) -> list[MegatronModule]:
     validate_model_chunks(model_chunks)
-    return cast(list[MegatronModule], list(model_chunks))
+    return list(model_chunks)

--- a/src/art/megatron/weights/merge.py
+++ b/src/art/megatron/weights/merge.py
@@ -12,6 +12,7 @@ from art.megatron.model_support.lora_disk import (
     resolve_lora_handler,
     save_vllm_lora_tensors,
 )
+from art.megatron.model_support.spec import ModelSupportHandler
 
 safetensors = importlib.import_module("safetensors")
 safetensors_torch = importlib.import_module("safetensors.torch")
@@ -155,7 +156,7 @@ def _load_adapter_shards(
 def load_lora_adapter_state_dict(
     lora_path: str,
     *,
-    handler: Any | None = None,
+    handler: ModelSupportHandler | None = None,
     allow_unvalidated_arch: bool = False,
 ) -> dict[str, torch.Tensor]:
     base_dir = Path(lora_path)

--- a/src/art/megatron/weights/merged_weight_export.py
+++ b/src/art/megatron/weights/merged_weight_export.py
@@ -3,9 +3,11 @@ from itertools import chain
 import time
 from typing import Any, Iterator, cast
 
+from megatron.bridge import AutoBridge
 from pydantic import BaseModel, ConfigDict
 import torch
 
+from art.megatron.model_support.spec import ModelSupportHandler
 from art.megatron.runtime.jobs import (
     MergedWeightTransferInitInfo,
     MergedWeightTransferSpec,
@@ -18,6 +20,7 @@ from art.megatron.weights.param_name_canonicalization import (
 from art.weight_transfer import (
     DEFAULT_PACKED_BUFFER_SIZE_BYTES,
     DEFAULT_PACKED_NUM_BUFFERS,
+    TrainerNcclCommunicator,
     trainer_init,
     trainer_send_weights,
 )
@@ -26,7 +29,7 @@ from art.weight_transfer import (
 class MergedWeightExport(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    bridge: Any
+    bridge: AutoBridge
     model: ModelChunks
     model_config_value: Any
     conversion_tasks: list[Any]
@@ -39,7 +42,7 @@ def _hf_param_names(hf_param: Any) -> list[str]:
     return list(hf_param.values())
 
 
-def build_art_conversion_tasks(*, bridge: Any, model: ModelChunks) -> list[Any]:
+def build_art_conversion_tasks(*, bridge: AutoBridge, model: ModelChunks) -> list[Any]:
     from megatron.bridge.models.conversion.model_bridge import (
         WeightConversionTask,
         _megatron_local_name_to_global,
@@ -53,7 +56,7 @@ def build_art_conversion_tasks(*, bridge: Any, model: ModelChunks) -> list[Any]:
     hf_source = bridge.hf_pretrained.state.source
     hf_keys = set(hf_source.get_all_keys())
     megatron_models = as_megatron_api_chunks(model)
-    model_config = cast(Any, model[0].config)
+    model_config = getattr(model[0], "config")
     tasks: list[Any] = []
     for vp_stage, chunk in enumerate(model):
         for local_name, _ in chain(
@@ -69,6 +72,10 @@ def build_art_conversion_tasks(*, bridge: Any, model: ModelChunks) -> list[Any]:
                 vp_stage,
             )
             mapping = mapping_registry.megatron_to_hf_lookup(global_name)
+            if mapping is None:
+                raise RuntimeError(
+                    f"Missing HF conversion mapping for Megatron param {global_name}"
+                )
             hf_params = _hf_param_names(mapping.hf_param)
             missing_hf_params = sorted(set(hf_params) - hf_keys)
             if missing_hf_params:
@@ -102,14 +109,14 @@ def build_art_conversion_tasks(*, bridge: Any, model: ModelChunks) -> list[Any]:
 
 def build_merged_weight_export(
     *,
-    bridge: Any,
+    bridge: AutoBridge,
     model: ModelChunks,
-    model_support_handler: Any,
+    model_support_handler: ModelSupportHandler,
 ) -> MergedWeightExport:
     return MergedWeightExport(
         bridge=bridge,
         model=model,
-        model_config_value=model[0].config,
+        model_config_value=getattr(model[0], "config"),
         conversion_tasks=build_art_conversion_tasks(
             bridge=bridge,
             model=model,
@@ -273,10 +280,10 @@ def ensure_merged_weight_transfer_group(
     *,
     rank: int,
     world_size: int,
-    merged_weight_transfer_group: Any | None,
+    merged_weight_transfer_group: TrainerNcclCommunicator | None,
     merged_weight_transfer_init_info: MergedWeightTransferInitInfo | None,
     spec: MergedWeightTransferSpec,
-) -> tuple[Any, MergedWeightTransferInitInfo]:
+) -> tuple[TrainerNcclCommunicator | None, MergedWeightTransferInitInfo]:
     if merged_weight_transfer_init_info == spec.init_info:
         if _is_sender_rank(rank):
             assert merged_weight_transfer_group is not None
@@ -326,11 +333,11 @@ def sync_merged_weights_to_vllm(
     model_support_handler: Any,
     rank: int,
     world_size: int,
-    merged_weight_transfer_group: Any | None,
+    merged_weight_transfer_group: TrainerNcclCommunicator | None,
     merged_weight_transfer_init_info: MergedWeightTransferInitInfo | None,
     spec: MergedWeightTransferSpec,
     pause_generation: bool,
-) -> tuple[Any, MergedWeightTransferInitInfo]:
+) -> tuple[TrainerNcclCommunicator | None, MergedWeightTransferInitInfo]:
     import httpx
 
     (

--- a/src/art/preprocessing/pack.py
+++ b/src/art/preprocessing/pack.py
@@ -27,7 +27,7 @@ class PackedTensors(TypedDict):
     weights: torch.Tensor
     pixel_values: list[torch.Tensor | None]
     image_grid_thw: list[torch.Tensor | None]
-    moe_routing_replay: NotRequired[PackedMoeRoutingReplay]
+    moe_routing_replay: PackedMoeRoutingReplay | None
 
 
 class DiskPackedTensors(TypedDict):
@@ -202,6 +202,7 @@ def packed_tensors_from_tokenized_results(
         "image_grid_thw": [
             torch.concat(tensors) if tensors else None for tensors in image_grid_thw
         ],
+        "moe_routing_replay": None,
     }
     if include_moe_routing:
         (

--- a/tests/integration/megatron/model_support/oracle_worker.py
+++ b/tests/integration/megatron/model_support/oracle_worker.py
@@ -913,6 +913,7 @@ def _worker_run(request: WorkerRunRequest) -> None:
         _debug("finished build_training_runtime")
     model_chunks = runtime.model
     optimizer = runtime.optimizer
+    assert optimizer is not None
     _assert_runtime_configuration(model_chunks, request.case_config)
 
     topology_dir = Path(request.topology_dir)

--- a/tests/integration/megatron/model_support/test_provider_support.py
+++ b/tests/integration/megatron/model_support/test_provider_support.py
@@ -291,7 +291,8 @@ def test_get_provider_bundle_honors_single_gpu_env_topology(
     assert resolved.recompute_method == "uniform"
     assert resolved.recompute_num_layers == 1
 
-    layer_spec = resolved.transformer_layer_spec(resolved, vp_stage=0)
+    transformer_layer_spec = cast(Any, resolved.transformer_layer_spec)
+    layer_spec = transformer_layer_spec(resolved, vp_stage=0)
     assert (
         layer_spec.submodules.self_attention.submodules.core_attention
         is FlexDotProductAttention

--- a/tests/integration/megatron/train_inf_mismatch/real_path.py
+++ b/tests/integration/megatron/train_inf_mismatch/real_path.py
@@ -532,11 +532,11 @@ async def _score_base_real_generation_path(
             name=f"{served_name}_client",
             project="train_inf_mismatch",
             base_model=parity_config.base_model,
-            _internal_config={
-                "init_args": {
+            _internal_config=art.dev.InternalModelConfig(
+                init_args={
                     "max_seq_length": parity_config.packed.sequence_length,
                 },
-            },
+            ),
         )
         object.__setattr__(model, "inference_base_url", f"http://{host}:{port}/v1")
         object.__setattr__(model, "inference_api_key", "EMPTY")
@@ -585,7 +585,9 @@ async def _score_base_real_generation_path(
             global_grad_accumulation_sequences=global_grad_accumulation_sequences,
         ).to_dir(routing_replay_dir)
         routing_replay_path = str(routing_replay_dir)
-        stats = packed_tensors["moe_routing_replay"].pack_stats
+        moe_routing_replay = packed_tensors["moe_routing_replay"]
+        assert moe_routing_replay is not None
+        stats = moe_routing_replay.pack_stats
     else:
         stats = MoeRoutingPackStats()
 
@@ -972,23 +974,23 @@ async def run_real_path_train_inf_mismatch(
         name=f"train-inf-real-{uuid.uuid4().hex[:8]}",
         project="train_inf_mismatch",
         base_model=parity_config.base_model,
-        _internal_config={
-            "trainer_gpu_ids": parity_config.trainer_gpu_ids,
-            "inference_gpu_ids": parity_config.inference_gpu_ids,
-            "rollout_weights_mode": "lora",
-            "allow_unvalidated_arch": parity_config.allow_unvalidated_arch,
-            "engine_args": {
-                "tensor_parallel_size": len(parity_config.inference_gpu_ids),
-                "enable_expert_parallel": is_moe
+        _internal_config=art.dev.InternalModelConfig(
+            trainer_gpu_ids=parity_config.trainer_gpu_ids,
+            inference_gpu_ids=parity_config.inference_gpu_ids,
+            rollout_weights_mode="lora",
+            allow_unvalidated_arch=parity_config.allow_unvalidated_arch,
+            engine_args=art.dev.EngineArgs(
+                tensor_parallel_size=len(parity_config.inference_gpu_ids),
+                enable_expert_parallel=is_moe
                 and len(parity_config.inference_gpu_ids) > 1,
-                "max_model_len": parity_config.packed.sequence_length + 8,
-                "max_logprobs": TOP_K,
+                max_model_len=parity_config.packed.sequence_length + 8,
+                max_logprobs=TOP_K,
                 **parity_config.engine_args,
-            },
-            "init_args": {
+            ),
+            init_args={
                 "max_seq_length": parity_config.packed.sequence_length,
             },
-        },
+        ),
     )
     _move_adapter_to_step_zero(adapter_path=adapter_path, model=model, backend=backend)
 
@@ -1035,6 +1037,7 @@ async def run_real_path_train_inf_mismatch(
         )
         if is_moe:
             routing_replay = packed_tensors["moe_routing_replay"]
+            assert routing_replay is not None
             stats = routing_replay.pack_stats
         else:
             from art.preprocessing.moe_routing import MoeRoutingPackStats

--- a/tests/unit/test_moe_routing_real_path.py
+++ b/tests/unit/test_moe_routing_real_path.py
@@ -163,6 +163,7 @@ def test_pack_carries_routes_through_shared_prefix_splicing() -> None:
 
     assert packed["tokens"].tolist()[0][:6] == [10, 11, 20, 21, 22, 23]
     routing_replay = packed["moe_routing_replay"]
+    assert routing_replay is not None
     assert routing_replay.expert_indices.tolist()[0][:6] == [
         _route(0),
         _route(10),


### PR DESCRIPTION
## Summary
- Tighten Megatron runtime/provider/helper type hints while skipping Pydantic runtime validation for arbitrary Megatron objects.
- Alias `ModelChunk` to `MegatronModule` and keep validation helpers for Megatron API boundaries.
- Forward TE `backward_dw()` through LoRA wrappers so delayed weight-gradient hooks remain available after wrapping.

## Test plan
- `uv run prek run --all-files`
- `uv run pytest --tb=short tests/integration/test_lora_quack_cutover.py tests/integration/megatron/lora/test_merged_weight_export.py tests/unit/test_pipeline_trainer_local_backend.py::test_load_adapter_into_model_reloads_optimizer_when_provided tests/unit/test_model_support_import_boundary.py tests/unit/test_moe_routing_replay.py tests/unit/test_moe_routing_real_path.py tests/integration/megatron/model_support/test_hf_parity_invariants.py tests/integration/megatron/model_support/test_compile_flags.py tests/integration/megatron/model_support/test_workflow.py tests/integration/megatron/model_support/test_packed_position_ids.py tests/integration/megatron/model_support/test_provider_support.py`
- Minimal Megatron yes/no/maybe smoke via `dev/yes-no-maybe-megatron.py`
- Synthetic Megatron gradient smoke with one trainable trajectory group