### PR TITLE
Preserve complete trajectories in Parquet

### DIFF
--- a/src/art/utils/trajectory_logging.py
+++ b/src/art/utils/trajectory_logging.py
@@ -1,27 +1,28 @@
-"""
-Parquet-based trajectory logging.
+"""Versioned Parquet persistence for trajectory groups."""
 
-This module provides efficient Parquet serialization for trajectory data,
-offering ~25x compression compared to JSONL and fast columnar queries.
-
-For legacy JSONL support and migration utilities, see trajectory_migration.py.
-"""
-
+from collections.abc import Mapping
 import json
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from openai.types.chat.chat_completion import Choice
-from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
+import pydantic
 
-from art.trajectories import Trajectory, TrajectoryGroup
+from art.trajectories import History, Trajectory, TrajectoryGroup
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+_FORMAT_VERSION = 2
+_JSON_VALUE = pydantic.TypeAdapter(Any)
 
 
-def _flatten_message(msg: dict) -> dict:
-    """Convert a message or Choice to flat parquet format."""
-    if "finish_reason" in msg:
-        # Choice format - extract inner message, mark as trainable
-        inner = msg.get("message", {})
+def _flatten_message(message: Mapping[str, object]) -> dict[str, object]:
+    """Convert a legacy message or Choice to the query-friendly v1 shape."""
+    if "finish_reason" in message:
+        inner = message.get("message", {})
+        if not isinstance(inner, Mapping):
+            inner = {}
         tool_calls = inner.get("tool_calls")
         return {
             "role": inner.get("role"),
@@ -30,98 +31,163 @@ def _flatten_message(msg: dict) -> dict:
             "tool_call_id": None,
             "trainable": True,
         }
-    else:
-        # Regular message
-        tool_calls = msg.get("tool_calls")
-        return {
-            "role": msg.get("role"),
-            "content": msg.get("content"),
-            "tool_calls": json.dumps(tool_calls) if tool_calls else None,
-            "tool_call_id": msg.get("tool_call_id"),
-            "trainable": False,
-        }
-
-
-def _unflatten_message(msg_dict: dict) -> dict:
-    """Convert flat parquet format back to message dict."""
-    result = {
-        "role": msg_dict["role"],
-        "content": msg_dict["content"],
+    tool_calls = message.get("tool_calls")
+    return {
+        "role": message.get("role"),
+        "content": message.get("content"),
+        "tool_calls": json.dumps(tool_calls) if tool_calls else None,
+        "tool_call_id": message.get("tool_call_id"),
+        "trainable": False,
     }
-    if msg_dict.get("tool_calls"):
-        result["tool_calls"] = json.loads(msg_dict["tool_calls"])
-    if msg_dict.get("tool_call_id"):
-        result["tool_call_id"] = msg_dict["tool_call_id"]
+
+
+def _unflatten_message(message: Mapping[str, object]) -> dict[str, object]:
+    """Convert the query-friendly v1 shape back to a legacy message."""
+    result = {"role": message["role"], "content": message["content"]}
+    if tool_calls := message.get("tool_calls"):
+        result["tool_calls"] = json.loads(str(tool_calls))
+    if tool_call_id := message.get("tool_call_id"):
+        result["tool_call_id"] = tool_call_id
     return result
 
 
-def write_trajectory_groups_parquet(
-    trajectory_groups: list[TrajectoryGroup],
-    path: str | Path,
-) -> None:
-    """
-    Write trajectory groups to a Parquet file with ZSTD compression.
+def _compact_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
 
-    Args:
-        trajectory_groups: List of TrajectoryGroup objects to serialize.
-        path: Output path for the Parquet file.
-    """
+
+def _choice_data(item: object) -> dict[str, Any] | None:
+    if isinstance(item, Choice):
+        raw = item.model_dump(mode="json", warnings="error")
+    elif (
+        isinstance(item, Mapping)
+        and {
+            "finish_reason",
+            "index",
+            "message",
+        }
+        <= item.keys()
+    ):
+        raw = dict(item)
+        try:
+            return Choice.model_validate(raw).model_dump(mode="json", warnings="error")
+        except pydantic.ValidationError:
+            return None
+    else:
+        from litellm.types.utils import Choices
+
+        if not isinstance(item, Choices):
+            return None
+        raw = item.model_dump(mode="json", warnings="error")
+    return Choice.model_validate(raw).model_dump(mode="json", warnings="error")
+
+
+def _history_data(history: History) -> dict[str, Any]:
+    data = history.model_dump(
+        mode="json", exclude={"messages_and_choices"}, warnings="error"
+    )
+    if history.messages_and_choices:
+        data["messages_and_choices"] = [
+            choice
+            if (choice := _choice_data(item)) is not None
+            else _JSON_VALUE.dump_python(item, mode="json", warnings="error")
+            for item in history.messages_and_choices
+        ]
+    return data
+
+
+def _trajectory_data(trajectory: Trajectory) -> dict[str, Any]:
+    data = trajectory.model_dump(
+        mode="json",
+        exclude={"messages_and_choices", "additional_histories"},
+        exclude_computed_fields=True,
+        warnings="error",
+    )
+    if trajectory.messages_and_choices:
+        data["messages_and_choices"] = [
+            choice
+            if (choice := _choice_data(item)) is not None
+            else _JSON_VALUE.dump_python(item, mode="json", warnings="error")
+            for item in trajectory.messages_and_choices
+        ]
+    if trajectory.additional_histories:
+        data["additional_histories"] = [
+            _history_data(history) for history in trajectory.additional_histories
+        ]
+    return data
+
+
+def _restore_history(data: object) -> History:
+    if not isinstance(data, dict):
+        raise ValueError("Parquet additional history must be a JSON object")
+    restored = dict(data)
+    messages = restored.get("messages_and_choices", [])
+    if not isinstance(messages, list):
+        raise ValueError("Parquet history messages must be a list")
+    restored["messages_and_choices"] = [
+        Choice.model_validate(choice)
+        if (choice := _choice_data(item)) is not None
+        else item
+        for item in messages
+    ]
+    return History.model_validate(restored)
+
+
+def _restore_trajectory(payload: object) -> Trajectory:
+    data = _json_object(payload, field="trajectory_json")
+    messages = data.get("messages_and_choices", [])
+    if not isinstance(messages, list):
+        raise ValueError("Parquet trajectory messages must be a list")
+    data["messages_and_choices"] = [
+        Choice.model_validate(choice)
+        if (choice := _choice_data(item)) is not None
+        else item
+        for item in messages
+    ]
+    histories = data.get("additional_histories", [])
+    if not isinstance(histories, list):
+        raise ValueError("Parquet additional_histories must be a list")
+    data["additional_histories"] = [_restore_history(item) for item in histories]
+    return Trajectory.model_validate(data)
+
+
+def _legacy_messages(trajectory: Trajectory) -> list[dict[str, object]] | None:
+    if trajectory.exchanges:
+        return None
+    messages = []
+    for item in trajectory.messages_and_choices:
+        if isinstance(item, Choice):
+            message = item.to_dict()
+        elif isinstance(item, Mapping):
+            message = item
+        else:
+            from litellm.types.utils import Choices
+
+            if not isinstance(item, Choices):
+                return None
+            message = {
+                "finish_reason": item.finish_reason,
+                "index": item.index,
+                "message": (
+                    item.message.to_dict()
+                    if hasattr(item.message, "to_dict")
+                    else item.message
+                ),
+            }
+        try:
+            flattened = _flatten_message(message)
+        except (TypeError, ValueError):
+            return None
+        if flattened["content"] is not None and not isinstance(
+            flattened["content"], str
+        ):
+            return None
+        messages.append(flattened)
+    return messages
+
+
+def _schema() -> "pa.Schema":
     import pyarrow as pa
-    import pyarrow.parquet as pq
 
-    rows = []
-    for group_index, group in enumerate(trajectory_groups):
-        group_metadata = json.dumps(group.metadata) if group.metadata else None
-        group_metrics = json.dumps(group.metrics) if group.metrics else None
-        group_logs = group.logs if group.logs else None
-        for trajectory in group.trajectories:
-            if not isinstance(trajectory, Trajectory):
-                continue
-
-            # Flatten messages
-            messages = []
-            for message_or_choice in trajectory.messages_and_choices:
-                if isinstance(message_or_choice, dict):
-                    message = message_or_choice
-                elif isinstance(message_or_choice, Choice):
-                    message = message_or_choice.to_dict()
-                else:
-                    from litellm.types.utils import Choices
-
-                    if not isinstance(message_or_choice, Choices):
-                        raise TypeError(
-                            "trajectory messages must be dict, OpenAI Choice, or "
-                            "LiteLLM Choices objects"
-                        )
-                    message = {
-                        "finish_reason": message_or_choice.finish_reason,
-                        "index": message_or_choice.index,
-                        "message": message_or_choice.message.to_dict()
-                        if hasattr(message_or_choice.message, "to_dict")
-                        else message_or_choice.message,
-                    }
-                messages.append(_flatten_message(message))  # type: ignore
-
-            rows.append(
-                {
-                    "group_index": group_index,
-                    "group_metadata": group_metadata,
-                    "group_metrics": group_metrics,
-                    "group_logs": group_logs,
-                    "reward": trajectory.reward,
-                    "metrics": json.dumps(trajectory.metrics)
-                    if trajectory.metrics
-                    else None,
-                    "metadata": json.dumps(trajectory.metadata)
-                    if trajectory.metadata
-                    else None,
-                    "tools": json.dumps(trajectory.tools) if trajectory.tools else None,
-                    "logs": trajectory.logs if trajectory.logs else None,
-                    "messages": messages,
-                }
-            )
-
-    # Define schema
     message_type = pa.struct(
         [
             ("role", pa.string()),
@@ -131,10 +197,15 @@ def write_trajectory_groups_parquet(
             ("trainable", pa.bool_()),
         ]
     )
-
-    schema = pa.schema(
+    return pa.schema(
         [
+            ("format_version", pa.int16()),
             ("group_index", pa.int64()),
+            ("trajectory_index", pa.int64()),
+            ("group_json", pa.large_string()),
+            ("trajectory_json", pa.large_string()),
+            # Stable materialized columns remain convenient for analytics. The JSON
+            # payloads above are authoritative and preserve the complete models.
             ("group_metadata", pa.string()),
             ("group_metrics", pa.string()),
             ("group_logs", pa.list_(pa.string())),
@@ -144,114 +215,293 @@ def write_trajectory_groups_parquet(
             ("tools", pa.string()),
             ("logs", pa.list_(pa.string())),
             ("messages", pa.list_(message_type)),
-        ]
+        ],
+        metadata={b"art.trajectory_parquet.version": str(_FORMAT_VERSION).encode()},
     )
 
-    if not rows:
-        table = pa.table({name: [] for name in schema.names}, schema=schema)
-        pq.write_table(table, path, compression="zstd")
-        return
 
-    table = pa.Table.from_pylist(rows, schema=schema)
+def write_trajectory_groups_parquet(
+    trajectory_groups: list[TrajectoryGroup],
+    path: str | Path,
+) -> None:
+    """Persist complete trajectory groups with Zstd-compressed Parquet."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    rows: list[dict[str, object]] = []
+    for group_index, group in enumerate(trajectory_groups):
+        group_data = group.model_dump(
+            mode="json", exclude={"trajectories"}, warnings="error"
+        )
+        common: dict[str, object] = {
+            "format_version": _FORMAT_VERSION,
+            "group_index": group_index,
+            "group_json": _compact_json(group_data),
+            "group_metadata": (
+                _compact_json(group_data["metadata"])
+                if group_data.get("metadata")
+                else None
+            ),
+            "group_metrics": (
+                _compact_json(group_data["metrics"])
+                if group_data.get("metrics")
+                else None
+            ),
+            "group_logs": group_data.get("logs") or None,
+        }
+        if not group.trajectories:
+            rows.append(
+                {
+                    **common,
+                    "trajectory_index": None,
+                    "trajectory_json": None,
+                    "reward": None,
+                    "metrics": None,
+                    "metadata": None,
+                    "tools": None,
+                    "logs": None,
+                    "messages": None,
+                }
+            )
+            continue
+
+        for trajectory_index, trajectory in enumerate(group.trajectories):
+            trajectory_data = _trajectory_data(trajectory)
+            rows.append(
+                {
+                    **common,
+                    "trajectory_index": trajectory_index,
+                    "trajectory_json": _compact_json(trajectory_data),
+                    "reward": trajectory.reward,
+                    "metrics": (
+                        _compact_json(trajectory_data["metrics"])
+                        if trajectory_data.get("metrics")
+                        else None
+                    ),
+                    "metadata": (
+                        _compact_json(trajectory_data["metadata"])
+                        if trajectory_data.get("metadata")
+                        else None
+                    ),
+                    "tools": (
+                        _compact_json(trajectory_data["tools"])
+                        if trajectory_data.get("tools")
+                        else None
+                    ),
+                    "logs": trajectory_data.get("logs") or None,
+                    "messages": _legacy_messages(trajectory),
+                }
+            )
+
+    schema = _schema()
+    table = (
+        pa.Table.from_pylist(rows, schema=schema)
+        if rows
+        else pa.table({name: [] for name in schema.names}, schema=schema)
+    )
     pq.write_table(table, path, compression="zstd")
 
 
-def read_trajectory_groups_parquet(path: str | Path) -> list[TrajectoryGroup]:
-    """
-    Read trajectory groups from a Parquet file.
+def _json_object(payload: object, *, field: str) -> dict[str, Any]:
+    if not isinstance(payload, (str, bytes, bytearray)):
+        raise ValueError(f"Parquet {field} must be JSON text")
+    try:
+        value = json.loads(payload)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValueError(f"Parquet {field} contains invalid JSON") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"Parquet {field} must contain a JSON object")
+    return value
 
-    Args:
-        path: Path to the Parquet file.
 
-    Returns:
-        List of TrajectoryGroup objects.
-    """
-    import duckdb
+def _read_v2(rows: list[dict[str, object]]) -> list[TrajectoryGroup]:
+    grouped: dict[int, list[dict[str, object]]] = {}
+    for row in rows:
+        version = row.get("format_version")
+        if version != _FORMAT_VERSION:
+            raise ValueError(f"Unsupported trajectory Parquet version: {version!r}")
+        group_index = row.get("group_index")
+        if not isinstance(group_index, int) or isinstance(group_index, bool):
+            raise ValueError("Parquet group_index must be an integer")
+        grouped.setdefault(group_index, []).append(row)
 
-    con = duckdb.connect(":memory:")
-    rows = con.execute(f"SELECT * FROM '{path}' ORDER BY group_index").fetchall()
-    columns = [desc[0] for desc in con.description]
+    result: list[TrajectoryGroup] = []
+    if sorted(grouped) != list(range(len(grouped))):
+        raise ValueError("Parquet group indexes are duplicate or non-contiguous")
+    for group_index in sorted(grouped):
+        group_rows = grouped[group_index]
+        group_payloads = {row.get("group_json") for row in group_rows}
+        if len(group_payloads) != 1:
+            raise ValueError(f"Parquet group {group_index} has conflicting metadata")
+        group_data = _json_object(group_payloads.pop(), field="group_json")
+        if "trajectories" in group_data:
+            raise ValueError("Parquet group_json must not contain trajectories")
 
-    groups_dict: dict[int, list[Trajectory]] = {}
-    group_metadata_by_index: dict[int, dict[str, Any]] = {}
-    group_metrics_by_index: dict[int, dict[str, Any]] = {}
-    group_logs_by_index: dict[int, list[str]] = {}
+        indexed: list[tuple[int, Trajectory]] = []
+        sentinel_count = 0
+        for row in group_rows:
+            trajectory_index = row.get("trajectory_index")
+            trajectory_json = row.get("trajectory_json")
+            if trajectory_index is None:
+                if trajectory_json is not None:
+                    raise ValueError("Parquet group sentinel contains a trajectory")
+                sentinel_count += 1
+                continue
+            if not isinstance(trajectory_index, int) or isinstance(
+                trajectory_index, bool
+            ):
+                raise ValueError("Parquet trajectory_index must be an integer")
+            if not isinstance(trajectory_json, (str, bytes, bytearray)):
+                raise ValueError("Parquet trajectory_json must be JSON text")
+            indexed.append((trajectory_index, _restore_trajectory(trajectory_json)))
 
-    def _load_json_payload(payload: object | None) -> dict[str, Any]:
-        if payload is None:
-            return {}
-        if isinstance(payload, dict):
-            return cast(dict[str, Any], payload)
-        if isinstance(payload, (str, bytes, bytearray)):
-            if not payload:
-                return {}
-            try:
-                return json.loads(payload)
-            except (json.JSONDecodeError, TypeError):
-                return {}
+        indexed.sort(key=lambda item: item[0])
+        if [index for index, _ in indexed] != list(range(len(indexed))):
+            raise ValueError(
+                f"Parquet group {group_index} has duplicate or missing trajectories"
+            )
+        if indexed and sentinel_count:
+            raise ValueError(f"Parquet group {group_index} mixes data and a sentinel")
+        if not indexed and sentinel_count != 1:
+            raise ValueError(f"Parquet group {group_index} has no valid group sentinel")
+        result.append(
+            TrajectoryGroup.model_validate(
+                {**group_data, "trajectories": [item for _, item in indexed]}
+            )
+        )
+    return result
+
+
+def _load_legacy_object(payload: object | None) -> dict[str, Any]:
+    if payload is None:
         return {}
+    if isinstance(payload, dict):
+        return cast(dict[str, Any], payload)
+    if isinstance(payload, (str, bytes, bytearray)) and payload:
+        try:
+            value = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return value if isinstance(value, dict) else {}
+    return {}
+
+
+def _read_v1(rows: list[dict[str, object]]) -> list[TrajectoryGroup]:
+    groups: dict[int, list[Trajectory]] = {}
+    group_metadata: dict[int, dict[str, Any]] = {}
+    group_metrics: dict[int, dict[str, Any]] = {}
+    group_logs: dict[int, list[str]] = {}
 
     for row in rows:
-        row_dict = dict(zip(columns, row))
-
-        if row_dict.get("reward") is None and row_dict.get("messages") is None:
+        if row.get("reward") is None and row.get("messages") is None:
             continue
-
-        group_index = row_dict.get("group_index", 0)
-        if group_index not in group_metadata_by_index:
-            group_metadata_by_index[group_index] = _load_json_payload(
-                row_dict.get("group_metadata")
-            )
-        if group_index not in group_metrics_by_index:
-            group_metrics_by_index[group_index] = _load_json_payload(
-                row_dict.get("group_metrics")
-            )
-        if group_index not in group_logs_by_index:
-            raw_group_logs = row_dict.get("group_logs")
-            if isinstance(raw_group_logs, (list, tuple)):
-                group_logs_by_index[group_index] = [
-                    str(item) for item in raw_group_logs
-                ]
-            elif raw_group_logs is None:
-                group_logs_by_index[group_index] = []
-            else:
-                group_logs_by_index[group_index] = [str(raw_group_logs)]
-
-        # Convert messages
-        messages_and_choices = []
-        for msg in row_dict.get("messages") or []:
-            # Handle tuple format from DuckDB
-            if not isinstance(msg, dict):
-                msg = {
-                    "role": msg[0],
-                    "content": msg[1],
-                    "tool_calls": msg[2],
-                    "tool_call_id": msg[3],
-                    "trainable": msg[4],
-                }
-            messages_and_choices.append(_unflatten_message(msg))
-
-        trajectory = Trajectory(
-            messages_and_choices=messages_and_choices,
-            reward=row_dict["reward"],
-            metrics=json.loads(row_dict["metrics"]) if row_dict.get("metrics") else {},
-            metadata=json.loads(row_dict["metadata"])
-            if row_dict.get("metadata")
-            else {},
-            logs=row_dict.get("logs") or [],
+        raw_group_index = row.get("group_index", 0)
+        if not isinstance(raw_group_index, int) or isinstance(raw_group_index, bool):
+            raise ValueError("Legacy Parquet group_index must be an integer")
+        group_index = raw_group_index
+        group_metadata.setdefault(
+            group_index, _load_legacy_object(row.get("group_metadata"))
+        )
+        group_metrics.setdefault(
+            group_index, _load_legacy_object(row.get("group_metrics"))
+        )
+        raw_logs = row.get("group_logs")
+        group_logs.setdefault(
+            group_index,
+            [str(item) for item in raw_logs]
+            if isinstance(raw_logs, (list, tuple))
+            else ([] if raw_logs is None else [str(raw_logs)]),
         )
 
-        if group_index not in groups_dict:
-            groups_dict[group_index] = []
-        groups_dict[group_index].append(trajectory)
+        raw_messages = row.get("messages")
+        if raw_messages is None:
+            raw_messages = []
+        if not isinstance(raw_messages, (list, tuple)):
+            raise ValueError("Legacy Parquet messages must be a list")
+        messages = []
+        for raw_message in raw_messages:
+            if isinstance(raw_message, Mapping):
+                message = {str(key): value for key, value in raw_message.items()}
+            else:
+                if not isinstance(raw_message, (list, tuple)):
+                    raise ValueError("Legacy Parquet message must be a struct")
+                message = {
+                    "role": raw_message[0],
+                    "content": raw_message[1],
+                    "tool_calls": raw_message[2],
+                    "tool_call_id": raw_message[3],
+                    "trainable": raw_message[4],
+                }
+            messages.append(_unflatten_message(message))
+        reward = row.get("reward")
+        if not isinstance(reward, (int, float)) or isinstance(reward, bool):
+            raise ValueError("Legacy Parquet reward must be numeric")
+        raw_trajectory_logs = row.get("logs")
+        if raw_trajectory_logs is None:
+            trajectory_logs = []
+        elif isinstance(raw_trajectory_logs, (list, tuple)):
+            trajectory_logs = [str(item) for item in raw_trajectory_logs]
+        else:
+            raise ValueError("Legacy Parquet logs must be a list")
+        groups.setdefault(group_index, []).append(
+            Trajectory(
+                messages_and_choices=messages,
+                reward=float(reward),
+                metrics=_load_legacy_object(row.get("metrics")),
+                metadata=_load_legacy_object(row.get("metadata")),
+                logs=trajectory_logs,
+            )
+        )
 
     return [
         TrajectoryGroup(
-            trajectories=groups_dict[idx],
+            trajectories=groups[index],
             exceptions=[],
-            metadata=group_metadata_by_index.get(idx, {}),
-            metrics=group_metrics_by_index.get(idx, {}),
-            logs=group_logs_by_index.get(idx, []),
+            metadata=group_metadata.get(index, {}),
+            metrics=group_metrics.get(index, {}),
+            logs=group_logs.get(index, []),
         )
-        for idx in sorted(groups_dict.keys())
+        for index in sorted(groups)
     ]
+
+
+def read_trajectory_groups_parquet(path: str | Path) -> list[TrajectoryGroup]:
+    """Read exact v2 trajectory groups or legacy v1 files."""
+    import duckdb
+    import pyarrow.parquet as pq
+
+    schema = pq.read_schema(path)
+    metadata = schema.metadata or {}
+    raw_version = metadata.get(b"art.trajectory_parquet.version")
+    try:
+        file_version = int(raw_version) if raw_version is not None else None
+    except ValueError as exc:
+        raise ValueError("Invalid trajectory Parquet version metadata") from exc
+    if file_version not in {None, _FORMAT_VERSION}:
+        raise ValueError(f"Unsupported trajectory Parquet version: {file_version}")
+    has_version_column = "format_version" in schema.names
+    has_canonical_columns = bool(
+        {"group_json", "trajectory_json"}.intersection(schema.names)
+    )
+    if file_version == _FORMAT_VERSION and not has_version_column:
+        raise ValueError("Versioned trajectory Parquet is missing format_version")
+    if has_canonical_columns and not has_version_column:
+        raise ValueError("Canonical trajectory Parquet is missing its version marker")
+    if (
+        has_version_column
+        and file_version is None
+        and not pq.read_metadata(path).num_rows
+    ):
+        raise ValueError(
+            "Empty versioned trajectory Parquet is missing version metadata"
+        )
+
+    with duckdb.connect(":memory:") as connection:
+        result = connection.execute("SELECT * FROM read_parquet(?)", [str(path)])
+        rows = [
+            dict(zip((column[0] for column in result.description), row))
+            for row in result.fetchall()
+        ]
+    if not rows:
+        return []
+    return _read_v2(rows) if has_version_column else _read_v1(rows)

--- a/src/art/utils/trajectory_migration.py
+++ b/src/art/utils/trajectory_migration.py
@@ -14,11 +14,14 @@ from dataclasses import dataclass, field
 import json
 from pathlib import Path
 from typing import Any, Callable, Iterator, cast
+import warnings
 
+import pydantic
 import yaml
 
 from art.trajectories import History, Trajectory, TrajectoryGroup
 from art.types import Choice, Message, MessageOrChoice
+from art.utils.trajectory_logging import write_trajectory_groups_parquet
 
 # ============================================================================
 # Legacy JSONL serialization helpers
@@ -108,30 +111,34 @@ def deserialize_trajectory_groups(serialized: str) -> list[TrajectoryGroup]:
 
 
 def dict_to_trajectory_group(d: dict[str, Any]) -> TrajectoryGroup:
-    return TrajectoryGroup(
-        trajectories=[
-            dict_to_trajectory(trajectory) for trajectory in d["trajectories"]
-        ],
-        exceptions=[],
+    return TrajectoryGroup.model_validate(
+        {
+            **d,
+            "trajectories": [
+                dict_to_trajectory(trajectory) for trajectory in d["trajectories"]
+            ],
+        }
     )
 
 
 def dict_to_trajectory(d: dict[str, Any]) -> Trajectory:
-    return Trajectory(
-        messages_and_choices=[
-            dict_to_message_or_choice(message_or_choice)
-            for message_or_choice in d["messages_and_choices"]
-        ],
-        reward=d["reward"],
-        metrics=d["metrics"],
-        metadata=d["metadata"],
-        logs=d["logs"],
+    return Trajectory.model_validate(
+        {
+            **d,
+            "messages_and_choices": [
+                dict_to_message_or_choice(message_or_choice)
+                for message_or_choice in d.get("messages_and_choices", [])
+            ],
+        }
     )
 
 
 def dict_to_message_or_choice(d: dict[str, Any]) -> MessageOrChoice:
     if "message" in d:
-        return Choice(**d)
+        try:
+            return Choice(**d)
+        except pydantic.ValidationError:
+            return cast(Message, d)
     else:
         return cast(Message, d)
 
@@ -190,9 +197,6 @@ def migrate_jsonl_to_parquet(
     Returns:
         MigrationResult with statistics about the migration.
     """
-    import pyarrow as pa
-    import pyarrow.parquet as pq
-
     jsonl_path = Path(jsonl_path)
     result = MigrationResult()
 
@@ -217,102 +221,15 @@ def migrate_jsonl_to_parquet(
         return result
 
     try:
-        # Read JSONL file
-        trajectory_groups_data = []
+        trajectory_groups_data: list[dict[str, Any]] = []
         with open(jsonl_path, "r") as f:
             for line in f:
                 if line.strip():
                     trajectory_groups_data.append(json.loads(line))
-
-        # Convert to flat rows for Parquet
-        rows = []
-        for group_index, group in enumerate(trajectory_groups_data):
-            for traj in group.get("trajectories", []):
-                # Flatten messages
-                messages = []
-                for msg in traj.get("messages_and_choices", []):
-                    if "finish_reason" in msg:
-                        # Choice format - extract inner message, mark as trainable
-                        inner = msg.get("message", {})
-                        messages.append(
-                            {
-                                "role": inner.get("role"),
-                                "content": inner.get("content"),
-                                "tool_calls": json.dumps(inner.get("tool_calls"))
-                                if inner.get("tool_calls")
-                                else None,
-                                "tool_call_id": None,
-                                "trainable": True,
-                            }
-                        )
-                    else:
-                        # Regular message
-                        messages.append(
-                            {
-                                "role": msg.get("role"),
-                                "content": msg.get("content"),
-                                "tool_calls": json.dumps(msg.get("tool_calls"))
-                                if msg.get("tool_calls")
-                                else None,
-                                "tool_call_id": msg.get("tool_call_id"),
-                                "trainable": False,
-                            }
-                        )
-
-                rows.append(
-                    {
-                        "group_index": group_index,
-                        "reward": traj.get("reward"),
-                        "metrics": json.dumps(traj.get("metrics"))
-                        if traj.get("metrics")
-                        else None,
-                        "metadata": json.dumps(traj.get("metadata"))
-                        if traj.get("metadata")
-                        else None,
-                        "tools": json.dumps(traj.get("tools"))
-                        if traj.get("tools")
-                        else None,
-                        "logs": traj.get("logs"),
-                        "additional_histories": json.dumps(
-                            traj.get("additional_histories")
-                        )
-                        if traj.get("additional_histories")
-                        else None,
-                        "messages": messages,
-                    }
-                )
-
-        # Define the message struct schema
-        message_type = pa.struct(
-            [
-                ("role", pa.string()),
-                ("content", pa.string()),
-                ("tool_calls", pa.string()),
-                ("tool_call_id", pa.string()),
-                ("trainable", pa.bool_()),
-            ]
+        write_trajectory_groups_parquet(
+            [dict_to_trajectory_group(group) for group in trajectory_groups_data],
+            parquet_path,
         )
-
-        schema = pa.schema(
-            [
-                ("group_index", pa.int64()),
-                ("reward", pa.float64()),
-                ("metrics", pa.string()),
-                ("metadata", pa.string()),
-                ("tools", pa.string()),
-                ("logs", pa.list_(pa.string())),
-                ("additional_histories", pa.string()),
-                ("messages", pa.list_(message_type)),
-            ]
-        )
-
-        # Handle empty case
-        if not rows:
-            table = pa.table({name: [] for name in schema.names}, schema=schema)
-            pq.write_table(table, parquet_path, compression="zstd")
-        else:
-            table = pa.Table.from_pylist(rows, schema=schema)
-            pq.write_table(table, parquet_path, compression="zstd")
 
         # Get new size
         new_size = parquet_path.stat().st_size
@@ -476,5 +393,7 @@ def auto_migrate_on_register(model_dir: Path | str) -> MigrationResult:
             f"Migrated {result.files_migrated} trajectory files to Parquet "
             f"(saved {result.space_saved / 1024 / 1024:.1f} MB)"
         )
+    if result.errors:
+        warnings.warn("\n".join(result.errors), RuntimeWarning, stacklevel=2)
 
     return result

--- a/tests/unit/test_frontend_logging.py
+++ b/tests/unit/test_frontend_logging.py
@@ -119,7 +119,11 @@ class TestFrontendLoggingCompatibility:
 
         # Check expected columns exist
         expected_columns = [
+            "format_version",
             "group_index",
+            "trajectory_index",
+            "group_json",
+            "trajectory_json",
             "group_metadata",
             "group_metrics",
             "group_logs",

--- a/tests/unit/test_trajectory_parquet.py
+++ b/tests/unit/test_trajectory_parquet.py
@@ -35,7 +35,7 @@ from openai.types.chat.chat_completion_user_message_param import (
 )
 import pytest
 
-from art import Trajectory, TrajectoryGroup
+from art import History, Trajectory, TrajectoryGroup
 from art.types import MessageOrChoice
 from art.utils.trajectory_logging import (
     read_trajectory_groups_parquet,
@@ -43,6 +43,7 @@ from art.utils.trajectory_logging import (
 )
 from art.utils.trajectory_migration import (
     MigrationResult,
+    auto_migrate_on_register,
     deserialize_trajectory_groups,
     message_or_choice_to_dict,
     migrate_jsonl_to_parquet,
@@ -54,6 +55,191 @@ from art.utils.trajectory_migration import (
 
 # Path to test fixtures
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "trajectories"
+
+
+def _exchange_trajectory() -> Trajectory:
+    return Trajectory.model_validate(
+        {
+            "reward": 1.25,
+            "initial_policy_version": 3,
+            "final_policy_version": 4,
+            "metadata": {"nested": {"unicode": "你好"}},
+            "exchanges": {
+                "chat_completions": [
+                    {
+                        "request": {
+                            "model": "test/model",
+                            "messages": [{"role": "user", "content": "chat"}],
+                            "cache_salt": "salt",
+                            "provider_extension": {"enabled": True},
+                        },
+                        "response": {
+                            "id": "chat-1",
+                            "object": "chat.completion",
+                            "created": 1,
+                            "model": "test/model",
+                            "prompt_token_ids": [1, 2],
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "finish_reason": "stop",
+                                    "message": {
+                                        "role": "assistant",
+                                        "content": "answer",
+                                    },
+                                    "token_ids": [3],
+                                }
+                            ],
+                        },
+                        "start_time": "2026-01-01T00:00:00",
+                        "end_time": "2026-01-01T00:00:01",
+                    }
+                ],
+                "completions": [
+                    {
+                        "request": {"model": "test/model", "prompt": [10, 11]},
+                        "response": {
+                            "id": "completion-1",
+                            "object": "text_completion",
+                            "created": 1,
+                            "model": "test/model",
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "finish_reason": "stop",
+                                    "text": "x",
+                                    "prompt_token_ids": [10, 11],
+                                    "token_ids": [12],
+                                    "logprobs": {
+                                        "tokens": ["x"],
+                                        "token_logprobs": [-0.2],
+                                        "top_logprobs": [{}],
+                                        "text_offset": [0],
+                                    },
+                                }
+                            ],
+                        },
+                        "start_time": "2026-01-01T00:00:02",
+                        "end_time": "2026-01-01T00:00:03",
+                    }
+                ],
+                "responses": [
+                    {
+                        "request": {
+                            "model": "test/model",
+                            "input": "respond",
+                            "provider_extension": True,
+                        },
+                        "response": {
+                            "id": "response-1",
+                            "created_at": 1.0,
+                            "model": "test/model",
+                            "object": "response",
+                            "output": [
+                                {
+                                    "id": "response-message-1",
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "status": "completed",
+                                    "content": [
+                                        {
+                                            "type": "output_text",
+                                            "text": "done",
+                                            "annotations": [],
+                                            "logprobs": [],
+                                        }
+                                    ],
+                                }
+                            ],
+                            "parallel_tool_calls": True,
+                            "tool_choice": "auto",
+                            "tools": [],
+                            "raw_output_tokens": [{"token_id": 20, "logprob": -0.3}],
+                        },
+                        "start_time": "2026-01-01T00:00:04",
+                        "end_time": "2026-01-01T00:00:05",
+                    }
+                ],
+                "messages": [
+                    {
+                        "request": {
+                            "model": "test/model",
+                            "messages": [{"role": "user", "content": "hello"}],
+                            "max_tokens": 8,
+                        },
+                        "response": {
+                            "id": "message-1",
+                            "type": "message",
+                            "role": "assistant",
+                            "model": "test/model",
+                            "content": [{"type": "text", "text": "hi"}],
+                            "stop_reason": "end_turn",
+                            "stop_sequence": None,
+                            "usage": {"input_tokens": 1, "output_tokens": 1},
+                            "token_ids": [30],
+                            "logprobs": [-0.4],
+                        },
+                        "start_time": "2026-01-01T00:00:06",
+                        "end_time": "2026-01-01T00:00:07",
+                    }
+                ],
+            },
+        }
+    )
+
+
+def _write_v1_parquet(path: Path, *, include_group_fields: bool) -> None:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    message_type = pa.struct(
+        [
+            ("role", pa.string()),
+            ("content", pa.string()),
+            ("tool_calls", pa.string()),
+            ("tool_call_id", pa.string()),
+            ("trainable", pa.bool_()),
+        ]
+    )
+    fields = [
+        ("reward", pa.float64()),
+        ("metrics", pa.string()),
+        ("metadata", pa.string()),
+        ("tools", pa.string()),
+        ("logs", pa.list_(pa.string())),
+        ("messages", pa.list_(message_type)),
+    ]
+    row: dict[str, object] = {
+        "reward": 0.75,
+        "metrics": '{"score":1}',
+        "metadata": '{"source":"v1"}',
+        "tools": None,
+        "logs": ["legacy"],
+        "messages": [
+            {
+                "role": "user",
+                "content": "old data",
+                "tool_calls": None,
+                "tool_call_id": None,
+                "trainable": False,
+            }
+        ],
+    }
+    if include_group_fields:
+        fields = [
+            ("group_index", pa.int64()),
+            ("group_metadata", pa.string()),
+            ("group_metrics", pa.string()),
+            ("group_logs", pa.list_(pa.string())),
+            *fields,
+        ]
+        row.update(
+            group_index=0,
+            group_metadata='{"fixture":"runtime-v1"}',
+            group_metrics='{"judge":0.5}',
+            group_logs=["legacy group"],
+        )
+    pq.write_table(pa.Table.from_pylist([row], schema=pa.schema(fields)), path)
 
 
 def test_legacy_choice_serialization_omits_unset_fields() -> None:
@@ -231,8 +417,207 @@ class TestParquetRoundTrip:
         assert group.metrics == {"judge_score": 0.7, "pass_rate": 1}
         assert group.logs == ["group log 1", "group log 2"]
 
+    def test_complete_models_round_trip(self, tmp_path: Path) -> None:
+        legacy = Trajectory(
+            messages_and_choices=[
+                {"role": "user", "content": "legacy"},
+                Choice.model_validate(
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": "preserved"},
+                        "logprobs": {
+                            "content": [
+                                {
+                                    "token": "preserved",
+                                    "logprob": -0.25,
+                                    "bytes": None,
+                                    "top_logprobs": [],
+                                    "token_id": 42,
+                                }
+                            ]
+                        },
+                    }
+                ),
+            ],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "lookup", "parameters": {}},
+                }
+            ],
+            additional_histories=[
+                History(messages_and_choices=[{"role": "user", "content": "alternate"}])
+            ],
+            initial_policy_version=7,
+            final_policy_version=8,
+        )
+        original = [
+            TrajectoryGroup(
+                [_exchange_trajectory(), legacy],
+                exceptions=[RuntimeError("captured failure")],
+                metadata={"scenario": {"id": 7, "tags": ["a", "b"]}},
+                metrics={"pass_rate": 0.5},
+                logs=["group log"],
+            )
+        ]
+        path = tmp_path / "complete.parquet"
+
+        write_trajectory_groups_parquet(original, path)
+        loaded = read_trajectory_groups_parquet(path)
+
+        assert [
+            group.model_dump(mode="json", exclude_defaults=False, warnings="error")
+            for group in loaded
+        ] == [
+            group.model_dump(mode="json", exclude_defaults=False, warnings="error")
+            for group in original
+        ]
+        import pyarrow.parquet as pq
+
+        rows = pq.read_table(path).to_pylist()
+        assert rows[0]["messages"] is None
+        assert rows[1]["messages"] is not None
+        exchange_payload = json.loads(rows[0]["trajectory_json"])
+        assert "model" not in exchange_payload["exchanges"]["chat_completions"][0]
+
+    def test_multipart_legacy_content_does_not_block_canonical_write(
+        self, tmp_path: Path
+    ) -> None:
+        trajectory = Trajectory(
+            messages_and_choices=[
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hello"}],
+                }
+            ]
+        )
+        path = tmp_path / "multipart.parquet"
+
+        write_trajectory_groups_parquet([TrajectoryGroup([trajectory])], path)
+        [loaded] = read_trajectory_groups_parquet(path)
+
+        assert (
+            loaded.trajectories[0].messages_and_choices
+            == trajectory.messages_and_choices
+        )
+        import pyarrow.parquet as pq
+
+        assert pq.read_table(path).to_pylist()[0]["messages"] is None
+
+    def test_empty_and_exception_only_groups_round_trip(self, tmp_path: Path) -> None:
+        original = [
+            TrajectoryGroup(metadata={"empty": True}),
+            TrajectoryGroup(
+                exceptions=[ValueError("bad rollout")], logs=["failed group"]
+            ),
+        ]
+        path = tmp_path / "empty-groups.parquet"
+
+        write_trajectory_groups_parquet(original, path)
+        loaded = read_trajectory_groups_parquet(path)
+
+        assert [group.model_dump(mode="json") for group in loaded] == [
+            group.model_dump(mode="json") for group in original
+        ]
+
+    @pytest.mark.parametrize("include_group_fields", [False, True])
+    def test_reads_unversioned_v1_files(
+        self, tmp_path: Path, include_group_fields: bool
+    ) -> None:
+        path = tmp_path / "v1.parquet"
+        _write_v1_parquet(path, include_group_fields=include_group_fields)
+
+        [group] = read_trajectory_groups_parquet(path)
+
+        assert group.trajectories[0].reward == 0.75
+        assert group.trajectories[0].metrics == {"score": 1}
+        assert group.trajectories[0].metadata == {"source": "v1"}
+        assert group.trajectories[0].logs == ["legacy"]
+        assert group.metadata == (
+            {"fixture": "runtime-v1"} if include_group_fields else {}
+        )
+
+    def test_v2_rows_are_restored_by_trajectory_index(self, tmp_path: Path) -> None:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        path = tmp_path / "reordered.parquet"
+        group = TrajectoryGroup(
+            [Trajectory(reward=1), Trajectory(reward=2), Trajectory(reward=3)]
+        )
+        write_trajectory_groups_parquet([group], path)
+        table = pq.read_table(path)
+        pq.write_table(table.take(pa.array([2, 0, 1])), path)
+
+        [loaded] = read_trajectory_groups_parquet(path)
+
+        assert [trajectory.reward for trajectory in loaded] == [1, 2, 3]
+
+    def test_rejects_unknown_empty_v2_format(self, tmp_path: Path) -> None:
+        import pyarrow.parquet as pq
+
+        source = tmp_path / "source.parquet"
+        future = tmp_path / "future.parquet"
+        write_trajectory_groups_parquet([], source)
+        table = pq.read_table(source).replace_schema_metadata(
+            {b"art.trajectory_parquet.version": b"3"}
+        )
+        pq.write_table(table, future)
+
+        with pytest.raises(ValueError, match="Unsupported trajectory Parquet version"):
+            read_trajectory_groups_parquet(future)
+
+    def test_rejects_duplicate_trajectory_indexes(self, tmp_path: Path) -> None:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        path = tmp_path / "duplicate.parquet"
+        write_trajectory_groups_parquet(
+            [TrajectoryGroup([Trajectory(reward=1), Trajectory(reward=2)])], path
+        )
+        table = pq.read_table(path)
+        index = table.schema.get_field_index("trajectory_index")
+        table = table.set_column(
+            index,
+            "trajectory_index",
+            pa.array([0, 0], type=table.schema.field(index).type),
+        )
+        pq.write_table(table, path)
+
+        with pytest.raises(ValueError, match="duplicate or missing trajectories"):
+            read_trajectory_groups_parquet(path)
+
+    def test_rejects_missing_v2_markers_and_group_rows(self, tmp_path: Path) -> None:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        source = tmp_path / "source.parquet"
+        write_trajectory_groups_parquet(
+            [TrajectoryGroup([_exchange_trajectory()]), TrajectoryGroup()], source
+        )
+        table = pq.read_table(source)
+
+        markerless = tmp_path / "markerless.parquet"
+        format_index = table.schema.get_field_index("format_version")
+        pq.write_table(
+            table.remove_column(format_index).replace_schema_metadata(None), markerless
+        )
+        with pytest.raises(ValueError, match="missing its version marker"):
+            read_trajectory_groups_parquet(markerless)
+
+        empty_markerless = tmp_path / "empty-markerless.parquet"
+        pq.write_table(table.slice(0, 0).remove_column(format_index), empty_markerless)
+        with pytest.raises(ValueError, match="missing format_version"):
+            read_trajectory_groups_parquet(empty_markerless)
+
+        missing_group = tmp_path / "missing-group.parquet"
+        pq.write_table(table.take(pa.array([1])), missing_group)
+        with pytest.raises(ValueError, match="group indexes.*non-contiguous"):
+            read_trajectory_groups_parquet(missing_group)
+
     def test_choice_format(self, tmp_path: Path):
-        """Test trajectories with Choice format (finish_reason) are flattened to messages."""
+        """Choice-shaped legacy entries retain their generated-response identity."""
         original = [
             TrajectoryGroup(
                 trajectories=[
@@ -264,20 +649,35 @@ class TestParquetRoundTrip:
         loaded = read_trajectory_groups_parquet(parquet_path)
 
         traj = loaded[0].trajectories[0]
-        # Choice format is flattened to a simple message dict
-        # The inner message content is preserved
         user_msg = _ensure_user_message(traj.messages_and_choices[0])
-        assistant_msg = _ensure_assistant_message(traj.messages_and_choices[1])
+        assistant_choice = traj.messages_and_choices[1]
 
         assert user_msg["role"] == "user"
         user_content = user_msg["content"]
         assert isinstance(user_content, str)
         assert user_content == "Hello"
 
-        assert assistant_msg["role"] == "assistant"
-        assistant_content = assistant_msg.get("content")
-        assert isinstance(assistant_content, str)
-        assert assistant_content == "Hi!"
+        assert isinstance(assistant_choice, Choice)
+        assert assistant_choice.finish_reason == "stop"
+        assert assistant_choice.index == 0
+        assert assistant_choice.message.role == "assistant"
+        assert assistant_choice.message.content == "Hi!"
+
+    def test_nonstandard_choice_dict_round_trips_verbatim(self, tmp_path: Path) -> None:
+        choice = {
+            "finish_reason": "eos",
+            "index": 0,
+            "message": {"role": "assistant", "content": "done"},
+        }
+        original = TrajectoryGroup.model_validate(
+            {"trajectories": [{"messages_and_choices": [choice], "reward": 1.0}]}
+        )
+        path = tmp_path / "nonstandard-choice.parquet"
+
+        write_trajectory_groups_parquet([original], path)
+        [loaded] = read_trajectory_groups_parquet(path)
+
+        assert loaded.trajectories[0].messages_and_choices == [choice]
 
     def test_unicode_content(self, tmp_path: Path):
         """Test trajectories with unicode and special characters."""
@@ -468,6 +868,40 @@ class TestParquetRoundTrip:
 class TestMigration:
     """Test JSONL to Parquet migration."""
 
+    def test_migrate_complete_exchange_group(self, tmp_path: Path) -> None:
+        group = TrajectoryGroup(
+            [_exchange_trajectory()],
+            exceptions=[ValueError("captured")],
+            metadata={"source": "exchange-jsonl"},
+        )
+        jsonl_path = tmp_path / "exchange.jsonl"
+        jsonl_path.write_text(group.model_dump_json())
+
+        result = migrate_jsonl_to_parquet(jsonl_path)
+        [loaded] = read_trajectory_groups_parquet(jsonl_path.with_suffix(".parquet"))
+
+        assert result.errors == []
+        assert loaded.model_dump(mode="json") == group.model_dump(mode="json")
+
+    def test_migrate_nonstandard_choice_dict(self, tmp_path: Path) -> None:
+        choice = {
+            "finish_reason": "eos",
+            "index": 0,
+            "message": {"role": "assistant", "content": "done"},
+        }
+        jsonl_path = tmp_path / "nonstandard-choice.jsonl"
+        jsonl_path.write_text(
+            json.dumps(
+                {"trajectories": [{"messages_and_choices": [choice], "reward": 1.0}]}
+            )
+        )
+
+        result = migrate_jsonl_to_parquet(jsonl_path)
+        [group] = read_trajectory_groups_parquet(jsonl_path.with_suffix(".parquet"))
+
+        assert result.errors == []
+        assert group.trajectories[0].messages_and_choices == [choice]
+
     def test_migrate_simple_jsonl(self, tmp_path: Path):
         """Test migrating a simple JSONL file."""
         # Create a JSONL file with enough content to benefit from compression
@@ -510,6 +944,11 @@ class TestMigration:
         parquet_path = tmp_path / "0001.parquet"
         assert parquet_path.exists()
         assert not jsonl_path.exists()
+        import pyarrow.parquet as pq
+
+        schema = pq.read_schema(parquet_path)
+        assert "format_version" in schema.names
+        assert schema.metadata == {b"art.trajectory_parquet.version": b"2"}
 
         # Verify content
         loaded = read_trajectory_groups_parquet(parquet_path)
@@ -761,6 +1200,16 @@ class TestEdgeCases:
 
         result = migrate_jsonl_to_parquet(bad_file)
         assert result.files_migrated == 0
+        assert len(result.errors) == 1
+
+    def test_auto_migration_warns_on_errors(self, tmp_path: Path) -> None:
+        trajectories = tmp_path / "trajectories"
+        trajectories.mkdir()
+        (trajectories / "bad.jsonl").write_text("not valid json{{{")
+
+        with pytest.warns(RuntimeWarning, match="Error migrating"):
+            result = auto_migrate_on_register(tmp_path)
+
         assert len(result.errors) == 1
 
     def test_empty_file(self, tmp_path: Path):


### PR DESCRIPTION
## Summary\n\n- add a versioned Parquet v2 envelope that preserves complete trajectory and group state while retaining the existing query-friendly analytics columns\n- read legacy unversioned v1 files and migrate JSONL through the same canonical writer\n- preserve exchange trajectories, tools, additional histories, policy versions, exceptions, empty groups, ordering, and Choice/logprob identity\n- fail closed on damaged or unknown format markers and surface automatic migration failures\n\n## Compatibility\n\n- existing v1 Parquet files remain readable\n- valid choice-shaped dictionaries normalize to OpenAI Choice objects; nonstandard provider dictionaries round-trip verbatim\n- exchange trajectories intentionally leave the legacy messages projection null rather than inventing a lossy transcript\n- older ART readers are not v2-aware and may read v2 files lossily; upgrade readers before consuming v2 output\n\n## Validation\n\n- 136 passed, 2 skipped (untracked golden-fixture directory), including trajectory capture/tokenization, Parquet/migration, analytics loading, and frontend logging\n- Ruff, Ruff format, ty, uv lock sync, and all prek hooks pass\n- independent adversarial reviews by a Codex subagent and Claude Fable 5; accepted findings have regression coverage\n