### PR TITLE
Avoid redundant Megatron empty_cache and GC cleanup

### DIFF
--- a/src/art/megatron/service.py
+++ b/src/art/megatron/service.py
@@ -1,7 +1,6 @@
 import asyncio
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-import gc
 import importlib
 import json
 import os
@@ -62,13 +61,6 @@ from .training.sft_batches import materialize_sft_batches
 safetensors = importlib.import_module("safetensors")
 safe_open = safetensors.safe_open
 OFFLOAD_BETWEEN_JOBS_ENV = "ART_MEGATRON_OFFLOAD_BETWEEN_JOBS"
-
-
-def gc_and_empty_cuda_cache(n: int = 3) -> None:
-    for _ in range(n):
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
 
 
 class _RuntimeRequestKwargs(TypedDict, total=False):
@@ -821,7 +813,6 @@ class MegatronService:
         self._validate_megatron_dependencies()
         await self._ensure_megatron_running(megatron_topology=megatron_topology)
         await self._sleep_runtime()
-        gc_and_empty_cuda_cache()
 
         lora_path = self._resolve_training_lora_path()
         self._clear_pending_jobs()

--- a/src/art/megatron/shared_prefix_state.py
+++ b/src/art/megatron/shared_prefix_state.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import gc
 from typing import Any
 
 from pydantic import Field

--- a/src/art/megatron/shared_prefix_state.py
+++ b/src/art/megatron/shared_prefix_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 from typing import Any
 
 from pydantic import Field

--- a/src/art/megatron/train.py
+++ b/src/art/megatron/train.py
@@ -14,7 +14,6 @@ Public cross-repo API consumed by serverless-training:
 - run_megatron_worker_loop
 """
 
-import gc
 import json
 import math
 import os
@@ -494,7 +493,6 @@ def run_megatron_rl_job(
     next_step_first_ref_logprobs = None
     step_result = None
 
-    job_completed = False
     try:
         configure_moe_routing_replay(
             runtime,
@@ -618,7 +616,6 @@ def run_megatron_rl_job(
             lora_path=job.lora_path,
             optimizer_state_path=job.optimizer_state_path,
         )
-        job_completed = True
     finally:
         configure_moe_routing_replay(runtime)
         if packed_tensors is not None:
@@ -642,9 +639,6 @@ def run_megatron_rl_job(
         if cp_lookahead_state is not None:
             cp_lookahead_state.pending_prepared_micro = None
             del cp_lookahead_state
-        if job_completed:
-            gc.collect()
-            torch.cuda.empty_cache()
 
 
 def run_megatron_sft_job(
@@ -653,7 +647,6 @@ def run_megatron_sft_job(
 ) -> None:
     adapter_model = None
 
-    job_completed = False
     try:
         configure_moe_routing_replay(runtime)
         adapter_model = _load_lora_and_optimizer(
@@ -764,13 +757,9 @@ def run_megatron_sft_job(
             lora_path=job.lora_path,
             optimizer_state_path=job.optimizer_state_path,
         )
-        job_completed = True
     finally:
         if adapter_model is not None:
             del adapter_model
-        if job_completed:
-            gc.collect()
-            torch.cuda.empty_cache()
 
 
 def _load_megatron_job(job_path: str, *, supports_sft: bool) -> MegatronJob:
@@ -1271,8 +1260,6 @@ def _prepare_kl_reference_logprobs(
         if loaded_ref_adapter:
             assert runtime.optimizer is not None
             load_adapter_into_model(runtime.model, adapter_model, runtime.optimizer)
-        gc.collect()
-        torch.cuda.empty_cache()
 
 
 def run_megatron_sft_step(
@@ -1595,7 +1582,6 @@ def run_training_step(
     if cp_lookahead_state is not None:
         cp_lookahead_state.pending_prepared_micro = pending_prepared_micro
 
-    torch.cuda.empty_cache()
     token_count = _local_trainable_token_count_tensor(
         loss_inputs_for_count,
         device=device,

--- a/src/art/megatron/training/offload.py
+++ b/src/art/megatron/training/offload.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-import gc
 import logging
 from typing import Any, Sequence, cast
 
@@ -104,8 +103,6 @@ def offload_to_cpu(
             param.data = pinned_buffers[key]
 
     torch.cuda.synchronize()
-    gc.collect()
-    torch.cuda.empty_cache()
     offload_state.is_offloaded = True
     _rank0_info(rank, OFFLOADED_FROZEN_PARAMS_MESSAGE)
 

--- a/src/art/megatron/training/streaming_weight_offload.py
+++ b/src/art/megatron/training/streaming_weight_offload.py
@@ -160,7 +160,7 @@ class StreamingWeightOffloader:
                     )
                 )
             )
-        self.offload_all(wait=True)
+        self.offload_all()
         _rank0_info(
             self.rank, STREAMING_INSTALLED_MESSAGE, len(self.layers), param_count
         )
@@ -169,7 +169,7 @@ class StreamingWeightOffloader:
         self._prefetch_window(0, 1, self.config.resident_layers)
 
     def finish_job(self) -> None:
-        self.offload_all(wait=True)
+        self.offload_all()
 
     def remove(self) -> None:
         for handle in self._hooks:
@@ -180,11 +180,9 @@ class StreamingWeightOffloader:
             self._condition.notify_all()
         self._worker.join(timeout=5.0)
 
-    def offload_all(self, *, wait: bool) -> None:
+    def offload_all(self) -> None:
         for layer_state in self.layers:
             self._ensure_offloaded(layer_state)
-        if wait:
-            torch.cuda.empty_cache()
 
     def _pre_forward(self, layer_state: _LayerState) -> None:
         recompute_forward = _is_recompute_forward()

--- a/src/art/megatron/training/weight_offload.py
+++ b/src/art/megatron/training/weight_offload.py
@@ -95,17 +95,13 @@ class WeightOffloadManager:
             self.streaming.begin_job()
 
     def after_job(self) -> None:
-        did_release_gpu_memory = False
         if self.streaming is not None:
             self.streaming.finish_job()
-            did_release_gpu_memory = True
         if self.offload_between_jobs:
             if self.streaming is None:
                 offload_to_cpu(self.model, self.rank, self.offload_state)
             else:
                 offload_trainable_buffers_to_cpu(self.model, self.rank)
-            did_release_gpu_memory = True
-        if did_release_gpu_memory:
             gc.collect()
             torch.cuda.empty_cache()
 

--- a/src/art/megatron/training/weight_offload.py
+++ b/src/art/megatron/training/weight_offload.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
-import gc
 import os
 
 import torch
@@ -102,7 +101,6 @@ class WeightOffloadManager:
                 offload_to_cpu(self.model, self.rank, self.offload_state)
             else:
                 offload_trainable_buffers_to_cpu(self.model, self.rank)
-            gc.collect()
             torch.cuda.empty_cache()
 
     @contextmanager


### PR DESCRIPTION
## Summary
- Remove redundant `gc.collect()` and `torch.cuda.empty_cache()` calls from Megatron service, job, and step cleanup paths.
- Keep CUDA cache clearing centralized for colocated weight offload only, after weights are offloaded.
- Avoid dedicated-mode cleanup syncs between training jobs.

## Tests
- Benchmarked Megatron throughput at max sequence length with CP4/EP4 Qwen3.5; completed without OOM.
- Throughput improved over previous results.
