### PR TITLE
Remove LocalBackend from root exports

### DIFF
--- a/docs/integrations/langgraph-integration.mdx
+++ b/docs/integrations/langgraph-integration.mdx
@@ -262,11 +262,12 @@ from pydantic import BaseModel, Field
 from tenacity import retry, stop_after_attempt
 
 from art.langgraph import init_chat_model, wrap_rollout
+from art.local import LocalBackend
 from art.utils import iterate_dataset
 
 # Initialize model and backend
 model = art.Model(name="Qwen/Qwen2.5-7B-Instruct")
-backend = art.LocalBackend()
+backend = LocalBackend()
 
 # Data models
 class EmailResult(BaseModel):

--- a/src/art/__init__.py
+++ b/src/art/__init__.py
@@ -84,7 +84,6 @@ __all__ = [
     "gather_trajectory_groups",
     "trajectory_group_batches",
     "Backend",
-    "LocalBackend",
     "LocalTrainResult",
     "LoRAConfig",
     "ServerlessBackend",


### PR DESCRIPTION
## Summary
- remove `LocalBackend` from the root `art.__all__` export list
- update the stale LangGraph docs snippet to import `LocalBackend` from `art.local`
- add an import-boundary regression test for root `art` imports and star imports

## Context
`LocalBackend` was intentionally removed from eager root imports in #548 so lightweight `import art` does not pull backend-only dependencies. This keeps that behavior explicit instead of reintroducing a top-level `art.LocalBackend` export.

Alternative to #642.

## Test plan
- `uv run pytest tests/unit/test_model_support_import_boundary.py`
- `uv run ruff check src/art/__init__.py tests/unit/test_model_support_import_boundary.py`
- manual `uv run python` check that `LocalBackend` is absent from `art.__all__`, absent from `from art import *`, and `art.local` is not loaded