### PR TITLE
ci: select TrainerRank GPU validation by branch

### DIFF
--- a/.github/workflows/trainer-rank-gpu.yml
+++ b/.github/workflows/trainer-rank-gpu.yml
@@ -4,18 +4,12 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
-    inputs:
-      pr_number:
-        description: Pull request number to validate
-        required: true
-        type: number
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
-  group: trainer-rank-gpu-${{ github.event_name }}-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: trainer-rank-gpu-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -27,48 +21,41 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', inputs.pr_number) }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - id: changes
         name: Classify changed files
         env:
-          GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            pr="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
-            head_repo="$(jq -r '.head.repo.full_name' <<<"${pr}")"
-            if [ "${head_repo}" != "${GITHUB_REPOSITORY}" ]; then
-              echo "Manual GPU validation only supports branches in ${GITHUB_REPOSITORY}." >&2
-              exit 1
-            fi
-            BASE_SHA="$(jq -r '.base.sha' <<<"${pr}")"
-            HEAD_SHA="$(jq -r '.head.sha' <<<"${pr}")"
-          fi
           echo "head_sha=${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "required=true" >> "${GITHUB_OUTPUT}"
+            echo "### Manual TrainerRank GPU validation requested" \
+              >> "${GITHUB_STEP_SUMMARY}"
+            echo >> "${GITHUB_STEP_SUMMARY}"
+            echo "Validating \`${GITHUB_REF}\` at \`${HEAD_SHA}\`." \
+              >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
           git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null \
             || git fetch --no-tags origin "${BASE_SHA}"
 
           pattern='^src/art/megatron/(prefix_tree(_packing|_state)?\.py|context_parallel/|flex_attn/|gdn/|lora\.py|megatron_patches\.py|training/(finalize_grads|microbatches)\.py)'
           changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
           critical="$(printf '%s\n' "${changed}" | grep -E "${pattern}" || true)"
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ] || [ -n "${critical}" ]; then
+          if [ -n "${critical}" ]; then
             echo "required=true" >> "${GITHUB_OUTPUT}"
             {
               echo "### TrainerRank GPU validation required"
               echo
-              if [ -n "${critical}" ]; then
-                echo '```text'
-                printf '%s\n' "${critical}"
-                echo '```'
-              else
-                echo "Manual validation requested for PR #${PR_NUMBER}."
-              fi
+              echo '```text'
+              printf '%s\n' "${critical}"
+              echo '```'
             } >> "${GITHUB_STEP_SUMMARY}"
           else
             echo "required=false" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary
- remove the manual PR-number input
- validate the exact SHA selected by GitHub's built-in branch picker
- keep automatic pull-request critical-path classification unchanged
- remove the unused pull-request API permission and lookup

## Validation
- `uv run --no-sync prek run --files .github/workflows/trainer-rank-gpu.yml`
- YAML parse check
- [manual branch-picker dispatch passed on 2x H200](https://github.com/OpenPipe/ART/actions/runs/29509310387)
