### PR TITLE
test: run Megatron tree coverage in CI

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -238,13 +238,23 @@ jobs:
           uv run --no-sync prek run ty --all-files
           uv run --no-sync prek run uv-lock-check --all-files
 
-      - name: Run Megatron unit tests
+      - name: Run Megatron lightweight tests
         run: |
+          uv run --no-sync python -c "import megatron.core.packed_seq_params"
           uv run --no-sync pytest --nbval --current-env --tb=short \
             tests/unit/test_megatron_reference_logprobs.py \
             tests/unit/test_moe_routing_replay.py \
             tests/unit/test_moe_routing_real_path.py \
-            tests/unit/test_pipeline_trainer_local_backend.py
+            tests/unit/test_pipeline_trainer_local_backend.py \
+            tests/unit/test_prefix_tree.py \
+            tests/unit/test_prefix_tree_attention_builder.py \
+            tests/unit/test_prefix_tree_grad_parity.py \
+            tests/unit/test_prefix_tree_packing.py \
+            tests/unit/test_trainer_rank_validation.py \
+            tests/unit/test_trainer_rank_weird_shapes.py \
+            tests/integration/megatron/gdn_shared_prefix/test_gdn_planner_runtime_model.py \
+            tests/integration/megatron/gdn_shared_prefix/test_gdn_cp_layout_distributed.py::test_distributed_gdn_cp_layout_all_to_all_roundtrips \
+            tests/integration/megatron/gdn_shared_prefix/test_gdn_cp_layout_distributed.py::test_distributed_gdn_cp_layout_handles_empty_ranks
 
       - name: Install backend dependencies
         run: |
@@ -256,4 +266,10 @@ jobs:
             --ignore=tests/unit/test_megatron_reference_logprobs.py \
             --ignore=tests/unit/test_moe_routing_replay.py \
             --ignore=tests/unit/test_moe_routing_real_path.py \
-            --ignore=tests/unit/test_pipeline_trainer_local_backend.py
+            --ignore=tests/unit/test_pipeline_trainer_local_backend.py \
+            --ignore=tests/unit/test_prefix_tree.py \
+            --ignore=tests/unit/test_prefix_tree_attention_builder.py \
+            --ignore=tests/unit/test_prefix_tree_grad_parity.py \
+            --ignore=tests/unit/test_prefix_tree_packing.py \
+            --ignore=tests/unit/test_trainer_rank_validation.py \
+            --ignore=tests/unit/test_trainer_rank_weird_shapes.py


### PR DESCRIPTION
## Summary

- run prefix-tree, block-mask, gradient-parity, and TrainerRank unit suites while Megatron dependencies are installed
- add CPU/Gloo context-parallel exchange coverage for CP sizes 2, 4, and 8
- assert the Megatron packed-sequence dependency is present so these suites cannot silently skip
- exclude the moved suites from the later mutually exclusive backend environment

## Validation

- `prek run --all-files`
- exact Megatron lightweight command on the H200 validation image: 170 passed in 57.17s

