### PR TITLE
Fix silent loss in legacy trajectory serialization

### DIFF
--- a/src/art/utils/trajectory_migration.py
+++ b/src/art/utils/trajectory_migration.py
@@ -38,15 +38,14 @@ def serialize_trajectory_groups(trajectory_groups: list[TrajectoryGroup]) -> str
 
 
 def trajectory_group_to_dict(trajectory_group: TrajectoryGroup) -> dict[str, Any]:
-    trajectory_dicts = []
-    for trajectory in trajectory_group.trajectories:
-        if not isinstance(trajectory, Trajectory):
-            # remove exceptions
-            continue
-        trajectory_dicts.append(trajectory_to_dict(trajectory))
-
     return {
-        "trajectories": trajectory_dicts,
+        "trajectories": [
+            trajectory_to_dict(trajectory)
+            for trajectory in trajectory_group.trajectories
+        ],
+        **trajectory_group.model_dump(
+            mode="json", exclude={"trajectories"}, warnings="error"
+        ),
     }
 
 
@@ -76,6 +75,20 @@ def trajectory_to_dict(trajectory: Trajectory) -> dict[str, Any]:
             else trajectory.additional_histories
         ),
         "logs": trajectory.logs,
+        **trajectory.model_dump(
+            mode="json",
+            exclude={
+                "reward",
+                "metrics",
+                "metadata",
+                "messages_and_choices",
+                "tools",
+                "additional_histories",
+                "logs",
+            },
+            exclude_computed_fields=True,
+            warnings="error",
+        ),
     }
 
 
@@ -84,12 +97,8 @@ def message_or_choice_to_dict(message_or_choice: MessageOrChoice) -> dict[str, A
     item_dict = (
         message_or_choice.to_dict()
         if isinstance(message_or_choice, Choice)
-        else message_or_choice
+        else dict(message_or_choice)
     )
-
-    if "logprobs" in item_dict:
-        # item is a choice with logprobs, remove the logprobs
-        item_dict.pop("logprobs")  # ty:ignore[invalid-argument-type]
 
     if "content" in item_dict and isinstance(item_dict["content"], Iterator):
         item_dict["content"] = list(item_dict["content"])  # type: ignore
@@ -123,6 +132,22 @@ def dict_to_trajectory_group(d: dict[str, Any]) -> TrajectoryGroup:
 
 def dict_to_trajectory(d: dict[str, Any]) -> Trajectory:
     return Trajectory.model_validate(
+        {
+            **d,
+            "messages_and_choices": [
+                dict_to_message_or_choice(message_or_choice)
+                for message_or_choice in d.get("messages_and_choices", [])
+            ],
+            "additional_histories": [
+                dict_to_history(history)
+                for history in d.get("additional_histories", [])
+            ],
+        }
+    )
+
+
+def dict_to_history(d: dict[str, Any]) -> History:
+    return History.model_validate(
         {
             **d,
             "messages_and_choices": [

--- a/tests/unit/test_trajectory_parquet.py
+++ b/tests/unit/test_trajectory_parquet.py
@@ -256,6 +256,72 @@ def test_legacy_choice_serialization_omits_unset_fields() -> None:
     }
 
 
+def test_legacy_serializer_round_trips_complete_exchange_group() -> None:
+    original = TrajectoryGroup(
+        [_exchange_trajectory()],
+        exceptions=[RuntimeError("captured failure")],
+        metadata={"scenario": {"id": 7}},
+        metrics={"pass_rate": 0.5},
+        logs=["group log"],
+    )
+
+    [loaded] = deserialize_trajectory_groups(serialize_trajectory_groups([original]))
+
+    assert loaded.model_dump(
+        mode="json", exclude_defaults=False
+    ) == original.model_dump(mode="json", exclude_defaults=False)
+
+
+def test_legacy_serializer_round_trips_complete_legacy_trajectory() -> None:
+    choice = Choice.model_validate(
+        {
+            "index": 7,
+            "finish_reason": "stop",
+            "message": {"role": "assistant", "content": "preserved"},
+            "logprobs": {
+                "content": [
+                    {
+                        "token": "preserved",
+                        "logprob": -0.25,
+                        "bytes": None,
+                        "top_logprobs": [],
+                        "token_id": 42,
+                    }
+                ]
+            },
+        }
+    )
+    original = TrajectoryGroup(
+        [
+            Trajectory(
+                messages_and_choices=[choice],
+                additional_histories=[History(messages_and_choices=[choice])],
+                reward=1.0,
+                initial_policy_version=3,
+                final_policy_version=4,
+                metrics={"score": 1},
+                metadata={"source": "legacy"},
+                logs=["trajectory log"],
+            )
+        ]
+    )
+
+    [loaded] = deserialize_trajectory_groups(serialize_trajectory_groups([original]))
+    loaded_choice = loaded.trajectories[0].messages_and_choices[0]
+    loaded_history_choice = (
+        loaded.trajectories[0].additional_histories[0].messages_and_choices[0]
+    )
+
+    assert loaded.model_dump(
+        mode="json", exclude_defaults=False
+    ) == original.model_dump(mode="json", exclude_defaults=False)
+    assert isinstance(loaded_choice, Choice)
+    assert loaded_choice.index == 7
+    assert loaded_choice.logprobs == choice.logprobs
+    assert isinstance(loaded_history_choice, Choice)
+    assert loaded_history_choice.logprobs == choice.logprobs
+
+
 def _ensure_message(item: MessageOrChoice) -> ChatCompletionMessageParam:
     """Narrow a trajectory entry to a concrete message (not a Choice)."""
     assert not isinstance(item, Choice)


### PR DESCRIPTION
## Summary

Preserve complete trajectory-group state in the legacy JSONL serializer without changing the shape of ordinary legacy records.

## Changes

- serialize non-default group fields, including exceptions, metadata, metrics, and logs
- serialize modern trajectory fields, including exchanges and policy versions
- retain choice logprobs and avoid mutating mapping-backed messages during serialization
- add focused exchange and legacy-history round-trip regressions

Compatibility semantics: existing legacy keys and unset-field omission are preserved. Modern/group keys are additive only when non-default state exists. Strict external readers that reject unknown keys may need to tolerate these additive fields; ART's legacy deserializer already accepts them.

## Test plan

- `uv run pytest tests/unit/test_trajectory_parquet.py -q` (36 passed, 2 skipped)
- `uv run prek run --all-files` (ruff, ruff-format, ty, uv.lock sync check passed)
