### PR TITLE
Fix routing replay split sizes for attention

### DIFF
--- a/src/art/megatron/training/trace.py
+++ b/src/art/megatron/training/trace.py
@@ -98,19 +98,17 @@ def _routing_replay_token_uid_sets(
     *,
     attention_state: Any | None,
 ) -> dict[str, torch.Tensor | None]:
+    attention_token_uids = flatten_local_token_uids(token_uids)
     plan = getattr(attention_state, "gdn_execution_plan", None)
     if plan is not None:
         return {
-            "attention": torch.tensor(
-                tuple(getattr(plan, "attention_token_indices")),
-                dtype=torch.int64,
-            ),
+            "attention": attention_token_uids,
             "gdn": torch.tensor(
                 tuple(getattr(plan, "gdn_token_indices")),
                 dtype=torch.int64,
             ),
         }
-    return {"attention": flatten_local_token_uids(token_uids)}
+    return {"attention": attention_token_uids}
 
 
 def _set_root_output_trace_token_uids(

--- a/tests/unit/test_moe_routing_replay.py
+++ b/tests/unit/test_moe_routing_replay.py
@@ -18,6 +18,7 @@ from art.megatron.routing_replay import (
     TopologyAwareLocalTokenIndexer,
     build_router_key_from_module_name,
 )
+from art.megatron.training.trace import _routing_replay_token_uid_sets
 
 
 def _make_route(
@@ -121,6 +122,15 @@ class _FakeParallelState:
 
     def get_tensor_model_parallel_rank(self) -> int:
         return self._tp_rank
+
+
+class _FakeGdnExecutionPlan:
+    attention_token_indices = (0, 1, 2, 3)
+    gdn_token_indices = (0, 2)
+
+
+class _FakeAttentionState:
+    gdn_execution_plan = _FakeGdnExecutionPlan()
 
 
 class _FakeRouterReplay:
@@ -240,6 +250,26 @@ def _expected_routing_map(route: RouterCallRoute) -> torch.Tensor:
     rows = torch.arange(route.num_global_tokens).unsqueeze(1)
     routing_map[rows, route.expert_indices.to(torch.long)] = True
     return routing_map
+
+
+def test_routing_replay_token_uid_sets_keep_full_attention_layout_with_gdn_plan() -> (
+    None
+):
+    token_uids = torch.tensor([[0, 1, 2, 3, 4, 5]], dtype=torch.int64)
+
+    token_uid_sets = _routing_replay_token_uid_sets(
+        token_uids,
+        attention_state=_FakeAttentionState(),
+    )
+
+    assert torch.equal(
+        token_uid_sets["attention"],
+        torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int64),
+    )
+    assert torch.equal(
+        token_uid_sets["gdn"],
+        torch.tensor([0, 2], dtype=torch.int64),
+    )
 
 
 def test_build_router_key_from_compiled_module_name() -> None:

--- a/tests/unit/test_moe_routing_replay.py
+++ b/tests/unit/test_moe_routing_replay.py
@@ -261,13 +261,17 @@ def test_routing_replay_token_uid_sets_keep_full_attention_layout_with_gdn_plan(
         token_uids,
         attention_state=_FakeAttentionState(),
     )
+    attention_token_uids = token_uid_sets["attention"]
+    gdn_token_uids = token_uid_sets["gdn"]
 
+    assert attention_token_uids is not None
     assert torch.equal(
-        token_uid_sets["attention"],
+        attention_token_uids,
         torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int64),
     )
+    assert gdn_token_uids is not None
     assert torch.equal(
-        token_uid_sets["gdn"],
+        gdn_token_uids,
         torch.tensor([0, 2], dtype=torch.int64),
     )
 


### PR DESCRIPTION
## Summary
- preserve the full attention token layout when recording routing replay token UID sets
- keep the compacted GDN token UID layout only for GDN replay
- add a unit test that covers the differing attention-vs-GDN replay shapes

## Why
The Megatron routing replay path could fail with `split_with_sizes expects split_sizes to sum exactly ...` when attention replay used compacted GDN token UID sets. Attention needs the original flattened token layout, while GDN uses the compact routed-token layout.

## Validation
- `uv run --with torch --with safetensors --with megatron-core==0.17.0 --with transformers==5.2.0 --group dev pytest tests/unit/test_moe_routing_replay.py tests/unit/test_dedicated_config.py`
- Sky 2x H200 Bonnie Megatron repro against this fix completed 1 training step without the split-size crash
- Stacked LoRA PR smoke run against this branch also completed 1 Megatron training step successfully
