### PR TITLE
Keep routing replay target prep out of Dynamo

### DIFF
--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -1,5 +1,7 @@
 from collections.abc import Sequence
+import json
 import math
+import os
 import re
 from typing import Any, Literal, NamedTuple, cast
 
@@ -33,6 +35,8 @@ from .kernels.cute_grouped_lora_quack import (
 MOE_LORA_RANK = 1
 DENSE_LORA_RANK = 8
 LORA_ALPHA = 32
+MEGATRON_LORA_RANK_ENV = "ART_MEGATRON_LORA_RANK"
+MEGATRON_LORA_TARGET_MODULES_ENV = "ART_MEGATRON_LORA_TARGET_MODULES"
 _LAYER_BLOCK_RE = re.compile(r"^(?P<block>.*\.layers\.\d+)\.")
 
 ShardDomain = Literal["tp", "expert_tp"]
@@ -192,6 +196,26 @@ def _linear_disables_tensor_parallel_comm(linear: Any) -> bool:
 
 def default_lora_rank_for_handler(handler: Any) -> int:
     return MOE_LORA_RANK if bool(getattr(handler, "is_moe", False)) else DENSE_LORA_RANK
+
+
+def _configured_lora_rank(provider: Any, handler: Any) -> int:
+    rank = getattr(provider, "_art_lora_rank", None)
+    if rank is None:
+        rank = os.environ.get(MEGATRON_LORA_RANK_ENV)
+    if rank is None:
+        return default_lora_rank_for_handler(handler)
+    return int(rank)
+
+
+def _configured_lora_target_modules(provider: Any, spec: Any) -> list[str]:
+    target_modules = getattr(provider, "_art_lora_target_modules", None)
+    if target_modules is None and (
+        raw_target_modules := os.environ.get(MEGATRON_LORA_TARGET_MODULES_ENV)
+    ):
+        target_modules = json.loads(raw_target_modules)
+    if target_modules is None:
+        target_modules = spec.default_target_modules
+    return [str(target_module) for target_module in target_modules]
 
 
 def _column_parallel_lora_input(x: torch.Tensor, linear: Any) -> torch.Tensor:
@@ -1687,8 +1711,8 @@ def apply_lora_adapters(
     provider = cast(Any, provider)
     handler = provider._art_model_support_handler
     spec = provider._art_model_support_spec
-    target_modules = list(spec.default_target_modules)
-    rank = default_lora_rank_for_handler(handler)
+    target_modules = _configured_lora_target_modules(provider, spec)
+    rank = _configured_lora_rank(provider, handler)
     handler.apply_lora_adapters(
         model,
         provider,

--- a/src/art/megatron/model_support/handlers/qwen3_5.py
+++ b/src/art/megatron/model_support/handlers/qwen3_5.py
@@ -483,7 +483,10 @@ class Qwen35MoeHandler(Qwen35BaseHandler):
         rank: int,
         alpha: int,
     ) -> None:
-        from art.megatron.lora import wrap_grouped_moe_experts_3d
+        from art.megatron.lora import (
+            wrap_grouped_moe_experts_3d,
+            wrap_shared_experts_mlp,
+        )
 
         wrap_grouped_moe_experts_3d(
             _require_moe_experts(module),
@@ -492,6 +495,16 @@ class Qwen35MoeHandler(Qwen35BaseHandler):
             rank=rank,
             alpha=alpha,
         )
+        shared_experts = getattr(module.mlp, "shared_experts", None)
+        if shared_experts is not None:
+            wrap_shared_experts_mlp(
+                shared_experts,
+                adapter_model_prefix=adapter_model_prefix,
+                provider=provider,
+                target_modules=target_modules,
+                rank=rank,
+                alpha=alpha,
+            )
 
     def _add_mlp_adapter_weights(
         self,
@@ -502,6 +515,7 @@ class Qwen35MoeHandler(Qwen35BaseHandler):
     ) -> None:
         from art.megatron.weights.adapter_export import (
             add_grouped_moe_adapter_weights,
+            add_shared_experts_adapter_weights,
         )
 
         add_grouped_moe_adapter_weights(
@@ -509,6 +523,13 @@ class Qwen35MoeHandler(Qwen35BaseHandler):
             layer_prefix=layer_prefix,
             experts=_require_moe_experts(module),
         )
+        shared_experts = getattr(module.mlp, "shared_experts", None)
+        if shared_experts is not None:
+            add_shared_experts_adapter_weights(
+                adapter_weights_by_base,
+                layer_prefix=layer_prefix,
+                shared_experts=shared_experts,
+            )
 
     def compile_workaround_config(
         self,
@@ -680,12 +701,23 @@ def _clone(tensor: torch.Tensor) -> torch.Tensor:
     return tensor.clone().contiguous()
 
 
-def _vllm_moe_config(adapter_config: dict[str, Any]) -> dict[str, Any]:
+def _has_shared_expert_lora_tensors(tensors: dict[str, torch.Tensor]) -> bool:
+    return any(".mlp.shared_expert." in key for key in tensors)
+
+
+def _vllm_moe_config(
+    adapter_config: dict[str, Any],
+    *,
+    has_shared_experts: bool = False,
+) -> dict[str, Any]:
     config = dict(adapter_config)
+    stripped_modules = {"gate_up_proj"}
+    if not has_shared_experts:
+        stripped_modules.update({"gate_proj", "up_proj", "down_proj"})
     target_modules = [
         module
         for module in list(config.get("target_modules") or [])
-        if module not in {"gate_proj", "up_proj", "down_proj", "gate_up_proj"}
+        if module not in stripped_modules
     ]
     if "experts" not in target_modules:
         target_modules.append("experts")
@@ -714,6 +746,7 @@ def _to_vllm_lora_tensors(
     adapter_config: dict[str, Any],
 ) -> tuple[dict[str, torch.Tensor], dict[str, Any]]:
     grouped = _group_art_moe_tensors(tensors)
+    has_shared_experts = _has_shared_expert_lora_tensors(tensors)
     if not grouped:
         has_fused_experts = any(_VLLM_MOE_KEY_RE.match(key) for key in tensors)
         transformed: dict[str, torch.Tensor] = {}
@@ -729,7 +762,8 @@ def _to_vllm_lora_tensors(
                 )
             transformed[vllm_key] = tensor
         return transformed, _vllm_moe_config(
-            adapter_config
+            adapter_config,
+            has_shared_experts=has_shared_experts,
         ) if has_fused_experts else adapter_config
     transformed: dict[str, torch.Tensor] = {}
     used_keys: set[str] = set()
@@ -783,7 +817,10 @@ def _to_vllm_lora_tensors(
             adapter_config=adapter_config,
         )
         transformed[vllm_key] = tensor
-    return transformed, _vllm_moe_config(adapter_config)
+    return transformed, _vllm_moe_config(
+        adapter_config,
+        has_shared_experts=has_shared_experts,
+    )
 
 
 def _from_vllm_lora_tensors(

--- a/src/art/megatron/model_support/registry.py
+++ b/src/art/megatron/model_support/registry.py
@@ -49,6 +49,9 @@ _QWEN3_5_MOE_TARGET_MODULES = (
     "in_proj_z",
     "out_proj",
     "experts",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
 )
 
 DEFAULT_DENSE_SPEC = ModelSupportSpec(

--- a/src/art/megatron/routing_replay.py
+++ b/src/art/megatron/routing_replay.py
@@ -744,16 +744,29 @@ class MoeRoutingReplayController:
                 topk = int(getattr(module, "topk"))
                 original_routing = module.routing
 
+                def _prepare_native_target_for_bound_router(
+                    _controller: MoeRoutingReplayController = self,
+                    _router_key: str = router_key,
+                ) -> None:
+                    _controller._prepare_native_target_for_router(_router_key)
+
+                prepare_native_target = torch.compiler.disable(
+                    _prepare_native_target_for_bound_router
+                )
+
                 def _routing_with_replay_target(
                     router_module: Any,
                     *args: Any,
                     _controller: MoeRoutingReplayController = self,
-                    _router_key: str = router_key,
                     _original_routing: Any = original_routing,
+                    _prepare_native_target: Any = prepare_native_target,
                     **kwargs: Any,
                 ) -> Any:
                     del router_module
-                    _controller._prepare_native_target_for_router(_router_key)
+                    del _controller
+                    # Replay target selection mutates Python cursor dictionaries and
+                    # must stay outside Dynamo; routing compute below remains compiled.
+                    _prepare_native_target()
                     return _original_routing(*args, **kwargs)
 
                 module.routing = types.MethodType(_routing_with_replay_target, module)

--- a/src/art/megatron/service.py
+++ b/src/art/megatron/service.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 import gc
 import importlib
+import json
 import os
 from pathlib import Path
 import shutil
@@ -32,7 +33,12 @@ from ..vllm_runtime import (
     ManagedVllmRuntime,
     VllmRuntimeLaunchConfig,
 )
-from .lora import LORA_ALPHA, default_lora_rank_for_handler
+from .lora import (
+    LORA_ALPHA,
+    MEGATRON_LORA_RANK_ENV,
+    MEGATRON_LORA_TARGET_MODULES_ENV,
+    default_lora_rank_for_handler,
+)
 from .model_support.lora_disk import normalize_lora_checkpoint_to_vllm
 from .model_support.registry import (
     UnsupportedModelArchitectureError,
@@ -730,6 +736,11 @@ class MegatronService:
         random_state = self._megatron_random_state()
         if random_state is not None:
             env["ART_MEGATRON_RANDOM_STATE"] = str(random_state)
+        lora_config = self.config.get("lora_config", {})
+        if (rank := lora_config.get("rank")) is not None:
+            env[MEGATRON_LORA_RANK_ENV] = str(int(rank))
+        if target_modules := lora_config.get("target_modules"):
+            env[MEGATRON_LORA_TARGET_MODULES_ENV] = json.dumps(list(target_modules))
         if megatron_topology is not None:
             for env_name in self._megatron_topology_env_names():
                 env.pop(env_name, None)

--- a/src/art/megatron/service.py
+++ b/src/art/megatron/service.py
@@ -73,6 +73,7 @@ def create_identity_lora(
     base_model: str,
     lora_path: str,
     rank: int | None = None,
+    target_modules: list[str] | None = None,
     lora_alpha: int = LORA_ALPHA,
     random_state: int | None = None,
     allow_unvalidated_arch: bool = False,
@@ -98,7 +99,7 @@ def create_identity_lora(
 
     if random_state is not None:
         torch.manual_seed(random_state)
-    target_modules = default_target_modules(base_model)
+    target_modules = target_modules or default_target_modules(base_model)
     handler = get_model_support_handler(
         base_model,
         allow_unvalidated_arch=allow_unvalidated_arch,
@@ -427,11 +428,16 @@ class MegatronService:
             self.base_model,
             allow_unvalidated_arch=self._allow_unvalidated_arch,
         )
+        lora_config = self.config.get("lora_config", {})
+        rank = int(lora_config.get("rank", default_lora_rank_for_handler(handler)))
+        target_modules = lora_config.get("target_modules") or default_target_modules(
+            self.base_model
+        )
         return LoraConfig(
             base_model_name_or_path=self.base_model,
-            r=default_lora_rank_for_handler(handler),
+            r=rank,
             lora_alpha=LORA_ALPHA,
-            target_modules=default_target_modules(self.base_model),
+            target_modules=target_modules,
             bias="none",
         )
 
@@ -448,9 +454,13 @@ class MegatronService:
         return True
 
     def _create_identity_lora(self, lora_path: str) -> None:
+        lora_config = self.config.get("lora_config", {})
+        rank = lora_config.get("rank")
         create_identity_lora(
             self.base_model,
             lora_path,
+            rank=int(rank) if rank is not None else None,
+            target_modules=lora_config.get("target_modules"),
             random_state=self._megatron_random_state(),
             allow_unvalidated_arch=self._allow_unvalidated_arch,
         )

--- a/tests/integration/megatron/lora/test_lora_disk_codecs.py
+++ b/tests/integration/megatron/lora/test_lora_disk_codecs.py
@@ -189,6 +189,34 @@ def _qwen35_moe_art_tensors(prefix: str, *, rank: int = 2) -> dict[str, torch.Te
     return tensors
 
 
+def _qwen35_shared_expert_art_tensors(
+    prefix: str,
+    *,
+    rank: int = 2,
+) -> dict[str, torch.Tensor]:
+    hidden = 3
+    intermediate = 4
+    tensors: dict[str, torch.Tensor] = {}
+    offset = 1000
+    for module, in_dim, out_dim in (
+        ("gate_proj", hidden, intermediate),
+        ("up_proj", hidden, intermediate),
+        ("down_proj", intermediate, hidden),
+    ):
+        module_prefix = f"{prefix}.mlp.shared_expert.{module}"
+        tensors[f"{module_prefix}.lora_A.weight"] = (
+            torch.arange(rank * in_dim, dtype=torch.float32).reshape(rank, in_dim)
+            + offset
+        )
+        offset += 100
+        tensors[f"{module_prefix}.lora_B.weight"] = (
+            torch.arange(out_dim * rank, dtype=torch.float32).reshape(out_dim, rank)
+            + offset
+        )
+        offset += 100
+    return tensors
+
+
 def _pack_qwen35_vllm_lora_b(blocks: list[torch.Tensor]) -> torch.Tensor:
     stacked = torch.stack(blocks, dim=0)
     return stacked.permute(1, 2, 0).reshape(stacked.shape[1], -1).contiguous()
@@ -577,6 +605,41 @@ def test_qwen35_and_qwen36_vllm_canonical_roundtrip_and_stock_loader(tmp_path: P
         )
         assert "language_model.model.layers.0.mlp.experts" in loaded_modules
         assert "language_model.model.layers.0.mlp.experts.base_layer" in loaded_modules
+
+
+def test_qwen35_vllm_config_preserves_shared_expert_targets_when_present():
+    art_prefix = "base_model.model.model.layers.0"
+    original = {
+        **_qwen35_moe_art_tensors(art_prefix),
+        **_qwen35_shared_expert_art_tensors(art_prefix),
+    }
+    adapter_config = _qwen35_config("Qwen/Qwen3.6-35B-A3B")
+    adapter_config["target_modules"] = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "in_proj_qkv",
+        "in_proj_z",
+        "out_proj",
+        "experts",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+    ]
+    vllm_tensors, vllm_config = QWEN3_5_MOE_HANDLER.to_vllm_lora_tensors(
+        original,
+        adapter_config=adapter_config,
+    )
+    assert vllm_config["target_modules"] == adapter_config["target_modules"]
+    assert any(".mlp.shared_expert.gate_proj." in key for key in vllm_tensors)
+    assert any(".mlp.shared_expert.up_proj." in key for key in vllm_tensors)
+    assert any(".mlp.shared_expert.down_proj." in key for key in vllm_tensors)
+    roundtrip = QWEN3_5_MOE_HANDLER.from_vllm_lora_tensors(
+        vllm_tensors,
+        adapter_config=vllm_config,
+    )
+    _assert_tensors_equal(roundtrip, original)
 
 
 def test_qwen35_target_parameter_identity_normalizes_to_fused_vllm_layout(

--- a/tests/integration/megatron/runtime_isolation/test_service_runtime_boundary.py
+++ b/tests/integration/megatron/runtime_isolation/test_service_runtime_boundary.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from pathlib import Path
 import sys
 from types import SimpleNamespace
@@ -251,6 +252,10 @@ async def test_megatron_worker_uses_active_python_for_torchrun(
             "trainer_gpu_ids": [0],
             "inference_gpu_ids": [1],
             "rollout_weights_mode": "lora",
+            "lora_config": {
+                "rank": 8,
+                "target_modules": ["q_proj", "down_proj"],
+            },
         },
         output_dir=str(tmp_path),
     )
@@ -292,5 +297,11 @@ async def test_megatron_worker_uses_active_python_for_torchrun(
     ]
     assert "uv run" not in command
     assert recorded["cwd"] == str(Path(__file__).resolve().parents[4])
+    env = cast(dict[str, str], recorded["env"])
+    assert env["ART_MEGATRON_LORA_RANK"] == "8"
+    assert json.loads(env["ART_MEGATRON_LORA_TARGET_MODULES"]) == [
+        "q_proj",
+        "down_proj",
+    ]
     service._child_processes.close()
     service._megatron_log_file.close()

--- a/tests/integration/megatron/runtime_isolation/test_service_runtime_boundary.py
+++ b/tests/integration/megatron/runtime_isolation/test_service_runtime_boundary.py
@@ -49,6 +49,27 @@ class _FakeAsyncioProcess:
         return 0
 
 
+def test_megatron_default_lora_adapter_config_uses_model_lora_config(
+    tmp_path: Path,
+) -> None:
+    service = MegatronService(
+        model_name="test-model",
+        base_model="Qwen/Qwen3-0.6B",
+        config={
+            "lora_config": {
+                "rank": 8,
+                "target_modules": ["q_proj", "down_proj"],
+            },
+        },
+        output_dir=str(tmp_path),
+    )
+
+    config = service._default_lora_adapter_config()
+
+    assert config.r == 8
+    assert config.target_modules == {"q_proj", "down_proj"}
+
+
 @pytest.mark.asyncio
 async def test_megatron_shared_start_requires_runtime_sleep_mode(
     tmp_path: Path,

--- a/tests/unit/test_dedicated_config.py
+++ b/tests/unit/test_dedicated_config.py
@@ -169,6 +169,9 @@ def test_get_model_config_qwen3_5_moe_target_modules(base_model: str):
             "in_proj_z",
             "out_proj",
             "experts",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
         ]
 
 

--- a/tests/unit/test_moe_routing_replay.py
+++ b/tests/unit/test_moe_routing_replay.py
@@ -102,6 +102,61 @@ def _make_multi_call_bundle() -> MoeRoutingReplayBundle:
     )
 
 
+def _make_many_sampled_bundle(num_samples: int) -> MoeRoutingReplayBundle:
+    router_key = "chunk_00.layer_0000.mlp.router"
+    return MoeRoutingReplayBundle(
+        topology=ParallelTopology(tp=1, ep=1, etp=1, dp=1, sp=False, cp=1, pp=1, vpp=1),
+        num_steps=1,
+        max_topk=2,
+        router_keys=[router_key],
+        steps={
+            0: StepRoutes(
+                routers={
+                    router_key: StepRouterRoutes(
+                        calls={
+                            sample_index: _make_route(
+                                [[0, 2], [1, 0], [2, 1], [1, 0]],
+                                sample_index=sample_index,
+                            )
+                            for sample_index in range(num_samples)
+                        }
+                    )
+                },
+                global_token_uids=torch.arange(4, dtype=torch.int64),
+            )
+        },
+    )
+
+
+def _make_many_router_bundle(num_routers: int) -> MoeRoutingReplayBundle:
+    router_keys = [
+        f"chunk_00.layer_{layer_index:04d}.mlp.router"
+        for layer_index in range(num_routers)
+    ]
+    return MoeRoutingReplayBundle(
+        topology=ParallelTopology(tp=1, ep=1, etp=1, dp=1, sp=False, cp=1, pp=1, vpp=1),
+        num_steps=1,
+        max_topk=2,
+        router_keys=router_keys,
+        steps={
+            0: StepRoutes(
+                routers={
+                    router_key: StepRouterRoutes(
+                        calls={
+                            0: _make_route(
+                                [[0, 2], [1, 0], [2, 1], [1, 0]],
+                                sample_index=0,
+                            )
+                        }
+                    )
+                    for router_key in router_keys
+                },
+                global_token_uids=torch.arange(4, dtype=torch.int64),
+            )
+        },
+    )
+
+
 class _FakeParallelState:
     def __init__(
         self,
@@ -218,15 +273,49 @@ class _FakeLayer(nn.Module):
 
 
 class _FakeDecoder(nn.Module):
-    def __init__(self, router: _FakeRouter | None = None) -> None:
+    def __init__(
+        self,
+        router: _FakeRouter | None = None,
+        routers: list[_FakeRouter] | None = None,
+    ) -> None:
         super().__init__()
-        self.layers = nn.ModuleList([_FakeLayer(router)])
+        layer_routers = routers if routers is not None else [router]
+        self.layers = nn.ModuleList(
+            [_FakeLayer(layer_router) for layer_router in layer_routers]
+        )
 
 
 class _FakeChunk(nn.Module):
-    def __init__(self, router: _FakeRouter | None = None) -> None:
+    def __init__(
+        self,
+        router: _FakeRouter | None = None,
+        routers: list[_FakeRouter] | None = None,
+    ) -> None:
         super().__init__()
-        self.decoder = _FakeDecoder(router)
+        self.decoder = _FakeDecoder(router, routers)
+
+
+class _FakeRouterCaller(nn.Module):
+    def __init__(self, router: _FakeRouter) -> None:
+        super().__init__()
+        self.router = router
+
+    def forward(self, logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.router.routing(logits)
+
+
+class _FakeManyRouterCaller(nn.Module):
+    def __init__(self, chunk: _FakeChunk) -> None:
+        super().__init__()
+        self.chunk = chunk
+
+    def forward(self, logits: torch.Tensor) -> torch.Tensor:
+        maps: list[torch.Tensor] = []
+        for layer_module in self.chunk.decoder.layers:
+            layer = cast(_FakeLayer, layer_module)
+            _probs, routing_map = layer.mlp.router.routing(logits)
+            maps.append(routing_map.to(torch.float32))
+        return torch.stack(maps)
 
 
 def _fake_chunk_router(chunk: _FakeChunk) -> _FakeRouter:
@@ -252,20 +341,38 @@ def _expected_routing_map(route: RouterCallRoute) -> torch.Tensor:
     return routing_map
 
 
-def test_routing_replay_token_uid_sets_keep_full_attention_layout_with_gdn_plan() -> None:
+def _counting_backend() -> Any:
+    compile_count = {"value": 0}
+
+    def _backend(gm: torch.fx.GraphModule, example_inputs: list[Any]) -> Any:
+        del example_inputs
+        compile_count["value"] += 1
+        return gm.forward
+
+    _backend.compile_count = compile_count  # type: ignore[attr-defined]
+    return _backend
+
+
+def test_routing_replay_token_uid_sets_keep_full_attention_layout_with_gdn_plan() -> (
+    None
+):
     token_uids = torch.tensor([[0, 1, 2, 3, 4, 5]], dtype=torch.int64)
 
     token_uid_sets = _routing_replay_token_uid_sets(
         token_uids,
         attention_state=_FakeAttentionState(),
     )
+    attention_uids = token_uid_sets["attention"]
+    gdn_uids = token_uid_sets["gdn"]
+    assert attention_uids is not None
+    assert gdn_uids is not None
 
     assert torch.equal(
-        token_uid_sets["attention"],
+        attention_uids,
         torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int64),
     )
     assert torch.equal(
-        token_uid_sets["gdn"],
+        gdn_uids,
         torch.tensor([0, 2], dtype=torch.int64),
     )
 
@@ -360,6 +467,64 @@ def test_controller_uses_native_router_replay_target_indices() -> None:
 
     controller.finalize_step()
     controller.remove_router_patches()
+
+
+def test_controller_target_prepare_does_not_recompile_with_router_cursor() -> None:
+    bundle = _make_many_sampled_bundle(num_samples=10)
+    controller = MoeRoutingReplayController(bundle=bundle, strict=True, device="cpu")
+    chunk = _FakeChunk()
+    router = _fake_chunk_router(chunk)
+    backend = _counting_backend()
+    compiled = torch.compile(_FakeRouterCaller(router), backend=backend)
+
+    controller.install_router_patches([chunk])
+    try:
+        controller.set_step(step_index=0, sample_index=list(range(10)))
+        for sample_index in range(10):
+            controller.begin_micro(sample_index, sample_index)
+            controller.set_local_input_token_uids(torch.arange(4, dtype=torch.int64))
+            _probs, routing_map = compiled(torch.randn((4, 3), dtype=torch.float32))
+            assert torch.equal(
+                routing_map.cpu(),
+                _expected_routing_map(
+                    bundle.steps[0].routers[bundle.router_keys[0]].calls[sample_index]
+                ),
+            )
+
+        assert backend.compile_count["value"] <= 3  # type: ignore[attr-defined]
+        controller.finalize_step()
+    finally:
+        controller.remove_router_patches()
+
+
+def test_controller_target_prepare_does_not_recompile_per_router_key() -> None:
+    num_routers = 10
+    bundle = _make_many_router_bundle(num_routers)
+    controller = MoeRoutingReplayController(bundle=bundle, strict=True, device="cpu")
+    chunk = _FakeChunk(routers=[_FakeRouter() for _ in range(num_routers)])
+    backend = _counting_backend()
+    compiled = torch.compile(_FakeManyRouterCaller(chunk), backend=backend)
+
+    controller.install_router_patches([chunk])
+    try:
+        controller.set_step(step_index=0, sample_index=[0])
+        controller.begin_micro(0, 0)
+        controller.set_local_input_token_uids(torch.arange(4, dtype=torch.int64))
+        routing_maps = compiled(torch.randn((4, 3), dtype=torch.float32))
+        expected = torch.stack(
+            [
+                _expected_routing_map(bundle.steps[0].routers[router_key].calls[0]).to(
+                    torch.float32
+                )
+                for router_key in bundle.router_keys
+            ]
+        )
+        assert torch.equal(routing_maps.cpu(), expected)
+
+        assert backend.compile_count["value"] <= 3  # type: ignore[attr-defined]
+        controller.finalize_step()
+    finally:
+        controller.remove_router_patches()
 
 
 def test_controller_explicit_token_uids_refresh_native_router_replay() -> None:


### PR DESCRIPTION
## Summary
- keep MoE routing replay target preparation outside Dynamo tracing
- leave Megatron routing compute compiled after the graph break
- add a regression test for repeated routed replay calls advancing the replay cursor without recompile-limit churn

## Tests
- uv run ruff check src/art/megatron/routing_replay.py tests/unit/test_moe_routing_replay.py
- uv run ruff format --check src/art/megatron/routing_replay.py tests/unit/test_moe_routing_replay.py
- uv run ty check src/art/megatron/routing_replay.py tests/unit/test_moe_routing_replay.py
- uv run pytest tests/unit/test_moe_routing_replay.py