### PR TITLE
fix: Remove prefill/sample costs for megatron

### DIFF
--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -51,7 +51,6 @@ from .._backend_training import (
     build_rl_train_configs,
 )
 from ..backend import AnyTrainableModel, Backend
-from ..costs import build_cost_calculator, get_model_pricing
 from ..metrics_taxonomy import (
     TRAIN_GRADIENT_STEPS_KEY,
     build_training_summary_metrics,
@@ -358,11 +357,6 @@ class LocalBackend(Backend):
         # (wandb initialization is now handled by the model's _get_wandb_run method)
         if model.trainable and "WANDB_API_KEY" in os.environ:
             _ = model._get_wandb_run()
-        if model.trainable:
-            trainable_model = cast(TrainableModel, model)
-            pricing = get_model_pricing(trainable_model.base_model)
-            if pricing is not None:
-                trainable_model.set_cost_calculator(build_cost_calculator(pricing))
 
     def _model_inference_name(self, model: Model, step: int | None = None) -> str:
         """Return the inference name for a model checkpoint.

--- a/src/art/tinker/backend.py
+++ b/src/art/tinker/backend.py
@@ -5,9 +5,10 @@ from mp_actors import move_to_child_process
 
 from .. import dev
 from ..backend import AnyTrainableModel
+from ..costs import build_cost_calculator, get_model_pricing
 from ..local.backend import LocalBackend
 from ..local.service import ModelService
-from ..model import TrainableModel
+from ..model import Model, TrainableModel
 from ..utils.output_dirs import get_model_dir
 from .renderers import get_renderer_name
 
@@ -27,6 +28,15 @@ class TinkerBackend(LocalBackend):
             print("Setting TINKER_API_KEY to", tinker_api_key, "in environment")
             os.environ["TINKER_API_KEY"] = tinker_api_key
         super().__init__(in_process=in_process, path=path)
+
+    async def register(self, model: Model) -> None:
+        await super().register(model)
+        if not model.trainable:
+            return
+        trainable_model = cast(TrainableModel, model)
+        pricing = get_model_pricing(trainable_model.base_model)
+        if pricing is not None:
+            trainable_model.set_cost_calculator(build_cost_calculator(pricing))
 
     async def _prepare_backend_for_training(
         self,

--- a/tests/unit/test_pipeline_trainer_local_backend.py
+++ b/tests/unit/test_pipeline_trainer_local_backend.py
@@ -3,7 +3,8 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 import json
 from pathlib import Path
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -756,6 +757,76 @@ def test_local_backend_get_packed_tensors_warns_and_drops_overlong_results(
 
     assert packed_tensors is not None
     assert packed_tensors["tokens"].shape == (1, 4)
+
+
+@pytest.mark.asyncio
+async def test_local_backend_register_leaves_token_priced_generation_costs_disabled(
+    tmp_path: Path,
+) -> None:
+    model = TrainableModel(
+        name="local-backend-cost-accounting",
+        project="pipeline-tests",
+        base_model="openai/gpt-oss-20b",
+        base_path=str(tmp_path),
+    )
+    backend = LocalBackend(path=str(tmp_path))
+
+    with patch.object(model, "_get_wandb_run", return_value=None):
+        await backend.register(model)
+
+    assert model.cost_calculator(1_000, 2_000, "train") == {}
+
+
+@pytest.mark.asyncio
+async def test_megatron_backend_register_disables_token_priced_generation_costs(
+    tmp_path: Path,
+) -> None:
+    model = TrainableModel(
+        name="megatron-backend-cost-accounting",
+        project="pipeline-tests",
+        base_model="openai/gpt-oss-20b",
+        base_path=str(tmp_path),
+    )
+    backend = MegatronBackend(path=str(tmp_path))
+
+    with patch.object(model, "_get_wandb_run", return_value=None):
+        await backend.register(model)
+
+    assert model.cost_calculator(1_000, 2_000, "train") == {}
+
+
+@pytest.mark.asyncio
+async def test_tinker_backend_register_enables_tinker_token_priced_generation_costs(
+    tmp_path: Path,
+) -> None:
+    fake_tinker_server = ModuleType("art.tinker.server")
+    setattr(fake_tinker_server, "OpenAICompatibleTinkerServer", object)
+    had_tinker_module = "art.tinker" in sys.modules
+    had_tinker_backend_module = "art.tinker.backend" in sys.modules
+    with patch.dict("sys.modules", {"art.tinker.server": fake_tinker_server}):
+        from art.tinker.backend import TinkerBackend
+
+    if not had_tinker_backend_module:
+        sys.modules.pop("art.tinker.backend", None)
+    if not had_tinker_module:
+        sys.modules.pop("art.tinker", None)
+
+    model = TrainableModel(
+        name="tinker-backend-cost-accounting",
+        project="pipeline-tests",
+        base_model="openai/gpt-oss-20b",
+        base_path=str(tmp_path),
+    )
+    with patch.dict("os.environ", {}, clear=True):
+        backend = TinkerBackend(tinker_api_key="test-key", path=str(tmp_path))
+
+    with patch.object(model, "_get_wandb_run", return_value=None):
+        await backend.register(model)
+
+    assert model.cost_calculator(1_000, 2_000, "train") == {
+        "costs/train/tinker_prefill": pytest.approx(0.00012),
+        "costs/train/tinker_sample": pytest.approx(0.0006),
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- remove automatic token-priced cost calculator registration from `LocalBackend`

## Validation

- minimal Megatron yes/no/maybe smoke confirmed `costs/gpu` and no `tinker_*`, `prefill`, or `sample` cost keys