### PR TITLE
Security: Unsafe deserialization of pickle log files

### DIFF
--- a/src/art/langgraph/logging.py
+++ b/src/art/langgraph/logging.py
@@ -1,30 +1,27 @@
+import json
 import os
-import pickle
 
 
 class FileLogger:
     def __init__(self, filepath):
         self.text_path = filepath
-        self.pickle_path = filepath + ".pkl"
+        self.jsonl_path = filepath + ".jsonl"
 
     def log(self, name, entry):
         # Log as readable text
         with open(self.text_path, "a") as f:
             f.write(f"{name}: {entry}\n")
 
-        # Append to pickle log
-        with open(self.pickle_path, "ab") as pf:
-            pickle.dump((name, entry), pf)
+        # Append to JSON Lines log
+        with open(self.jsonl_path, "a") as jf:
+            jf.write(json.dumps([name, entry]) + "\n")
 
     def load_logs(self):
-        """Load all logs from the pickle file."""
-        if not os.path.exists(self.pickle_path):
+        """Load all logs from the JSON Lines file."""
+        if not os.path.exists(self.jsonl_path):
             return []
         logs = []
-        with open(self.pickle_path, "rb") as pf:
-            try:
-                while True:
-                    logs.append(pickle.load(pf))
-            except EOFError:
-                pass
+        with open(self.jsonl_path, "r") as jf:
+            for line in jf:
+                logs.append(tuple(json.loads(line)))
         return logs


### PR DESCRIPTION
## Summary

Security: Unsafe deserialization of pickle log files

## Problem

**Severity**: `High` | **File**: `src/art/langgraph/logging.py:L23`

FileLogger.load_logs() deserializes entries from a .pkl file using pickle.load(). Pickle is not safe for untrusted or tampered data and can execute arbitrary code during deserialization. If an attacker can write or replace the pickle log file, loading logs can lead to code execution in the caller's process.

## Solution

Avoid pickle for log storage. Use a safe format such as JSON Lines, msgpack without object hooks, or another data-only serialization format. If backwards compatibility is required, only load pickle files from trusted locations with strict file permissions and clearly document that they must never be opened from untrusted sources.

## Changes

- `src/art/langgraph/logging.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.8.0*