### PR TITLE
feat: Add ART GPU image build script

### DIFF
--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -191,7 +191,10 @@ jobs:
           IMAGE_TAG="${IMAGE_TAG:-latest}"
           SMOKE_GPUS="${SMOKE_GPUS:-H200:1}"
           cluster="art-gpu-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          sky_cmd=(uv run --python 3.10 --no-project --with 'skypilot[kubernetes,remote]==0.12.0' sky)
+          sky_venv="${RUNNER_TEMP}/skypilot-smoke"
+          uv venv --python 3.10 "${sky_venv}"
+          uv pip install --python "${sky_venv}/bin/python" 'skypilot[kubernetes,remote]==0.12.0'
+          sky_cmd=("${sky_venv}/bin/sky")
           dump_diagnostics() {
             echo "::group::Smoke diagnostics"
             free -h || true

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -1,6 +1,8 @@
 name: Build GPU Image
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       image_repo:

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -10,6 +10,11 @@ on:
         required: true
         default: "docker.io/bradhiltonnw/art-gpu"
         type: string
+      pull_image_repo:
+        description: "Image repository for cluster pulls/prewarm"
+        required: true
+        default: "images.coreweave.com/cluster-images/bradhiltonnw/art-gpu"
+        type: string
       tag:
         description: "Image tag to push"
         required: true
@@ -147,12 +152,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           IMAGE_REPO: ${{ inputs.image_repo || 'docker.io/bradhiltonnw/art-gpu' }}
+          PULL_IMAGE_REPO: ${{ inputs.pull_image_repo || 'images.coreweave.com/cluster-images/bradhiltonnw/art-gpu' }}
           IMAGE_TAG: ${{ inputs.tag }}
           NO_CACHE: ${{ inputs.no_cache }}
           PREWARM_NODES: ${{ inputs.prewarm_nodes }}
           PREWARM_TIMEOUT: ${{ inputs.prewarm_timeout }}
         run: |
-          IMAGE_TAG="${IMAGE_TAG:-gha-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
+          IMAGE_TAG="${IMAGE_TAG:-latest}"
           NO_CACHE="${NO_CACHE:-false}"
           PREWARM_NODES="${PREWARM_NODES:-true}"
           PREWARM_TIMEOUT="${PREWARM_TIMEOUT:-30m}"
@@ -160,6 +166,7 @@ jobs:
           args=(
             --infra "${SKY_INFRA}"
             --image-repo "${IMAGE_REPO}"
+            --pull-image-repo "${PULL_IMAGE_REPO}"
             --tag "${IMAGE_TAG}"
             --prewarm-timeout "${PREWARM_TIMEOUT}"
           )
@@ -177,11 +184,11 @@ jobs:
       - name: Smoke launch pushed image
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.smoke_launch }}
         env:
-          IMAGE_REPO: ${{ inputs.image_repo || 'docker.io/bradhiltonnw/art-gpu' }}
+          PULL_IMAGE_REPO: ${{ inputs.pull_image_repo || 'images.coreweave.com/cluster-images/bradhiltonnw/art-gpu' }}
           IMAGE_TAG: ${{ inputs.tag }}
           SMOKE_GPUS: ${{ inputs.smoke_gpus }}
         run: |
-          IMAGE_TAG="${IMAGE_TAG:-gha-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
+          IMAGE_TAG="${IMAGE_TAG:-latest}"
           SMOKE_GPUS="${SMOKE_GPUS:-H200:1}"
           cluster="art-gpu-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           sky_cmd=(uv run --python 3.10 --no-project --with 'skypilot[kubernetes,remote]==0.11.1' sky)
@@ -196,7 +203,7 @@ jobs:
               -c "${cluster}" \
               --infra "${SKY_INFRA}" \
               --gpus "${SMOKE_GPUS}" \
-              --image-id "docker:${IMAGE_REPO}:${IMAGE_TAG}" \
+              --image-id "docker:${PULL_IMAGE_REPO}:${IMAGE_TAG}" \
               --config kubernetes.pod_config.spec.schedulerName=binpack-scheduler \
               --config kubernetes.pod_config.spec.activeDeadlineSeconds=604800 \
               'python -c "import pathlib, subprocess; print(\"ART_IMAGE_SMOKE_OK\"); print(\"SKY_PYTHON_PATH\", pathlib.Path.home().joinpath(\".sky/python_path\").read_text().strip()); print(\"RAY_PATH\", pathlib.Path.home().joinpath(\".sky/ray_path\").read_text().strip()); print(\"UV\", subprocess.check_output([\"uv\", \"--version\"], text=True).strip())"'

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -182,17 +182,15 @@ jobs:
           IMAGE_TAG="${IMAGE_TAG:-gha-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
           SMOKE_GPUS="${SMOKE_GPUS:-H200:1}"
           cluster="art-gpu-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          sky_cmd=(uv run --python 3.10 --no-project --with 'skypilot[kubernetes,remote]==0.11.1' sky)
           cleanup() {
-            uv run --no-project --with 'skypilot[kubernetes,remote]==0.11.1' \
-              sky down -y "${cluster}" || true
+            "${sky_cmd[@]}" down -y "${cluster}" || true
           }
           trap cleanup EXIT
 
-          uv run --no-project --with 'skypilot[kubernetes,remote]==0.11.1' \
-            sky check kubernetes
+          "${sky_cmd[@]}" check kubernetes
 
-          /usr/bin/time -p uv run --no-project --with 'skypilot[kubernetes,remote]==0.11.1' \
-            sky launch -y \
+          /usr/bin/time -p "${sky_cmd[@]}" launch -y \
               -c "${cluster}" \
               --infra "${SKY_INFRA}" \
               --gpus "${SMOKE_GPUS}" \

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -191,7 +191,7 @@ jobs:
           IMAGE_TAG="${IMAGE_TAG:-latest}"
           SMOKE_GPUS="${SMOKE_GPUS:-H200:1}"
           cluster="art-gpu-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          sky_cmd=(uv run --python 3.10 --no-project --with 'skypilot[kubernetes,remote]==0.11.1' sky)
+          sky_cmd=(uv run --python 3.10 --no-project --with 'skypilot[kubernetes,remote]==0.11.2' sky)
           cleanup() {
             "${sky_cmd[@]}" down -y "${cluster}" || true
           }

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -193,7 +193,7 @@ jobs:
           cluster="art-gpu-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           sky_venv="${RUNNER_TEMP}/skypilot-smoke"
           uv venv --python 3.10 "${sky_venv}"
-          uv pip install --python "${sky_venv}/bin/python" 'skypilot[kubernetes,remote]==0.12.0'
+          uv pip install --python "${sky_venv}/bin/python" 'skypilot[kubernetes,remote]==0.12.0' 'kubernetes==34.1.0'
           sky_cmd=("${sky_venv}/bin/sky")
           dump_diagnostics() {
             echo "::group::Smoke diagnostics"

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Install kubectl
         run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends socat
           kubectl_version="$(curl -LsSf https://dl.k8s.io/release/stable.txt)"
           curl -LsSf -o kubectl "https://dl.k8s.io/release/${kubectl_version}/bin/linux/amd64/kubectl"
           sudo install -m 0755 kubectl /usr/local/bin/kubectl

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -192,10 +192,28 @@ jobs:
           SMOKE_GPUS="${SMOKE_GPUS:-H200:1}"
           cluster="art-gpu-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           sky_cmd=(uv run --python 3.10 --no-project --with 'skypilot[kubernetes,remote]==0.11.2' sky)
+          dump_diagnostics() {
+            echo "::group::Smoke diagnostics"
+            free -h || true
+            ps -eo pid,ppid,stat,rss,comm,args | grep -E 'SkyPilot|sky|python' || true
+            "${sky_cmd[@]}" api status || true
+            if [ -f "${HOME}/.sky/api_server/server.log" ]; then
+              tail -n 240 "${HOME}/.sky/api_server/server.log" || true
+            fi
+            echo "::endgroup::"
+          }
           cleanup() {
             "${sky_cmd[@]}" down -y "${cluster}" || true
           }
-          trap cleanup EXIT
+          finish() {
+            status=$?
+            if [ "${status}" -ne 0 ]; then
+              dump_diagnostics
+            fi
+            cleanup
+            exit "${status}"
+          }
+          trap finish EXIT
 
           "${sky_cmd[@]}" check kubernetes
 

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -171,7 +171,7 @@ jobs:
           bash scripts/build-gpu-image.sh "${args[@]}"
 
       - name: Smoke launch pushed image
-        if: ${{ inputs.smoke_launch != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.smoke_launch }}
         env:
           IMAGE_REPO: ${{ inputs.image_repo || 'docker.io/bradhiltonnw/art-gpu' }}
           IMAGE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Configure registry auth
         env:
-          IMAGE_REPO: ${{ inputs.image_repo }}
+          IMAGE_REPO: ${{ inputs.image_repo || 'docker.io/bradhiltonnw/art-gpu' }}
           REGISTRY_AUTH_JSON_B64_SECRET: ${{ secrets.REGISTRY_AUTH_JSON_B64 }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -142,12 +142,17 @@ jobs:
       - name: Build, push, and prewarm GPU image
         env:
           GH_TOKEN: ${{ github.token }}
-          IMAGE_REPO: ${{ inputs.image_repo }}
+          IMAGE_REPO: ${{ inputs.image_repo || 'docker.io/bradhiltonnw/art-gpu' }}
           IMAGE_TAG: ${{ inputs.tag }}
           NO_CACHE: ${{ inputs.no_cache }}
           PREWARM_NODES: ${{ inputs.prewarm_nodes }}
           PREWARM_TIMEOUT: ${{ inputs.prewarm_timeout }}
         run: |
+          IMAGE_TAG="${IMAGE_TAG:-gha-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
+          NO_CACHE="${NO_CACHE:-false}"
+          PREWARM_NODES="${PREWARM_NODES:-true}"
+          PREWARM_TIMEOUT="${PREWARM_TIMEOUT:-30m}"
+
           args=(
             --infra "${SKY_INFRA}"
             --image-repo "${IMAGE_REPO}"
@@ -166,12 +171,14 @@ jobs:
           bash scripts/build-gpu-image.sh "${args[@]}"
 
       - name: Smoke launch pushed image
-        if: ${{ inputs.smoke_launch }}
+        if: ${{ inputs.smoke_launch != false }}
         env:
-          IMAGE_REPO: ${{ inputs.image_repo }}
+          IMAGE_REPO: ${{ inputs.image_repo || 'docker.io/bradhiltonnw/art-gpu' }}
           IMAGE_TAG: ${{ inputs.tag }}
           SMOKE_GPUS: ${{ inputs.smoke_gpus }}
         run: |
+          IMAGE_TAG="${IMAGE_TAG:-gha-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}"
+          SMOKE_GPUS="${SMOKE_GPUS:-H200:1}"
           cluster="art-gpu-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           cleanup() {
             uv run --no-project --with 'skypilot[kubernetes,remote]==0.11.1' \

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -1,0 +1,194 @@
+name: Build GPU Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_repo:
+        description: "Image repository to push"
+        required: true
+        default: "docker.io/bradhiltonnw/art-gpu"
+        type: string
+      tag:
+        description: "Image tag to push"
+        required: true
+        default: "latest"
+        type: string
+      no_cache:
+        description: "Disable registry-backed BuildKit cache"
+        required: true
+        default: false
+        type: boolean
+      prewarm_nodes:
+        description: "Pre-pull the pushed image on GPU nodes"
+        required: true
+        default: true
+        type: boolean
+      prewarm_timeout:
+        description: "Timeout for GPU node prewarm rollout"
+        required: true
+        default: "30m"
+        type: string
+      smoke_launch:
+        description: "Launch a minimal SkyPilot task with the pushed image"
+        required: true
+        default: true
+        type: boolean
+      smoke_gpus:
+        description: "GPU request for the smoke launch"
+        required: true
+        default: "H200:1"
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-gpu-image-cks-wb3
+  cancel-in-progress: false
+
+jobs:
+  build-gpu-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    env:
+      SKY_INFRA: k8s/cks-wb3
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
+
+      - name: Install kubectl
+        run: |
+          kubectl_version="$(curl -LsSf https://dl.k8s.io/release/stable.txt)"
+          curl -LsSf -o kubectl "https://dl.k8s.io/release/${kubectl_version}/bin/linux/amd64/kubectl"
+          sudo install -m 0755 kubectl /usr/local/bin/kubectl
+          kubectl version --client=true
+
+      - name: Configure cks-wb3 kubeconfig
+        env:
+          CKS_WB3_KUBECONFIG: ${{ secrets.CKS_WB3_KUBECONFIG }}
+        run: |
+          if [ -z "${CKS_WB3_KUBECONFIG}" ]; then
+            echo "::error::Missing required CKS_WB3_KUBECONFIG secret."
+            exit 1
+          fi
+
+          mkdir -p "${HOME}/.kube"
+          export KUBECONFIG_PATH="${HOME}/.kube/config"
+          python3 - <<'PY'
+          import base64
+          import binascii
+          import os
+          from pathlib import Path
+
+          value = os.environ["CKS_WB3_KUBECONFIG"].encode()
+          compact_value = b"".join(value.split())
+          try:
+              decoded = base64.b64decode(compact_value, validate=True)
+              data = decoded if decoded.lstrip().startswith(b"apiVersion:") else value
+          except binascii.Error:
+              data = value
+
+          Path(os.environ["KUBECONFIG_PATH"]).write_bytes(data)
+          PY
+          chmod 600 "${KUBECONFIG_PATH}"
+          kubectl --context cks-wb3 get nodes >/dev/null
+
+      - name: Configure registry auth
+        env:
+          IMAGE_REPO: ${{ inputs.image_repo }}
+          REGISTRY_AUTH_JSON_B64_SECRET: ${{ secrets.REGISTRY_AUTH_JSON_B64 }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          if [ -n "${REGISTRY_AUTH_JSON_B64_SECRET}" ]; then
+            echo "REGISTRY_AUTH_JSON_B64=${REGISTRY_AUTH_JSON_B64_SECRET}" >> "${GITHUB_ENV}"
+            exit 0
+          fi
+
+          registry_host="${IMAGE_REPO%%/*}"
+          if [ -z "${registry_host}" ] || [ "${registry_host}" = "${IMAGE_REPO}" ]; then
+            registry_host="docker.io"
+          fi
+
+          if [ "${registry_host}" != "docker.io" ]; then
+            echo "Using script-managed auth for ${registry_host}."
+            exit 0
+          fi
+
+          dockerhub_password="${DOCKERHUB_TOKEN:-${DOCKERHUB_PASSWORD:-}}"
+          if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${dockerhub_password}" ]; then
+            echo "::error::Docker Hub pushes require REGISTRY_AUTH_JSON_B64 or DOCKERHUB_USERNAME plus DOCKERHUB_TOKEN."
+            exit 1
+          fi
+
+          printf '%s' "${dockerhub_password}" | docker login docker.io \
+            --username "${DOCKERHUB_USERNAME}" \
+            --password-stdin
+          {
+            printf 'REGISTRY_AUTH_JSON_B64='
+            base64 -w 0 "${HOME}/.docker/config.json"
+            printf '\n'
+          } >> "${GITHUB_ENV}"
+
+      - name: Build, push, and prewarm GPU image
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_REPO: ${{ inputs.image_repo }}
+          IMAGE_TAG: ${{ inputs.tag }}
+          NO_CACHE: ${{ inputs.no_cache }}
+          PREWARM_NODES: ${{ inputs.prewarm_nodes }}
+          PREWARM_TIMEOUT: ${{ inputs.prewarm_timeout }}
+        run: |
+          args=(
+            --infra "${SKY_INFRA}"
+            --image-repo "${IMAGE_REPO}"
+            --tag "${IMAGE_TAG}"
+            --prewarm-timeout "${PREWARM_TIMEOUT}"
+          )
+
+          if [ "${NO_CACHE}" = "true" ]; then
+            args+=(--no-cache)
+          fi
+
+          if [ "${PREWARM_NODES}" != "true" ]; then
+            args+=(--no-prewarm-nodes)
+          fi
+
+          bash scripts/build-gpu-image.sh "${args[@]}"
+
+      - name: Smoke launch pushed image
+        if: ${{ inputs.smoke_launch }}
+        env:
+          IMAGE_REPO: ${{ inputs.image_repo }}
+          IMAGE_TAG: ${{ inputs.tag }}
+          SMOKE_GPUS: ${{ inputs.smoke_gpus }}
+        run: |
+          cluster="art-gpu-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() {
+            uv run --no-project --with 'skypilot[kubernetes,remote]==0.11.1' \
+              sky down -y "${cluster}" || true
+          }
+          trap cleanup EXIT
+
+          /usr/bin/time -p uv run --no-project --with 'skypilot[kubernetes,remote]==0.11.1' \
+            sky launch -y \
+              -c "${cluster}" \
+              --infra "${SKY_INFRA}" \
+              --gpus "${SMOKE_GPUS}" \
+              --image-id "docker:${IMAGE_REPO}:${IMAGE_TAG}" \
+              --config kubernetes.pod_config.spec.schedulerName=binpack-scheduler \
+              --config kubernetes.pod_config.spec.activeDeadlineSeconds=604800 \
+              'python -c "import pathlib, subprocess; print(\"ART_IMAGE_SMOKE_OK\"); print(\"SKY_PYTHON_PATH\", pathlib.Path.home().joinpath(\".sky/python_path\").read_text().strip()); print(\"RAY_PATH\", pathlib.Path.home().joinpath(\".sky/ray_path\").read_text().strip()); print(\"UV\", subprocess.check_output([\"uv\", \"--version\"], text=True).strip())"'
+
+          kubectl --context cks-wb3 get pods -n default \
+            -l "skypilot-cluster=${cluster}" \
+            -o jsonpath='{range .items[*]}{.metadata.name} {.spec.containers[0].image}{"\n"}{end}'

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -191,7 +191,7 @@ jobs:
           IMAGE_TAG="${IMAGE_TAG:-latest}"
           SMOKE_GPUS="${SMOKE_GPUS:-H200:1}"
           cluster="art-gpu-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          sky_cmd=(uv run --python 3.10 --no-project --with 'skypilot[kubernetes,remote]==0.11.2' sky)
+          sky_cmd=(uv run --python 3.10 --no-project --with 'skypilot[kubernetes,remote]==0.12.0' sky)
           dump_diagnostics() {
             echo "::group::Smoke diagnostics"
             free -h || true

--- a/.github/workflows/build-gpu-image.yml
+++ b/.github/workflows/build-gpu-image.yml
@@ -186,6 +186,9 @@ jobs:
           }
           trap cleanup EXIT
 
+          uv run --no-project --with 'skypilot[kubernetes,remote]==0.11.1' \
+            sky check kubernetes
+
           /usr/bin/time -p uv run --no-project --with 'skypilot[kubernetes,remote]==0.11.1' \
             sky launch -y \
               -c "${cluster}" \

--- a/dev/yes-no-maybe-fork-pipeline.sky.yaml
+++ b/dev/yes-no-maybe-fork-pipeline.sky.yaml
@@ -4,7 +4,7 @@ workdir: .
 
 resources:
   accelerators: ["H200:2", "H100-SXM:2", "H100:2", "A100-80GB:2"]
-  image_id: docker:docker.io/bradhiltonnw/art-gpu:latest
+  image_id: docker:images.coreweave.com/cluster-images/bradhiltonnw/art-gpu:latest
   ports:
     - 7999 # main ART server
     - 8000 # vLLM server

--- a/dev/yes-no-maybe-fork-pipeline.sky.yaml
+++ b/dev/yes-no-maybe-fork-pipeline.sky.yaml
@@ -4,13 +4,14 @@ workdir: .
 
 resources:
   accelerators: ["H200:2", "H100-SXM:2", "H100:2", "A100-80GB:2"]
-  image_id: docker:pytorch/pytorch:2.9.0-cuda12.8-cudnn9-devel
+  image_id: docker:docker.io/bradhiltonnw/art-gpu:latest
   ports:
     - 7999 # main ART server
     - 8000 # vLLM server
 
 envs:
   GIT_RESET_CLEAN: "false"
+  INSTALL_EXTRAS: "false"
   PYTHONUTF8: "1"
   GIT_USER_NAME: "Your Name"
   GIT_USER_EMAIL: "your.email@example.com"
@@ -27,7 +28,8 @@ config:
   kubernetes:
     pod_config:
       spec:
-        schedulerName: gpu-binpack
+        schedulerName: binpack-scheduler
+        activeDeadlineSeconds: 604800
         containers:
           - name: ray-node
             env:

--- a/dev/yes-no-maybe-fork.sky.yaml
+++ b/dev/yes-no-maybe-fork.sky.yaml
@@ -4,13 +4,14 @@ workdir: .
 
 resources:
   accelerators: ["H200:1", "H100-SXM:1", "H100:1", "A100-80GB:1"]
-  image_id: docker:pytorch/pytorch:2.9.0-cuda12.8-cudnn9-devel
+  image_id: docker:docker.io/bradhiltonnw/art-gpu:latest
   ports:
     - 7999 # main ART server
     - 8000 # vLLM server
 
 envs:
   GIT_RESET_CLEAN: "false" # preserve workdir files synced by SkyPilot
+  INSTALL_EXTRAS: "false"
   PYTHONUTF8: "1"
   GIT_USER_NAME: "Your Name"
   GIT_USER_EMAIL: "your.email@example.com"
@@ -27,7 +28,8 @@ config:
   kubernetes:
     pod_config:
       spec:
-        schedulerName: gpu-binpack
+        schedulerName: binpack-scheduler
+        activeDeadlineSeconds: 604800
         containers:
           - name: ray-node
             env:

--- a/dev/yes-no-maybe-fork.sky.yaml
+++ b/dev/yes-no-maybe-fork.sky.yaml
@@ -4,7 +4,7 @@ workdir: .
 
 resources:
   accelerators: ["H200:1", "H100-SXM:1", "H100:1", "A100-80GB:1"]
-  image_id: docker:docker.io/bradhiltonnw/art-gpu:latest
+  image_id: docker:images.coreweave.com/cluster-images/bradhiltonnw/art-gpu:latest
   ports:
     - 7999 # main ART server
     - 8000 # vLLM server

--- a/docker/art-gpu.Dockerfile
+++ b/docker/art-gpu.Dockerfile
@@ -94,8 +94,7 @@ ENV CUDA_HOME=/usr/local/cuda-12.8 \
     MAX_JOBS=${BUILD_JOBS} \
     NINJAFLAGS=-j${BUILD_JOBS} \
     PYTHONUNBUFFERED=1 \
-    HOME=/home/sky \
-    ART_PROJECT_ENVIRONMENT=/home/sky/art-project-venv
+    HOME=/home/sky
 
 SHELL ["/bin/bash", "-c"]
 
@@ -152,18 +151,6 @@ COPY --from=builder --chown=sky:sky /opt/uv-python /opt/uv-python
 
 USER sky
 WORKDIR /home/sky
-
-COPY --chown=sky:sky pyproject.toml uv.lock /tmp/art-project/
-
-RUN mkdir -p "${HOME}/sky_workdir" \
- && UV_PROJECT_ENVIRONMENT="${ART_PROJECT_ENVIRONMENT}" UV_LINK_MODE=copy uv sync \
-      --project /tmp/art-project \
-      --frozen \
-      --all-extras \
-      --no-install-project \
-      --python 3.12 \
- && touch "${ART_PROJECT_ENVIRONMENT}/.art-prebaked-all-extras" \
- && rm -rf /tmp/art-project
 
 RUN mkdir -p "${HOME}/.local/bin" "${HOME}/.sky/sky_app" "${HOME}/sky_workdir" \
  && ln -sf /opt/conda/bin/uv "${HOME}/.local/bin/uv" \

--- a/docker/art-gpu.Dockerfile
+++ b/docker/art-gpu.Dockerfile
@@ -152,6 +152,18 @@ COPY --from=builder --chown=sky:sky /opt/uv-python /opt/uv-python
 USER sky
 WORKDIR /home/sky
 
+COPY --chown=sky:sky pyproject.toml uv.lock /tmp/art-project/
+
+RUN mkdir -p "${HOME}/sky_workdir" \
+ && UV_PROJECT_ENVIRONMENT="${HOME}/sky_workdir/.venv" UV_LINK_MODE=copy uv sync \
+      --project /tmp/art-project \
+      --frozen \
+      --all-extras \
+      --no-install-project \
+      --python 3.12 \
+ && touch "${HOME}/sky_workdir/.venv/.art-prebaked-all-extras" \
+ && rm -rf /tmp/art-project
+
 RUN mkdir -p "${HOME}/.local/bin" "${HOME}/.sky/sky_app" "${HOME}/sky_workdir" \
  && ln -sf /opt/conda/bin/uv "${HOME}/.local/bin/uv" \
  && uv venv --seed "${HOME}/skypilot-runtime" --python 3.10 \

--- a/docker/art-gpu.Dockerfile
+++ b/docker/art-gpu.Dockerfile
@@ -94,7 +94,8 @@ ENV CUDA_HOME=/usr/local/cuda-12.8 \
     MAX_JOBS=${BUILD_JOBS} \
     NINJAFLAGS=-j${BUILD_JOBS} \
     PYTHONUNBUFFERED=1 \
-    HOME=/home/sky
+    HOME=/home/sky \
+    ART_PROJECT_ENVIRONMENT=/home/sky/art-project-venv
 
 SHELL ["/bin/bash", "-c"]
 
@@ -155,13 +156,13 @@ WORKDIR /home/sky
 COPY --chown=sky:sky pyproject.toml uv.lock /tmp/art-project/
 
 RUN mkdir -p "${HOME}/sky_workdir" \
- && UV_PROJECT_ENVIRONMENT="${HOME}/sky_workdir/.venv" UV_LINK_MODE=copy uv sync \
+ && UV_PROJECT_ENVIRONMENT="${ART_PROJECT_ENVIRONMENT}" UV_LINK_MODE=copy uv sync \
       --project /tmp/art-project \
       --frozen \
       --all-extras \
       --no-install-project \
       --python 3.12 \
- && touch "${HOME}/sky_workdir/.venv/.art-prebaked-all-extras" \
+ && touch "${ART_PROJECT_ENVIRONMENT}/.art-prebaked-all-extras" \
  && rm -rf /tmp/art-project
 
 RUN mkdir -p "${HOME}/.local/bin" "${HOME}/.sky/sky_app" "${HOME}/sky_workdir" \

--- a/docker/art-gpu.Dockerfile
+++ b/docker/art-gpu.Dockerfile
@@ -3,7 +3,11 @@ ARG ART_SHA=unknown
 ARG UV_VERSION=0.11.7
 ARG BUILD_JOBS=2
 ARG UV_CONCURRENT_BUILDS=1
-ARG SKYPILOT_VERSION=0.11.1
+ARG APEX_PARALLEL_BUILD=2
+ARG APEX_NVCC_THREADS=1
+ARG TORCH_CUDA_ARCH_LIST=9.0
+ARG CUDNN_PACKAGE_VERSION=9.10.2.21
+ARG SKYPILOT_VERSION=0.12.0
 ARG SKY_REMOTE_RAY_VERSION=2.9.3
 
 FROM ${BASE_IMAGE} AS builder
@@ -11,6 +15,10 @@ FROM ${BASE_IMAGE} AS builder
 ARG UV_VERSION
 ARG BUILD_JOBS
 ARG UV_CONCURRENT_BUILDS
+ARG APEX_PARALLEL_BUILD
+ARG APEX_NVCC_THREADS
+ARG TORCH_CUDA_ARCH_LIST
+ARG CUDNN_PACKAGE_VERSION
 
 ENV CUDA_HOME=/usr/local/cuda-12.8 \
     PATH=/opt/conda/bin:${PATH} \
@@ -18,6 +26,9 @@ ENV CUDA_HOME=/usr/local/cuda-12.8 \
     UV_PYTHON_INSTALL_DIR=/opt/uv-python \
     UV_LINK_MODE=copy \
     UV_CONCURRENT_BUILDS=${UV_CONCURRENT_BUILDS} \
+    APEX_PARALLEL_BUILD=${APEX_PARALLEL_BUILD} \
+    NVCC_APPEND_FLAGS=--threads\ ${APEX_NVCC_THREADS} \
+    TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST} \
     CMAKE_BUILD_PARALLEL_LEVEL=${BUILD_JOBS} \
     MAX_JOBS=${BUILD_JOBS} \
     NINJAFLAGS=-j${BUILD_JOBS} \
@@ -37,9 +48,26 @@ RUN if ! getent group messagebus >/dev/null; then groupadd -r messagebus; fi \
 
 WORKDIR /opt/src/art
 COPY pyproject.toml uv.lock ./
+COPY vllm_runtime/pyproject.toml vllm_runtime/uv.lock ./vllm_runtime/
 
-RUN UV_LINK_MODE=hardlink uv sync --frozen --extra backend --no-install-project --python 3.12 \
- && rm -rf .venv
+RUN /opt/conda/bin/python -m pip install --no-cache-dir "nvidia-cudnn-cu12==${CUDNN_PACKAGE_VERSION}" \
+ && mkdir -p /usr/local/cuda-12.8/include /usr/local/cuda-12.8/lib64 \
+ && : > /tmp/art-cudnn-symlinks.txt \
+ && for src in /opt/conda/lib/python3.11/site-packages/nvidia/cudnn/include/*; do \
+      dst="/usr/local/cuda-12.8/include/$(basename "$src")"; \
+      if [ ! -e "$dst" ]; then ln -s "$src" "$dst" && printf '%s\n' "$dst" >> /tmp/art-cudnn-symlinks.txt; fi; \
+    done \
+ && for src in /opt/conda/lib/python3.11/site-packages/nvidia/cudnn/lib/*; do \
+      dst="/usr/local/cuda-12.8/lib64/$(basename "$src")"; \
+      if [ ! -e "$dst" ]; then ln -s "$src" "$dst" && printf '%s\n' "$dst" >> /tmp/art-cudnn-symlinks.txt; fi; \
+    done \
+ && UV_LINK_MODE=hardlink uv sync --frozen --extra backend --extra megatron --extra tinker --no-install-project --python 3.12 \
+ && rm -rf .venv \
+ && cd vllm_runtime \
+ && UV_LINK_MODE=hardlink uv sync --frozen --no-install-project --no-dev --python 3.12 \
+ && rm -rf .venv \
+ && if [ -f /tmp/art-cudnn-symlinks.txt ]; then while IFS= read -r link; do [ -L "$link" ] && rm "$link"; done < /tmp/art-cudnn-symlinks.txt; fi \
+ && rm -f /tmp/art-cudnn-symlinks.txt
 
 FROM ${BASE_IMAGE}
 
@@ -47,6 +75,9 @@ ARG ART_SHA
 ARG UV_VERSION
 ARG BUILD_JOBS
 ARG UV_CONCURRENT_BUILDS
+ARG APEX_PARALLEL_BUILD
+ARG APEX_NVCC_THREADS
+ARG TORCH_CUDA_ARCH_LIST
 ARG SKYPILOT_VERSION
 ARG SKY_REMOTE_RAY_VERSION
 
@@ -56,6 +87,9 @@ ENV CUDA_HOME=/usr/local/cuda-12.8 \
     UV_PYTHON_INSTALL_DIR=/opt/uv-python \
     UV_LINK_MODE=copy \
     UV_CONCURRENT_BUILDS=${UV_CONCURRENT_BUILDS} \
+    APEX_PARALLEL_BUILD=${APEX_PARALLEL_BUILD} \
+    NVCC_APPEND_FLAGS=--threads\ ${APEX_NVCC_THREADS} \
+    TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST} \
     CMAKE_BUILD_PARALLEL_LEVEL=${BUILD_JOBS} \
     MAX_JOBS=${BUILD_JOBS} \
     NINJAFLAGS=-j${BUILD_JOBS} \
@@ -83,6 +117,7 @@ RUN if ! getent group messagebus >/dev/null; then groupadd -r messagebus; fi \
       git \
       htop \
       jq \
+      libcudnn9-headers-cuda-12 \
       libibverbs-dev \
       nano \
       netcat-openbsd \

--- a/docker/art-gpu.Dockerfile
+++ b/docker/art-gpu.Dockerfile
@@ -1,0 +1,130 @@
+ARG BASE_IMAGE=docker.io/pytorch/pytorch:2.9.0-cuda12.8-cudnn9-devel
+ARG ART_SHA=unknown
+ARG UV_VERSION=0.11.7
+ARG BUILD_JOBS=2
+ARG UV_CONCURRENT_BUILDS=1
+ARG SKYPILOT_VERSION=0.11.1
+ARG SKY_REMOTE_RAY_VERSION=2.9.3
+
+FROM ${BASE_IMAGE} AS builder
+
+ARG UV_VERSION
+ARG BUILD_JOBS
+ARG UV_CONCURRENT_BUILDS
+
+ENV CUDA_HOME=/usr/local/cuda-12.8 \
+    PATH=/opt/conda/bin:${PATH} \
+    UV_CACHE_DIR=/opt/uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/uv-python \
+    UV_LINK_MODE=copy \
+    UV_CONCURRENT_BUILDS=${UV_CONCURRENT_BUILDS} \
+    CMAKE_BUILD_PARALLEL_LEVEL=${BUILD_JOBS} \
+    MAX_JOBS=${BUILD_JOBS} \
+    NINJAFLAGS=-j${BUILD_JOBS} \
+    PYTHONUNBUFFERED=1
+
+SHELL ["/bin/bash", "-c"]
+
+RUN if ! getent group messagebus >/dev/null; then groupadd -r messagebus; fi \
+ && dpkg-statoverride --remove /usr/lib/dbus-1.0/dbus-daemon-launch-helper || true \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends git libibverbs-dev \
+ && rm -rf /var/lib/apt/lists/* \
+ && /opt/conda/bin/python -m pip install --no-cache-dir --upgrade "uv==${UV_VERSION}" \
+ && /opt/conda/bin/conda clean -afy \
+ && /opt/conda/bin/uv --version \
+ && mkdir -p "${UV_CACHE_DIR}" "${UV_PYTHON_INSTALL_DIR}"
+
+WORKDIR /opt/src/art
+COPY pyproject.toml uv.lock ./
+
+RUN UV_LINK_MODE=hardlink uv sync --frozen --extra backend --no-install-project --python 3.12 \
+ && rm -rf .venv
+
+FROM ${BASE_IMAGE}
+
+ARG ART_SHA
+ARG UV_VERSION
+ARG BUILD_JOBS
+ARG UV_CONCURRENT_BUILDS
+ARG SKYPILOT_VERSION
+ARG SKY_REMOTE_RAY_VERSION
+
+ENV CUDA_HOME=/usr/local/cuda-12.8 \
+    PATH=/home/sky/.local/bin:/opt/conda/bin:${PATH} \
+    UV_CACHE_DIR=/opt/uv-cache \
+    UV_PYTHON_INSTALL_DIR=/opt/uv-python \
+    UV_LINK_MODE=copy \
+    UV_CONCURRENT_BUILDS=${UV_CONCURRENT_BUILDS} \
+    CMAKE_BUILD_PARALLEL_LEVEL=${BUILD_JOBS} \
+    MAX_JOBS=${BUILD_JOBS} \
+    NINJAFLAGS=-j${BUILD_JOBS} \
+    PYTHONUNBUFFERED=1 \
+    HOME=/home/sky
+
+SHELL ["/bin/bash", "-c"]
+
+LABEL org.opencontainers.image.source="https://github.com/openpipe/art" \
+      org.opencontainers.image.revision="${ART_SHA}" \
+      org.opencontainers.image.description="ART GPU image with warmed uv caches for SkyPilot launches." \
+      org.opencontainers.image.title="art-gpu"
+
+# Keep apt metadata available because SkyPilot/setup may still run apt-get in
+# fresh clusters, and preinstall the small tools ART's setup expects.
+RUN if ! getent group messagebus >/dev/null; then groupadd -r messagebus; fi \
+ && dpkg-statoverride --remove /usr/lib/dbus-1.0/dbus-daemon-launch-helper || true \
+ && apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      -o Dpkg::Options::=--force-confdef \
+      -o Dpkg::Options::=--force-confold \
+      curl \
+      fuse \
+      gcc \
+      git \
+      htop \
+      jq \
+      libibverbs-dev \
+      nano \
+      netcat-openbsd \
+      ninja-build \
+      nvtop \
+      openssh-server \
+      patch \
+      pciutils \
+      rsync \
+      socat \
+      sudo \
+      tmux \
+      unzip \
+      wget \
+ && mkdir -p /var/run/sshd "${UV_CACHE_DIR}" "${UV_PYTHON_INSTALL_DIR}" \
+ && sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
+ && sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd \
+ && ssh-keygen -A \
+ && useradd -m -s /bin/bash sky \
+ && mkdir -p /home/sky/.local/bin /home/sky/.sky/sky_app \
+ && /bin/bash -c 'echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers' \
+ && /bin/bash -c 'echo '\''Defaults secure_path="/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"'\'' > /etc/sudoers.d/sky' \
+ && /opt/conda/bin/python -m pip install --no-cache-dir --upgrade "uv==${UV_VERSION}" \
+ && /opt/conda/bin/conda clean -afy \
+ && ln -sf /opt/conda/bin/uv /home/sky/.local/bin/uv \
+ && /opt/conda/bin/uv --version \
+ && chown -R sky:sky /home/sky "${UV_CACHE_DIR}" "${UV_PYTHON_INSTALL_DIR}"
+
+COPY --from=builder --chown=sky:sky /opt/uv-cache /opt/uv-cache
+COPY --from=builder --chown=sky:sky /opt/uv-python /opt/uv-python
+
+USER sky
+WORKDIR /home/sky
+
+RUN mkdir -p "${HOME}/.local/bin" "${HOME}/.sky/sky_app" "${HOME}/sky_workdir" \
+ && ln -sf /opt/conda/bin/uv "${HOME}/.local/bin/uv" \
+ && uv venv --seed "${HOME}/skypilot-runtime" --python 3.10 \
+ && VIRTUAL_ENV="${HOME}/skypilot-runtime" UV_LINK_MODE=copy UV_SYSTEM_PYTHON=false env -u PYTHONPATH -C "${HOME}" uv pip install \
+      "setuptools<70" \
+      "skypilot[kubernetes,remote]==${SKYPILOT_VERSION}" \
+      "ray[default]==${SKY_REMOTE_RAY_VERSION}" \
+      "pycryptodome==3.12.0" \
+ && VIRTUAL_ENV="${HOME}/skypilot-runtime" UV_LINK_MODE=copy UV_SYSTEM_PYTHON=false env -u PYTHONPATH -C "${HOME}" uv pip uninstall skypilot \
+ && printf '%s\n' "${HOME}/skypilot-runtime/bin/python" > "${HOME}/.sky/python_path" \
+ && VIRTUAL_ENV="${HOME}/skypilot-runtime" UV_LINK_MODE=copy UV_SYSTEM_PYTHON=false env -u PYTHONPATH -C "${HOME}" uv run --no-project --no-config which ray > "${HOME}/.sky/ray_path"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,12 +160,13 @@ override-dependencies = [
     "transformers==5.2.0",
     "torch==2.11.0",
 ]
-exclude-dependencies = ["pynvml", "emerging-optimizers"]
+exclude-dependencies = ["pynvml", "emerging-optimizers", "causal-conv1d", "mamba-ssm"]
 no-build-isolation-package = ["apex", "transformer-engine", "transformer-engine-cu12", "transformer-engine-torch", "megatron-bridge", "deep-ep", "nv-grouped-gemm"]
 
 [tool.uv.extra-build-dependencies]
 apex = ["torch>=2.11.0"]
 deep-ep = ["torch>=2.11.0"]
+megatron-core = ["pybind11"]
 nv-grouped-gemm = ["torch>=2.11.0"]
 transformer-engine-torch = ["torch>=2.11.0"]
 

--- a/scripts/build-gpu-image.sh
+++ b/scripts/build-gpu-image.sh
@@ -31,6 +31,7 @@ no_cache="${NO_CACHE:-false}"
 prewarm_nodes="${PREWARM_NODES:-true}"
 prewarm_namespace="${PREWARM_NAMESPACE:-default}"
 prewarm_name="${PREWARM_NAME:-art-gpu-image-prewarm}"
+prewarm_image_pull_secret="${PREWARM_IMAGE_PULL_SECRET:-art-gpu-registry-auth}"
 prewarm_node_selector="${PREWARM_NODE_SELECTOR:-node.coreweave.cloud/class=gpu}"
 prewarm_timeout="${PREWARM_TIMEOUT:-30m}"
 
@@ -381,6 +382,12 @@ if [[ "${prewarm_nodes}" == "true" ]]; then
     echo "Skipping GPU node prewarm: no nodes match ${prewarm_node_selector}"
   else
     echo "Prewarming ${prewarm_image} on ${gpu_node_count} GPU node(s)"
+    "${kubectl_cmd[@]}" create secret generic "${prewarm_image_pull_secret}" \
+      -n "${prewarm_namespace}" \
+      --from-file=.dockerconfigjson="${registry_auth_json_path}" \
+      --type=kubernetes.io/dockerconfigjson \
+      --dry-run=client -o yaml \
+      | "${kubectl_cmd[@]}" apply -n "${prewarm_namespace}" -f -
     "${kubectl_cmd[@]}" apply -n "${prewarm_namespace}" -f - <<EOF
 apiVersion: apps/v1
 kind: DaemonSet
@@ -405,6 +412,8 @@ spec:
     spec:
       nodeSelector:
         ${prewarm_node_selector_key}: ${prewarm_node_selector_value}
+      imagePullSecrets:
+        - name: ${prewarm_image_pull_secret}
       tolerations:
         - operator: Exists
       initContainers:

--- a/scripts/build-gpu-image.sh
+++ b/scripts/build-gpu-image.sh
@@ -245,9 +245,11 @@ cleanup() {
 trap cleanup EXIT
 printf '0' > "${build_log_offset_path}"
 
-mkdir -p "${context_dir}/docker"
+mkdir -p "${context_dir}/docker" "${context_dir}/vllm_runtime"
 cp "${repo_root}/pyproject.toml" "${context_dir}/pyproject.toml"
 cp "${repo_root}/uv.lock" "${context_dir}/uv.lock"
+cp "${repo_root}/vllm_runtime/pyproject.toml" "${context_dir}/vllm_runtime/pyproject.toml"
+cp "${repo_root}/vllm_runtime/uv.lock" "${context_dir}/vllm_runtime/uv.lock"
 cp "${repo_root}/.dockerignore" "${context_dir}/.dockerignore"
 cp "${repo_root}/docker/art-gpu.Dockerfile" "${context_dir}/docker/art-gpu.Dockerfile"
 printf '%s' "${registry_auth_json_b64}" | base64 -d > "${registry_auth_json_path}"

--- a/scripts/build-gpu-image.sh
+++ b/scripts/build-gpu-image.sh
@@ -153,7 +153,8 @@ if [[ -z "${pull_image_repo}" ]]; then
 fi
 
 registry_host="${image_repo%%/*}"
-if [[ -z "${registry_host}" || "${registry_host}" == "${image_repo}" ]]; then
+if [[ -z "${registry_host}" || "${registry_host}" == "${image_repo}" ||
+  ( "${registry_host}" != *.* && "${registry_host}" != *:* && "${registry_host}" != "localhost" ) ]]; then
   registry_host="docker.io"
 fi
 cache_ref="${BUILDKIT_CACHE_REF:-${image_repo}:buildcache}"

--- a/scripts/build-gpu-image.sh
+++ b/scripts/build-gpu-image.sh
@@ -392,6 +392,10 @@ spec:
   selector:
     matchLabels:
       app: ${prewarm_name}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
   template:
     metadata:
       labels:

--- a/scripts/build-gpu-image.sh
+++ b/scripts/build-gpu-image.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: build-gpu-image.sh [options]
+
+Options:
+  --cluster-name NAME    Temporary BuildKit pod name to use
+  --image-repo REPO      Image repository to publish
+  --infra INFRA          Kubernetes-backed SkyPilot infra (default: k8s/cks-wb3)
+  --no-cache             Disable registry-backed BuildKit cache
+  --no-prewarm-nodes     Skip pre-pulling the pushed image on GPU nodes
+  --prewarm-timeout DUR  Timeout for the prewarm DaemonSet rollout (default: 30m)
+  --tag TAG              Image tag to publish
+  --help                 Show this help
+EOF
+}
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cluster_name=""
+infra="${SKY_INFRA:-k8s/cks-wb3}"
+image_repo="${ART_IMAGE_REPO:-}"
+image_tag=""
+docker_config_path="${DOCKER_CONFIG_PATH:-${HOME}/.docker/config.json}"
+buildkit_image="${BUILDKIT_IMAGE:-moby/buildkit:v0.29.0-rootless}"
+buildkit_namespace="${KUBECTL_NAMESPACE:-default}"
+buildkit_wait_timeout="${BUILDKIT_WAIT_TIMEOUT:-300s}"
+no_cache="${NO_CACHE:-false}"
+prewarm_nodes="${PREWARM_NODES:-true}"
+prewarm_namespace="${PREWARM_NAMESPACE:-default}"
+prewarm_name="${PREWARM_NAME:-art-gpu-image-prewarm}"
+prewarm_node_selector="${PREWARM_NODE_SELECTOR:-node.coreweave.cloud/class=gpu}"
+prewarm_timeout="${PREWARM_TIMEOUT:-30m}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cluster-name)
+      cluster_name="$2"
+      shift 2
+      ;;
+    --image-repo)
+      image_repo="$2"
+      shift 2
+      ;;
+    --infra)
+      infra="$2"
+      shift 2
+      ;;
+    --no-cache)
+      no_cache=true
+      shift
+      ;;
+    --no-prewarm-nodes)
+      prewarm_nodes=false
+      shift
+      ;;
+    --prewarm-timeout)
+      prewarm_timeout="$2"
+      shift 2
+      ;;
+    --tag)
+      image_tag="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "${infra}" in
+  k8s/*)
+    kube_context="${infra#k8s/}"
+    ;;
+  kubernetes/*)
+    kube_context="${infra#kubernetes/}"
+    ;;
+  *)
+    echo "Unsupported --infra '${infra}'. Use k8s/<kubectl-context>." >&2
+    exit 1
+    ;;
+esac
+
+kubectl_cmd=(kubectl --context "${kube_context}")
+if [[ "${prewarm_node_selector}" != *=* ]]; then
+  echo "PREWARM_NODE_SELECTOR must be a key=value selector, got: ${prewarm_node_selector}" >&2
+  exit 1
+fi
+prewarm_node_selector_key="${prewarm_node_selector%%=*}"
+prewarm_node_selector_value="${prewarm_node_selector#*=}"
+
+art_sha="$(git -C "${repo_root}" rev-parse HEAD)"
+art_short_sha="$(git -C "${repo_root}" rev-parse --short=12 HEAD)"
+timestamp="$(date +%m%d-%H%M%S)"
+
+if [[ -z "${image_tag}" ]]; then
+  image_tag="skypilot-${art_short_sha}"
+fi
+
+if [[ -z "${cluster_name}" ]]; then
+  cluster_name="art-gpu-build-${timestamp}"
+fi
+
+dockerhub_user=""
+if [[ -f "${docker_config_path}" ]]; then
+  export DOCKER_CONFIG_PATH="${docker_config_path}"
+  dockerhub_user="$(
+    uv run --no-project python - <<'PY'
+import base64
+import json
+import os
+
+path = os.environ["DOCKER_CONFIG_PATH"]
+data = json.load(open(path))
+auths = data.get("auths", {})
+for key in (
+    "https://index.docker.io/v1/",
+    "https://index.docker.io/v1/access-token",
+    "https://index.docker.io/v1/refresh-token",
+):
+    entry = auths.get(key)
+    if entry and "auth" in entry:
+        print(base64.b64decode(entry["auth"]).decode().split(":", 1)[0])
+        break
+PY
+  )"
+fi
+
+if [[ -z "${image_repo}" ]]; then
+  if [[ -n "${dockerhub_user}" ]]; then
+    image_repo="docker.io/${dockerhub_user}/art-gpu"
+  else
+    image_repo="ghcr.io/openpipe/art-gpu"
+  fi
+fi
+
+registry_host="${image_repo%%/*}"
+if [[ -z "${registry_host}" || "${registry_host}" == "${image_repo}" ]]; then
+  registry_host="docker.io"
+fi
+cache_ref="${BUILDKIT_CACHE_REF:-${image_repo}:buildcache}"
+cache_opts=""
+if [[ "${no_cache}" != "true" ]]; then
+  cache_opts="--import-cache type=registry,ref=${cache_ref} --export-cache type=registry,ref=${cache_ref},mode=max"
+fi
+
+if [[ -n "${REGISTRY_AUTH_JSON_B64:-}" ]]; then
+  registry_auth_json_b64="${REGISTRY_AUTH_JSON_B64}"
+elif [[ "${registry_host}" == "docker.io" && -f "${docker_config_path}" ]]; then
+  dockerhub_auth_json="$(
+    DOCKER_CONFIG_PATH="${docker_config_path}" uv run --no-project python - <<'PY'
+import base64
+import json
+import os
+import urllib.request
+
+path = os.environ["DOCKER_CONFIG_PATH"]
+data = json.load(open(path))
+auths = data.get("auths", {})
+basic_auth = None
+for key in (
+    "https://index.docker.io/v1/",
+    "docker.io",
+    "index.docker.io/v1/",
+):
+    entry = auths.get(key)
+    if entry and "auth" in entry:
+        basic_auth = entry["auth"]
+        break
+
+if basic_auth is None:
+    raise SystemExit(f"Missing Docker Hub auth entry in {path}")
+
+username, password = base64.b64decode(basic_auth).decode().split(":", 1)
+login_req = urllib.request.Request(
+    "https://hub.docker.com/v2/users/login/",
+    data=json.dumps({"username": username, "password": password}).encode(),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(login_req, timeout=30) as resp:
+    login_payload = json.load(resp)
+
+access_auth = base64.b64encode(f"{username}:{login_payload['token']}".encode()).decode()
+refresh_auth = base64.b64encode(f"{username}:{login_payload['refresh_token']}".encode()).decode()
+
+print(
+    json.dumps(
+        {
+            "auths": {
+                "https://index.docker.io/v1/": {"auth": basic_auth},
+                "docker.io": {"auth": basic_auth},
+                "https://registry-1.docker.io/v2/": {"auth": basic_auth},
+                "registry-1.docker.io": {"auth": basic_auth},
+                "https://index.docker.io/v1/access-token": {"auth": access_auth},
+                "https://index.docker.io/v1/refresh-token": {"auth": refresh_auth},
+            }
+        },
+        separators=(",", ":"),
+    )
+)
+PY
+  )"
+  registry_auth_json_b64="$(printf '%s' "${dockerhub_auth_json}" | base64 | tr -d '\n')"
+else
+  ghcr_username="${GHCR_USERNAME:-$(gh api user --jq .login)}"
+  ghcr_token="${GHCR_TOKEN:-$(gh auth token)}"
+  ghcr_auth="$(printf '%s' "${ghcr_username}:${ghcr_token}" | base64 | tr -d '\n')"
+  registry_auth_json_b64="$(
+    printf '{"auths":{"ghcr.io":{"auth":"%s"}}}' "${ghcr_auth}" | base64 | tr -d '\n'
+  )"
+fi
+
+context_dir="$(mktemp -d "${TMPDIR:-/tmp}/art-gpu-build-context.XXXXXX")"
+buildkit_manifest_path="$(mktemp "${TMPDIR:-/tmp}/art-gpu-buildkit.XXXXXX")"
+registry_auth_json_path="$(mktemp "${TMPDIR:-/tmp}/art-gpu-auth.XXXXXX")"
+build_command_path="$(mktemp "${TMPDIR:-/tmp}/art-gpu-build-command.XXXXXX")"
+build_log_snapshot_path="$(mktemp "${TMPDIR:-/tmp}/art-gpu-build-log.XXXXXX")"
+build_log_offset_path="$(mktemp "${TMPDIR:-/tmp}/art-gpu-build-log-offset.XXXXXX")"
+cleanup() {
+  rm -rf "${context_dir}"
+  rm -f "${buildkit_manifest_path}" "${registry_auth_json_path}" \
+    "${build_command_path}" "${build_log_snapshot_path}" "${build_log_offset_path}"
+  "${kubectl_cmd[@]}" delete pod -n "${buildkit_namespace}" "${cluster_name}" \
+    --ignore-not-found --wait=true >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+printf '0' > "${build_log_offset_path}"
+
+mkdir -p "${context_dir}/docker"
+cp "${repo_root}/pyproject.toml" "${context_dir}/pyproject.toml"
+cp "${repo_root}/uv.lock" "${context_dir}/uv.lock"
+cp "${repo_root}/.dockerignore" "${context_dir}/.dockerignore"
+cp "${repo_root}/docker/art-gpu.Dockerfile" "${context_dir}/docker/art-gpu.Dockerfile"
+printf '%s' "${registry_auth_json_b64}" | base64 -d > "${registry_auth_json_path}"
+
+echo "Launching temporary BuildKit pod ${cluster_name} on ${infra}"
+echo "Publishing ${image_repo}:${image_tag}"
+if [[ "${no_cache}" == "true" ]]; then
+  echo "Registry cache disabled"
+else
+  echo "Using registry cache ${cache_ref}"
+fi
+echo "Using ART_SHA=${art_sha}"
+
+cat > "${buildkit_manifest_path}" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${cluster_name}
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
+spec:
+  restartPolicy: Never
+  containers:
+    - name: buildkitd
+      image: ${buildkit_image}
+      args:
+        - --oci-worker-no-process-sandbox
+      readinessProbe:
+        exec:
+          command: ["buildctl", "debug", "workers"]
+        initialDelaySeconds: 5
+        periodSeconds: 5
+      securityContext:
+        seccompProfile:
+          type: Unconfined
+        runAsUser: 1000
+        runAsGroup: 1000
+      volumeMounts:
+        - mountPath: /home/user/.local/share/buildkit
+          name: buildkitd
+  volumes:
+    - name: buildkitd
+      emptyDir: {}
+EOF
+
+"${kubectl_cmd[@]}" delete pod -n "${buildkit_namespace}" "${cluster_name}" \
+  --ignore-not-found --wait=true >/dev/null 2>&1 || true
+"${kubectl_cmd[@]}" apply -n "${buildkit_namespace}" -f "${buildkit_manifest_path}"
+"${kubectl_cmd[@]}" wait -n "${buildkit_namespace}" \
+  --for=condition=Ready "pod/${cluster_name}" \
+  --timeout="${buildkit_wait_timeout}"
+"${kubectl_cmd[@]}" exec -n "${buildkit_namespace}" "${cluster_name}" -- sh -lc \
+  'mkdir -p /home/user/.docker /tmp/build-context'
+"${kubectl_cmd[@]}" cp "${registry_auth_json_path}" \
+  "${buildkit_namespace}/${cluster_name}:/home/user/.docker/config.json"
+"${kubectl_cmd[@]}" cp "${context_dir}/." \
+  "${buildkit_namespace}/${cluster_name}:/tmp/build-context"
+
+cat > "${build_command_path}" <<EOF
+#!/bin/sh
+set -eu
+buildctl build \
+    --progress=plain \
+    ${cache_opts} \
+    --frontend dockerfile.v0 \
+    --local context=/tmp/build-context \
+    --local dockerfile=/tmp/build-context/docker \
+    --opt filename=art-gpu.Dockerfile \
+    --opt build-arg:ART_SHA=${art_sha} \
+    --output type=image,name=${image_repo}:${image_tag},push=true
+EOF
+
+sync_build_log() {
+  if "${kubectl_cmd[@]}" cp \
+    "${buildkit_namespace}/${cluster_name}:/tmp/art-build.log" \
+    "${build_log_snapshot_path}" >/dev/null 2>&1; then
+    uv run --no-project python - "${build_log_snapshot_path}" "${build_log_offset_path}" <<'PY'
+import sys
+from pathlib import Path
+
+log_path = Path(sys.argv[1])
+offset_path = Path(sys.argv[2])
+offset = int(offset_path.read_text() or "0")
+data = log_path.read_bytes()
+if offset < len(data):
+    sys.stdout.buffer.write(data[offset:])
+    sys.stdout.flush()
+offset_path.write_text(str(len(data)))
+PY
+  fi
+}
+
+"${kubectl_cmd[@]}" cp "${build_command_path}" \
+  "${buildkit_namespace}/${cluster_name}:/tmp/art-build.sh"
+"${kubectl_cmd[@]}" exec -n "${buildkit_namespace}" "${cluster_name}" -- sh -lc '
+  chmod +x /tmp/art-build.sh
+  rm -f /tmp/art-build.log /tmp/art-build.exit
+  nohup sh -c '"'"'/tmp/art-build.sh >/tmp/art-build.log 2>&1; printf "%s\n" "$?" >/tmp/art-build.exit'"'"' >/tmp/art-build.nohup 2>&1 &
+'
+
+while true; do
+  sync_build_log
+  build_exit_code="$(
+    "${kubectl_cmd[@]}" exec -n "${buildkit_namespace}" "${cluster_name}" -- sh -lc \
+      'if [ -f /tmp/art-build.exit ]; then sed -n 1p /tmp/art-build.exit; fi' 2>/dev/null || true
+  )"
+  if [[ -n "${build_exit_code}" ]]; then
+    sync_build_log
+    if [[ "${build_exit_code}" != "0" ]]; then
+      exit "${build_exit_code}"
+    fi
+    break
+  fi
+  sleep 10
+done
+
+echo
+echo "Image ready for testing:"
+echo "  ${image_repo}:${image_tag}"
+image_digest="$(
+  uv run --no-project python - "${build_log_snapshot_path}" "${image_repo}:${image_tag}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+log = Path(sys.argv[1]).read_text(errors="replace")
+image = re.escape(sys.argv[2])
+matches = re.findall(rf"pushing manifest for {image}@(sha256:[0-9a-f]+)", log)
+if matches:
+    print(matches[-1])
+PY
+)"
+prewarm_image="${image_repo}:${image_tag}"
+if [[ -n "${image_digest}" ]]; then
+  prewarm_image="${image_repo}@${image_digest}"
+fi
+
+if [[ "${prewarm_nodes}" == "true" ]]; then
+  gpu_node_count="$("${kubectl_cmd[@]}" get nodes -l "${prewarm_node_selector}" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  if [[ "${gpu_node_count}" == "0" ]]; then
+    echo "Skipping GPU node prewarm: no nodes match ${prewarm_node_selector}"
+  else
+    echo "Prewarming ${prewarm_image} on ${gpu_node_count} GPU node(s)"
+    "${kubectl_cmd[@]}" apply -n "${prewarm_namespace}" -f - <<EOF
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ${prewarm_name}
+  labels:
+    app: ${prewarm_name}
+spec:
+  selector:
+    matchLabels:
+      app: ${prewarm_name}
+  template:
+    metadata:
+      labels:
+        app: ${prewarm_name}
+      annotations:
+        art.openpipe/prewarm-token: "${timestamp}-${art_short_sha}"
+    spec:
+      nodeSelector:
+        ${prewarm_node_selector_key}: ${prewarm_node_selector_value}
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: prepull
+          image: ${prewarm_image}
+          imagePullPolicy: Always
+          command: ["bash", "-lc", "true"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+EOF
+    "${kubectl_cmd[@]}" rollout status -n "${prewarm_namespace}" "daemonset/${prewarm_name}" --timeout="${prewarm_timeout}"
+  fi
+else
+  echo "Skipping GPU node prewarm"
+fi

--- a/scripts/build-gpu-image.sh
+++ b/scripts/build-gpu-image.sh
@@ -11,6 +11,7 @@ Options:
   --infra INFRA          Kubernetes-backed SkyPilot infra (default: k8s/cks-wb3)
   --no-cache             Disable registry-backed BuildKit cache
   --no-prewarm-nodes     Skip pre-pulling the pushed image on GPU nodes
+  --pull-image-repo REPO Image repository for cluster pulls/prewarm
   --prewarm-timeout DUR  Timeout for the prewarm DaemonSet rollout (default: 30m)
   --tag TAG              Image tag to publish
   --help                 Show this help
@@ -22,6 +23,7 @@ repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cluster_name=""
 infra="${SKY_INFRA:-k8s/cks-wb3}"
 image_repo="${ART_IMAGE_REPO:-}"
+pull_image_repo="${ART_PULL_IMAGE_REPO:-}"
 image_tag=""
 docker_config_path="${DOCKER_CONFIG_PATH:-${HOME}/.docker/config.json}"
 buildkit_image="${BUILDKIT_IMAGE:-moby/buildkit:v0.29.0-rootless}"
@@ -56,6 +58,10 @@ while [[ $# -gt 0 ]]; do
     --no-prewarm-nodes)
       prewarm_nodes=false
       shift
+      ;;
+    --pull-image-repo)
+      pull_image_repo="$2"
+      shift 2
       ;;
     --prewarm-timeout)
       prewarm_timeout="$2"
@@ -141,6 +147,9 @@ if [[ -z "${image_repo}" ]]; then
   else
     image_repo="ghcr.io/openpipe/art-gpu"
   fi
+fi
+if [[ -z "${pull_image_repo}" ]]; then
+  pull_image_repo="${image_repo}"
 fi
 
 registry_host="${image_repo%%/*}"
@@ -245,6 +254,7 @@ printf '%s' "${registry_auth_json_b64}" | base64 -d > "${registry_auth_json_path
 
 echo "Launching temporary BuildKit pod ${cluster_name} on ${infra}"
 echo "Publishing ${image_repo}:${image_tag}"
+echo "Cluster pull image ${pull_image_repo}:${image_tag}"
 if [[ "${no_cache}" == "true" ]]; then
   echo "Registry cache disabled"
 else
@@ -358,6 +368,10 @@ done
 echo
 echo "Image ready for testing:"
 echo "  ${image_repo}:${image_tag}"
+if [[ "${pull_image_repo}" != "${image_repo}" ]]; then
+  echo "Cluster pull image:"
+  echo "  ${pull_image_repo}:${image_tag}"
+fi
 image_digest="$(
   uv run --no-project python - "${build_log_snapshot_path}" "${image_repo}:${image_tag}" <<'PY'
 import re
@@ -371,9 +385,9 @@ if matches:
     print(matches[-1])
 PY
 )"
-prewarm_image="${image_repo}:${image_tag}"
+prewarm_image="${pull_image_repo}:${image_tag}"
 if [[ -n "${image_digest}" ]]; then
-  prewarm_image="${image_repo}@${image_digest}"
+  prewarm_image="${pull_image_repo}@${image_digest}"
 fi
 
 if [[ "${prewarm_nodes}" == "true" ]]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,7 +9,12 @@ if [ -f .env ]; then
         [[ -z $line ]] && continue
         
         key="${line%%=*}"
-        if [ -z "${!key+x}" ]; then
+        current_value="${!key-}"
+        if [ -z "${!key+x}" ] ||
+            [ -z "${current_value}" ] ||
+            { [ "${key}" = "GIT_USER_NAME" ] && [ "${current_value}" = "Your Name" ]; } ||
+            { [ "${key}" = "GIT_USER_EMAIL" ] && [ "${current_value}" = "your.email@example.com" ]; } ||
+            { [ "${key}" = "INSTALL_EXTRAS" ] && [ "${current_value}" = "false" ]; }; then
             export "$line"
         fi
     done < .env

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -66,7 +66,12 @@ elif ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
 fi
 
 # Sync the dependencies
-if [ -f .venv/.art-prebaked-all-extras ]; then
+if [ -n "${ART_PROJECT_ENVIRONMENT:-}" ]; then
+    export UV_PROJECT_ENVIRONMENT="${ART_PROJECT_ENVIRONMENT}"
+fi
+
+uv_environment="${UV_PROJECT_ENVIRONMENT:-.venv}"
+if [ -f "${uv_environment}/.art-prebaked-all-extras" ]; then
     uv sync --all-extras --frozen
 elif [ "${INSTALL_EXTRAS:-false}" = "true" ]; then
     uv sync --all-extras --frozen

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -78,3 +78,8 @@ elif [ "${INSTALL_EXTRAS:-false}" = "true" ]; then
 else
     uv sync --extra backend --frozen
 fi
+
+if [ -n "${ART_PROJECT_ENVIRONMENT:-}" ]; then
+    rm -rf .venv
+    ln -s "${ART_PROJECT_ENVIRONMENT}" .venv
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -66,7 +66,9 @@ elif ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
 fi
 
 # Sync the dependencies
-if [ "${INSTALL_EXTRAS:-false}" = "true" ]; then
+if [ -f .venv/.art-prebaked-all-extras ]; then
+    uv sync --all-extras --frozen
+elif [ "${INSTALL_EXTRAS:-false}" = "true" ]; then
     uv sync --all-extras --frozen
 else
     uv sync --extra backend --frozen

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -67,7 +67,7 @@ fi
 
 # Sync the dependencies
 if [ "${INSTALL_EXTRAS:-false}" = "true" ]; then
-    uv sync --all-extras
+    uv sync --all-extras --frozen
 else
-    uv sync --extra backend
+    uv sync --extra backend --frozen
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,8 +8,10 @@ if [ -f .env ]; then
         [[ $line =~ ^#.*$ ]] && continue
         [[ -z $line ]] && continue
         
-        # Export the variable
-        export "$line"
+        key="${line%%=*}"
+        if [ -z "${!key+x}" ]; then
+            export "$line"
+        fi
     done < .env
 fi
 
@@ -41,7 +43,7 @@ fi
 # Configure git user name and email
 git config --global user.name "${GIT_USER_NAME}"
 git config --global user.email "${GIT_USER_EMAIL}"
-git config --global --add safe.directory /root/sky_workdir
+git config --global --add safe.directory "$(pwd)"
 
 if [ "${GIT_RESET_CLEAN:-true}" = "true" ]; then
     # Reset any uncommitted changes to the last commit
@@ -56,7 +58,9 @@ fi
 # Install astral-uv (standalone version)
 # Always prepend standalone install path so it takes precedence over system/conda uv
 export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
-if ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
+if command -v uv >/dev/null 2>&1; then
+    echo "Using $(uv --version)"
+elif ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
     echo "Failed to install uv." >&2
     exit 1
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -66,20 +66,8 @@ elif ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
 fi
 
 # Sync the dependencies
-if [ -n "${ART_PROJECT_ENVIRONMENT:-}" ]; then
-    export UV_PROJECT_ENVIRONMENT="${ART_PROJECT_ENVIRONMENT}"
-fi
-
-uv_environment="${UV_PROJECT_ENVIRONMENT:-.venv}"
-if [ -f "${uv_environment}/.art-prebaked-all-extras" ]; then
-    uv sync --all-extras --frozen
-elif [ "${INSTALL_EXTRAS:-false}" = "true" ]; then
+if [ "${INSTALL_EXTRAS:-false}" = "true" ]; then
     uv sync --all-extras --frozen
 else
     uv sync --extra backend --frozen
-fi
-
-if [ -n "${ART_PROJECT_ENVIRONMENT:-}" ]; then
-    rm -rf .venv
-    ln -s "${ART_PROJECT_ENVIRONMENT}" .venv
 fi

--- a/skypilot-config.yaml
+++ b/skypilot-config.yaml
@@ -383,7 +383,7 @@
 workdir: .
 resources:
   accelerators: ["H200:1", "H100-SXM:1", "H100:1", "A100-80GB:1"]
-  image_id: docker:docker.io/bradhiltonnw/art-gpu:latest
+  image_id: docker:images.coreweave.com/cluster-images/bradhiltonnw/art-gpu:latest
   ports:
     - 7999 # main ART server
     - 8000 # vLLM server

--- a/skypilot-config.yaml
+++ b/skypilot-config.yaml
@@ -383,12 +383,12 @@
 workdir: .
 resources:
   accelerators: ["H200:1", "H100-SXM:1", "H100:1", "A100-80GB:1"]
-  image_id: docker:pytorch/pytorch:2.9.0-cuda12.8-cudnn9-devel
+  image_id: docker:docker.io/bradhiltonnw/art-gpu:latest
   ports:
     - 7999 # main ART server
     - 8000 # vLLM server
 envs:
-  ALL_EXTRAS: "false"
+  INSTALL_EXTRAS: "false"
   GIT_USER_NAME: "Your Name"
   GIT_USER_EMAIL: "your.email@example.com"
   GITHUB_TOKEN: ""
@@ -399,7 +399,8 @@ config:
   kubernetes:
     pod_config:
       spec:
-        schedulerName: gpu-binpack
+        schedulerName: binpack-scheduler
+        activeDeadlineSeconds: 604800 # 7 days
         # Work around uv 0.10.5 stripping execute bits from Ray binaries.
         containers:
           - name: ray-node

--- a/uv.lock
+++ b/uv.lock
@@ -35,7 +35,9 @@ overrides = [
     { name = "transformers", specifier = "==5.2.0" },
 ]
 excludes = [
+    "causal-conv1d",
     "emerging-optimizers",
+    "mamba-ssm",
     "pynvml",
 ]
 
@@ -742,18 +744,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/ad/df/ff2aa55cf0d7c1462
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/07/facef6abd81378e6153b757dc1848621675d971fbc88ebb5d182ebc1c37f/casbin-1.43.0-py3-none-any.whl", hash = "sha256:63a3d1228870250e859ccd94133fe478821093f71dd37f05e0baa0c6fea26623", size = 475059, upload-time = "2025-05-10T06:57:16.89Z" },
 ]
-
-[[package]]
-name = "causal-conv1d"
-version = "1.6.2.post1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ninja" },
-    { name = "packaging" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/63/5c/2403b8410122d159405c4bd8456340c7251c193358fa24d30cb273fb5048/causal_conv1d-1.6.2.post1.tar.gz", hash = "sha256:245e314ea21064ded7a5bf6b3b842b644aa6f92e45cecfe3e935629744c35ff4", size = 29434, upload-time = "2026-05-09T13:00:51.622Z" }
 
 [[package]]
 name = "certifi"
@@ -3581,22 +3571,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mamba-ssm"
-version = "2.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "einops" },
-    { name = "ninja" },
-    { name = "packaging" },
-    { name = "setuptools" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "transformers" },
-    { name = "triton" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/67/ec89aa703da194a813e35d2ea2de8f74a7ce6991a120a29f3a0c5e30d4b9/mamba_ssm-2.3.1.tar.gz", hash = "sha256:4d529477ad94753962216d583fc8f1c127c717b7d7c875d6bbb9376366d0d761", size = 121707, upload-time = "2026-03-10T09:27:34.798Z" }
-
-[[package]]
 name = "markdown"
 version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3761,7 +3735,6 @@ version = "0.4.0rc0"
 source = { git = "https://github.com/NVIDIA-NeMo/Megatron-Bridge.git?rev=e049cc00c24d03e2ae45d2608c7a44e2d2364e3d#e049cc00c24d03e2ae45d2608c7a44e2d2364e3d" }
 dependencies = [
     { name = "accelerate" },
-    { name = "causal-conv1d" },
     { name = "comet-ml" },
     { name = "datasets" },
     { name = "diffusers" },
@@ -3770,7 +3743,6 @@ dependencies = [
     { name = "hydra-core" },
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
-    { name = "mamba-ssm" },
     { name = "megatron-core" },
     { name = "mlflow" },
     { name = "nvidia-resiliency-ext" },


### PR DESCRIPTION
## Summary
- Add an ART-specific Kubernetes BuildKit script for building, pushing, and prewarming the GPU image.
- Add an ART GPU Dockerfile that warms backend dependencies and bakes the SkyPilot runtime.
- Point ART SkyPilot configs at the new image and update Kubernetes pod settings/env handling needed for fast launches.

## Test plan
- `bash -n scripts/build-gpu-image.sh scripts/setup.sh`
- `git diff --check`
- `uv lock --check`
- Built and pushed `docker.io/bradhiltonnw/art-gpu:latest@sha256:284c62debc995d5cec96a595820581ffb28b6ee464e64575da62c19760f16b4f`
- Prewarmed 10/10 GPU nodes with the pushed digest
- Ran ART SkyPilot smoke launch: `ART image smoke ok 2.11.0+cu128`, total `1:04.23`