### PR TITLE
Keep routing replay target prep out of Dynamo

### DIFF
--- a/src/art/megatron/routing_replay.py
+++ b/src/art/megatron/routing_replay.py
@@ -744,16 +744,28 @@ class MoeRoutingReplayController:
                 topk = int(getattr(module, "topk"))
                 original_routing = module.routing
 
+                def _prepare_native_target_for_bound_router(
+                    _controller: MoeRoutingReplayController = self,
+                    _router_key: str = router_key,
+                ) -> None:
+                    _controller._prepare_native_target_for_router(_router_key)
+
+                prepare_native_target = torch.compiler.disable(
+                    _prepare_native_target_for_bound_router
+                )
+
                 def _routing_with_replay_target(
                     router_module: Any,
                     *args: Any,
-                    _controller: MoeRoutingReplayController = self,
-                    _router_key: str = router_key,
                     _original_routing: Any = original_routing,
+                    _prepare_native_target: Any = prepare_native_target,
                     **kwargs: Any,
                 ) -> Any:
                     del router_module
-                    _controller._prepare_native_target_for_router(_router_key)
+                    # Target selection mutates Python replay cursors and Megatron's
+                    # RouterReplay state; keep it out of Dynamo while preserving
+                    # compiled routing compute below.
+                    _prepare_native_target()
                     return _original_routing(*args, **kwargs)
 
                 module.routing = types.MethodType(_routing_with_replay_target, module)


### PR DESCRIPTION
## Summary
- keep MoE routing replay target preparation outside TorchDynamo with a narrow torch.compiler.disable boundary
- preserve compiled execution for the original Megatron routing call

## Why
Routing replay target preparation mutates Python replay cursors and Megatron RouterReplay state. When this runs inside a compiled router frame, Dynamo guards on changing replay state and recompiles across router/lifecycle calls.

## Validation
- uv sync --all-extras
- uv run ruff check src/art/megatron/routing_replay.py
- uv run ruff format --check src/art/megatron/routing_replay.py
- uv run ty check src/art/megatron/routing_replay.py
- commit hooks passed: ruff, ruff format, ty, uv.lock sync check

Additional local investigation: the shared 3-step Qwen3.5 Megatron smoke that reproduced the SIGSEGV on PR720+721 passed with this boundary applied, and the routing-replay Dynamo signatures disappeared.