### PR TITLE
Lazy-load exchange tokenization dependencies

### DIFF
--- a/src/art/trajectories/_history.py
+++ b/src/art/trajectories/_history.py
@@ -272,7 +272,7 @@ def completions_history(
             prompt = _exact_token_ids(
                 request_prompt, field="Completions request prompt"
             )
-        if prompt is None:
+        if prompt is None or completion is None:
             raise ValueError(
                 "Completions history requires exact prompt and output token IDs"
             )

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -12,7 +12,6 @@ from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion import Choice
 from openai.types.responses import Response
 from pydantic import BaseModel
-from transformers import PreTrainedTokenizerBase
 
 from . import (
     ChatCompletionsExchange,
@@ -318,7 +317,9 @@ def _artifact_config(model: str) -> _TokenizerConfig:
     from wandb.apis.public import Api
 
     artifact_path = model.removeprefix("wandb-artifact:///")
-    artifact = Api().artifact(f"{artifact_path}:latest")
+    if ":" not in artifact_path.rsplit("/", 1)[-1]:
+        artifact_path = f"{artifact_path}:latest"
+    artifact = Api().artifact(artifact_path)
     metadata = artifact.metadata
     base_model = metadata.get("base_model") or metadata.get("wandb.base_model")
     if not isinstance(base_model, str):
@@ -343,15 +344,10 @@ def _artifact_config(model: str) -> _TokenizerConfig:
 
 
 def _tokenizer_config(model: str, base_model: str | None) -> _TokenizerConfig:
-    if model.startswith("wandb-artifact:///"):
-        config = _artifact_config(model)
-        if base_model is not None:
-            if base_model != config.base_model:
-                config.revision = None
-            config.base_model = base_model
-        return config
     if base_model is not None:
         return _TokenizerConfig(base_model)
+    if model.startswith("wandb-artifact:///"):
+        return _artifact_config(model)
     return _TokenizerConfig(model)
 
 
@@ -959,7 +955,12 @@ def tokenize_one(
     selected_model = exchanges[0].model
     if selected_model is None:
         raise AssertionError("_exchange_list returned an exchange without a model")
-    config = _tokenizer_config(selected_model, base_model)
+    exact_tokens = [_exchange_tokens(exchange) for exchange in exchanges]
+    config = (
+        _TokenizerConfig(base_model if base_model is not None else selected_model)
+        if base_model is not None or tokenizer_instance is not None
+        else None
+    )
     tokenizer = tokenizer_instance
     token_ids: list[int] = []
     logprobs: list[float] = []
@@ -969,22 +970,30 @@ def tokenize_one(
         str, tuple[list[dict[str, Any]] | None, ResponsesExchange]
     ] = {}
 
-    for exchange in exchanges:
+    def fallback_config() -> _TokenizerConfig:
+        nonlocal config
+        if config is None:
+            config = _tokenizer_config(selected_model, base_model)
+        return config
+
+    for exchange, (prompt, completion, completion_logprobs) in zip(
+        exchanges, exact_tokens, strict=True
+    ):
         if isinstance(exchange, CompletionsExchange):
-            prompt = exchange.request.get("prompt")
-            if isinstance(prompt, list) and not all(
-                isinstance(item, int) and not isinstance(item, bool) for item in prompt
+            request_prompt = exchange.request.get("prompt")
+            if isinstance(request_prompt, list) and not all(
+                isinstance(item, int) and not isinstance(item, bool)
+                for item in request_prompt
             ):
                 raise ValueError(
                     "Trajectory tokenization does not support batched Completions prompts"
                 )
-            if not isinstance(prompt, (str, list)):
+            if not isinstance(request_prompt, (str, list)):
                 raise ValueError("Completions prompt must be text or one token ID list")
             if exchange.request.get("echo") is True:
                 raise ValueError(
                     "Trajectory tokenization does not support Completions echo=True"
                 )
-        prompt, completion, completion_logprobs = _exchange_tokens(exchange)
         messages_override: list[dict[str, Any]] | None = None
         if isinstance(exchange, ResponsesExchange):
             request = exchange.request
@@ -1012,25 +1021,27 @@ def tokenize_one(
                     ]
             response_histories[exchange.response.id] = (messages_override, exchange)
         if prompt is None:
+            resolved_config = fallback_config()
             if tokenizer is None:
-                tokenizer = _load_tokenizer(config)
+                tokenizer = _load_tokenizer(resolved_config)
             prompt = _template_ids(
                 tokenizer,
                 exchange,
                 completed=False,
-                config=config,
+                config=resolved_config,
                 chat_template=chat_template,
                 chat_template_kwargs=chat_template_kwargs,
                 messages_override=messages_override,
             )
         if not completion:
+            resolved_config = fallback_config()
             if tokenizer is None:
-                tokenizer = _load_tokenizer(config)
+                tokenizer = _load_tokenizer(resolved_config)
             completed = _template_ids(
                 tokenizer,
                 exchange,
                 completed=True,
-                config=config,
+                config=resolved_config,
                 chat_template=chat_template,
                 chat_template_kwargs=chat_template_kwargs,
                 messages_override=messages_override,

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -255,7 +255,8 @@ def _responses_tokens(
             require_token_ids=True,
             field="Responses raw_output_tokens",
         )
-        return None, token_ids, logprobs
+        if token_ids or not data.get("output"):
+            return None, token_ids, logprobs
     token_ids: list[int] = []
     logprobs: list[float] = []
     saw_rendered_output = False
@@ -354,10 +355,15 @@ def _artifact_config(model: str) -> _TokenizerConfig:
 
 
 def _tokenizer_config(model: str, base_model: str | None) -> _TokenizerConfig:
+    if model.startswith("wandb-artifact:///"):
+        config = _artifact_config(model)
+        if base_model is not None:
+            if base_model != config.base_model:
+                config.revision = None
+            config.base_model = base_model
+        return config
     if base_model is not None:
         return _TokenizerConfig(base_model)
-    if model.startswith("wandb-artifact:///"):
-        return _artifact_config(model)
     return _TokenizerConfig(model)
 
 
@@ -968,7 +974,12 @@ def tokenize_one(
     exact_tokens = [_exchange_tokens(exchange) for exchange in exchanges]
     config = (
         _TokenizerConfig(base_model if base_model is not None else selected_model)
-        if base_model is not None or tokenizer_instance is not None
+        if tokenizer_instance is not None
+        or (
+            base_model is not None
+            and chat_template is not None
+            and chat_template_kwargs is not None
+        )
         else None
     )
     tokenizer = tokenizer_instance

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -162,7 +162,7 @@ def _logprob_values(values: object) -> list[float]:
 
 def _chat_choice_tokens(
     choice: Choice, response_data: dict[str, Any]
-) -> tuple[list[int] | None, list[int], list[float]]:
+) -> tuple[list[int] | None, list[int] | None, list[float]]:
     choice_data = _dump(choice)
     prompt = choice_data.get("prompt_token_ids")
     if prompt is None:
@@ -176,20 +176,25 @@ def _chat_choice_tokens(
     if choice.logprobs is not None:
         logprob_values = choice.logprobs.content or choice.logprobs.refusal
     values = list(logprob_values or [])
+    message = _dump(choice.message)
+    if token_ids == [] and (
+        values or any(message.get(key) for key in ("content", "refusal", "tool_calls"))
+    ):
+        token_ids = None
     pair_ids, logprobs = _pairs(values, field="Chat Completions logprobs")
-    token_ids = token_ids or []
-    if token_ids and pair_ids and token_ids != pair_ids:
+    if token_ids is not None and pair_ids and token_ids != pair_ids:
         raise ValueError("Response token IDs disagree with choice logprobs")
+    selected = token_ids if token_ids is not None else pair_ids or None
     return (
         prompt_ids,
-        token_ids or pair_ids,
-        logprobs or _logprob_values(values) or [math.nan] * len(token_ids),
+        selected,
+        logprobs or _logprob_values(values) or [math.nan] * len(selected or []),
     )
 
 
 def _chat_tokens(
     response: ChatCompletion,
-) -> tuple[list[int] | None, list[int], list[float]]:
+) -> tuple[list[int] | None, list[int] | None, list[float]]:
     if len(response.choices) != 1:
         raise ValueError("Trajectory tokenization requires exactly one response choice")
     return _chat_choice_tokens(response.choices[0], _dump(response))
@@ -197,7 +202,7 @@ def _chat_tokens(
 
 def _completion_tokens(
     response: Completion,
-) -> tuple[list[int] | None, list[int], list[float]]:
+) -> tuple[list[int] | None, list[int] | None, list[float]]:
     if len(response.choices) != 1:
         raise ValueError("Trajectory tokenization requires exactly one response choice")
     choice = response.choices[0]
@@ -210,9 +215,10 @@ def _completion_tokens(
     token_ids = _exact_token_ids(
         choice_data.get("token_ids"), field="Completions token_ids"
     )
-    token_ids = token_ids or []
     logprobs = _dump(choice.logprobs)
     tokens = logprobs.get("tokens") or []
+    if token_ids == [] and (choice.text or tokens):
+        token_ids = None
     pair_ids: list[int] = []
     complete_pairs = True
     for value in tokens:
@@ -231,15 +237,17 @@ def _completion_tokens(
         float(value) if isinstance(value, (int, float)) else math.nan
         for value in logprobs.get("token_logprobs") or []
     ]
-    if token_ids and pair_ids and token_ids != pair_ids:
+    if token_ids is not None and pair_ids and token_ids != pair_ids:
         raise ValueError("Response token IDs disagree with completion logprobs")
-    selected = token_ids or pair_ids
-    if selected and len(pair_logprobs) != len(selected):
+    selected = token_ids if token_ids is not None else pair_ids or None
+    if selected is not None and len(pair_logprobs) != len(selected):
         pair_logprobs = [math.nan] * len(selected)
     return prompt_ids, selected, pair_logprobs
 
 
-def _responses_tokens(response: Response) -> tuple[None, list[int], list[float]]:
+def _responses_tokens(
+    response: Response,
+) -> tuple[None, list[int] | None, list[float]]:
     data = _dump(response)
     if "raw_output_tokens" in data:
         token_ids, logprobs = _pairs(
@@ -273,20 +281,22 @@ def _responses_tokens(response: Response) -> tuple[None, list[int], list[float]]
             logprobs.extend(pair_logprobs)
     if saw_rendered_output and complete:
         return None, token_ids, logprobs
-    return None, [], []
+    return None, None, []
 
 
-def _messages_tokens(response: Message) -> tuple[None, list[int], list[float]]:
+def _messages_tokens(
+    response: Message,
+) -> tuple[None, list[int] | None, list[float]]:
     data = _dump(response)
-    token_ids = (
-        _exact_token_ids(data.get("token_ids"), field="Messages token_ids") or []
-    )
+    token_ids = _exact_token_ids(data.get("token_ids"), field="Messages token_ids")
+    if token_ids == [] and data.get("content"):
+        token_ids = None
     logprobs = [
         float(value) if isinstance(value, (int, float)) else math.nan
         for value in data.get("logprobs") or []
     ]
-    if len(logprobs) != len(token_ids):
-        logprobs = [math.nan] * len(token_ids)
+    if token_ids is None or len(logprobs) != len(token_ids):
+        logprobs = [math.nan] * len(token_ids or [])
     return None, token_ids, logprobs
 
 
@@ -782,7 +792,7 @@ def _template_ids(
 
 def _exchange_tokens(
     exchange: Exchange,
-) -> tuple[list[int] | None, list[int], list[float]]:
+) -> tuple[list[int] | None, list[int] | None, list[float]]:
     if isinstance(exchange, ChatCompletionsExchange):
         return _chat_tokens(exchange.response)
     if isinstance(exchange, CompletionsExchange):
@@ -1033,7 +1043,7 @@ def tokenize_one(
                 chat_template_kwargs=chat_template_kwargs,
                 messages_override=messages_override,
             )
-        if not completion:
+        if completion is None:
             resolved_config = fallback_config()
             if tokenizer is None:
                 tokenizer = _load_tokenizer(resolved_config)

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 from datetime import datetime, timedelta
 import math
 from types import SimpleNamespace
@@ -112,15 +113,27 @@ def _completion_exchange(
     )
 
 
-def test_exact_tokens_form_one_append_only_history_without_tokenizer() -> None:
+def test_exact_tokens_form_one_append_only_history_without_tokenizer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = "wandb-artifact:///entity/project/run:step0"
     trajectory = art.Trajectory(
         exchanges=TrajectoryExchanges(
             chat_completions=[
-                _chat_exchange([1], [2], offset=0),
-                _chat_exchange([1, 2, 3], [4], offset=1),
+                _chat_exchange([1], [2], model=model, offset=0),
+                _chat_exchange([1, 2, 3], [4], model=model, offset=1),
             ]
         )
     )
+    real_import = builtins.__import__
+
+    def import_without_tokenizer_dependencies(name: str, *args: Any, **kwargs: Any):
+        if name.partition(".")[0] in {"transformers", "wandb"}:
+            raise AssertionError(f"unexpected import: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    monkeypatch.setattr(builtins, "__import__", import_without_tokenizer_dependencies)
 
     tokenized = art.tokenize_trajectory(trajectory)
 
@@ -255,7 +268,7 @@ def test_fallback_uses_template_overrides_and_nan_logprobs(
     start = datetime(2026, 1, 1)
     exchange = MessagesExchange(
         request=MessagesRequest(
-            model="test/model",
+            model="wandb-artifact:///entity/project/run:step0",
             messages=[{"role": "user", "content": "question"}],
             chat_template="request-template",
             chat_template_kwargs={"request": True},
@@ -266,8 +279,14 @@ def test_fallback_uses_template_overrides_and_nan_logprobs(
         end_time=start + timedelta(seconds=1),
     )
     tokenizer = _FakeTokenizer()
+    loaded_base_models: list[str] = []
     monkeypatch.setattr(
-        "art.trajectories._tokenize._load_tokenizer", lambda _config: tokenizer
+        "art.trajectories._tokenize._load_tokenizer",
+        lambda config: loaded_base_models.append(config.base_model) or tokenizer,
+    )
+    monkeypatch.setattr(
+        "art.trajectories._tokenize._artifact_config",
+        lambda _model: pytest.fail("explicit base_model should bypass W&B"),
     )
 
     result = art.tokenize_trajectory(
@@ -278,6 +297,7 @@ def test_fallback_uses_template_overrides_and_nan_logprobs(
     )
 
     assert result.token_ids == [10, 11]
+    assert loaded_base_models == ["base/model"]
     assert result.assistant_mask == [False, True]
     assert math.isnan(result.logprobs[1])
     assert tokenizer.calls == [
@@ -304,8 +324,17 @@ def test_fallback_uses_template_overrides_and_nan_logprobs(
     ]
 
 
-def test_checkpoint_fallback_uses_latest_artifact_renderer(
+@pytest.mark.parametrize(
+    ("model", "artifact_name"),
+    [
+        ("wandb-artifact:///entity/project/run", "entity/project/run:latest"),
+        ("wandb-artifact:///entity/project/run:step0", "entity/project/run:step0"),
+    ],
+)
+def test_checkpoint_fallback_preserves_artifact_version_and_renderer(
     monkeypatch: pytest.MonkeyPatch,
+    model: str,
+    artifact_name: str,
 ) -> None:
     artifact_names: list[str] = []
 
@@ -326,9 +355,9 @@ def test_checkpoint_fallback_uses_latest_artifact_renderer(
     monkeypatch.setattr("wandb.apis.public.Api", Api)
     from art.trajectories._tokenize import _tokenizer_config
 
-    config = _tokenizer_config("wandb-artifact:///entity/project/run", None)
+    config = _tokenizer_config(model, None)
 
-    assert artifact_names == ["entity/project/run:latest"]
+    assert artifact_names == [artifact_name]
     assert config.base_model == "base/model"
     assert config.revision == "revision"
     assert config.chat_template == "template"
@@ -929,11 +958,15 @@ def test_responses_previous_response_id_resolves_local_history(
         art.tokenize_trajectory(trajectory, base_model="base/model")
 
 
-def test_exchange_trajectories_feed_existing_training_tokenizer() -> None:
+def test_exchange_trajectories_feed_existing_training_tokenizer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from art.preprocessing.tokenize import tokenize_trajectory_groups
 
+    model = "wandb-artifact:///entity/project/run:step0"
+
     class Tokenizer:
-        name_or_path = "test/model"
+        name_or_path = model
 
         def decode(self, token_id: int) -> str:
             return str(token_id)
@@ -942,17 +975,21 @@ def test_exchange_trajectories_feed_existing_training_tokenizer() -> None:
         [
             art.Trajectory(
                 exchanges=TrajectoryExchanges(
-                    chat_completions=[_chat_exchange([1], [2])]
+                    chat_completions=[_chat_exchange([1], [2], model=model)]
                 ),
                 reward=1,
             ),
             art.Trajectory(
                 exchanges=TrajectoryExchanges(
-                    chat_completions=[_chat_exchange([1], [3])]
+                    chat_completions=[_chat_exchange([1], [3], model=model)]
                 ),
                 reward=0,
             ),
         ]
+    )
+    monkeypatch.setattr(
+        "art.trajectories._tokenize._artifact_config",
+        lambda _model: pytest.fail("supplied tokenizer should bypass W&B"),
     )
 
     results = list(

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -117,11 +117,14 @@ def test_exact_tokens_form_one_append_only_history_without_tokenizer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     model = "wandb-artifact:///entity/project/run:step0"
+    empty = _chat_exchange([1, 2, 3, 4], [], model=model, offset=2)
+    empty.response.choices[0].message.content = ""
     trajectory = art.Trajectory(
         exchanges=TrajectoryExchanges(
             chat_completions=[
                 _chat_exchange([1], [2], model=model, offset=0),
                 _chat_exchange([1, 2, 3], [4], model=model, offset=1),
+                empty,
             ]
         )
     )

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -356,15 +356,31 @@ def test_checkpoint_fallback_preserves_artifact_version_and_renderer(
             )
 
     monkeypatch.setattr("wandb.apis.public.Api", Api)
-    from art.trajectories._tokenize import _tokenizer_config
+    exchange = _chat_exchange([], [], model=model)
+    extra = exchange.response.choices[0].model_extra
+    assert extra is not None
+    extra.pop("prompt_token_ids")
+    extra.pop("token_ids")
+    exchange.response.choices[0].logprobs = None
+    tokenizer = _FakeTokenizer()
+    configs = []
+    monkeypatch.setattr(
+        "art.trajectories._tokenize._load_tokenizer",
+        lambda config: configs.append(config) or tokenizer,
+    )
 
-    config = _tokenizer_config(model, None)
+    art.tokenize_trajectory(
+        art.Trajectory(exchanges=TrajectoryExchanges(chat_completions=[exchange]))
+    )
+    config = configs[0]
 
     assert artifact_names == [artifact_name]
     assert config.base_model == "base/model"
     assert config.revision == "revision"
     assert config.chat_template == "template"
     assert config.chat_template_kwargs == {"thinking": True}
+    assert tokenizer.calls[0]["chat_template"] == "template"
+    assert tokenizer.calls[0]["thinking"] is True
 
 
 def test_anthropic_fallback_preserves_thinking_and_tool_history() -> None:
@@ -748,6 +764,27 @@ def test_responses_aggregates_complete_exact_pairs_across_content_blocks(
     assert result.logprobs[1:] == [-0.1, -0.2]
 
 
+def test_responses_empty_raw_tokens_fall_back_for_visible_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    exchange = _response_exchange("response-empty-raw", 0)
+    data = exchange.response.model_dump(mode="python")
+    data["raw_output_tokens"] = []
+    exchange.response = Response.model_validate(data)
+    monkeypatch.setattr(
+        "art.trajectories._tokenize._load_tokenizer", lambda _config: _FakeTokenizer()
+    )
+
+    result = art.tokenize_trajectory(
+        art.Trajectory(exchanges=TrajectoryExchanges(responses=[exchange])),
+        base_model="base/model",
+        chat_template="template",
+        chat_template_kwargs={},
+    )
+
+    assert result.token_ids == [10, 11]
+
+
 def test_responses_does_not_use_partial_exact_content_pairs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -967,9 +1004,24 @@ def test_exchange_trajectories_feed_existing_training_tokenizer(
     from art.preprocessing.tokenize import tokenize_trajectory_groups
 
     model = "wandb-artifact:///entity/project/run:step0"
+    fallback = _chat_exchange([], [], model=model)
+    fallback_extra = fallback.response.choices[0].model_extra
+    assert fallback_extra is not None
+    fallback_extra.pop("prompt_token_ids")
+    fallback_extra.pop("token_ids")
+    fallback.response.choices[0].logprobs = None
 
     class Tokenizer:
         name_or_path = model
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def apply_chat_template(
+            self, messages: list[dict[str, Any]], **kwargs: object
+        ) -> list[int]:
+            self.calls.append(kwargs)
+            return [1, 2] if messages[-1]["role"] == "assistant" else [1]
 
         def decode(self, token_id: int) -> str:
             return str(token_id)
@@ -977,9 +1029,7 @@ def test_exchange_trajectories_feed_existing_training_tokenizer(
     group = art.TrajectoryGroup(
         [
             art.Trajectory(
-                exchanges=TrajectoryExchanges(
-                    chat_completions=[_chat_exchange([1], [2], model=model)]
-                ),
+                exchanges=TrajectoryExchanges(chat_completions=[fallback]),
                 reward=1,
             ),
             art.Trajectory(
@@ -994,20 +1044,22 @@ def test_exchange_trajectories_feed_existing_training_tokenizer(
         "art.trajectories._tokenize._artifact_config",
         lambda _model: pytest.fail("supplied tokenizer should bypass W&B"),
     )
+    tokenizer = Tokenizer()
 
     results = list(
         tokenize_trajectory_groups(
-            # This path only calls decode; the minimal test double is intentional.
-            Tokenizer(),  # type: ignore[arg-type, ty:invalid-argument-type]
+            tokenizer,  # type: ignore[arg-type, ty:invalid-argument-type]
             [group],
-            allow_training_without_logprobs=False,
+            allow_training_without_logprobs=True,
             scale_rewards=False,
             shuffle_group_trajectories=False,
+            chat_template_kwargs={"serverless": True},
         )
     )
 
     assert [result.token_ids for result in results] == [[1, 2], [1, 3]]
     assert [result.assistant_mask for result in results] == [[0, 1], [0, 1]]
+    assert all(call["serverless"] is True for call in tokenizer.calls)
 
 
 def test_exchange_training_requires_logprobs_unless_allowed() -> None:


### PR DESCRIPTION
## Summary\n\nMake exchange trajectory tokenization usable in credential-free serverless preprocessing when inference services already return exact token IDs and logprobs.\n\n## Changes\n\n- validate and collect exact exchange token metadata before resolving tokenizer or artifact configuration\n- lazily resolve fallback tokenizer/config only when rendering is required\n- let supplied tokenizers and complete explicit renderer arguments bypass W&B artifact metadata lookup\n- preserve artifact renderer metadata for genuine fallback rendering\n- preserve existing artifact aliases/versions instead of appending :latest\n- distinguish missing completion metadata from valid zero-token completions without dropping visible Responses output\n- add regressions for the no-Transformers/no-W&B exact-token path, supplied-tokenizer fallback preprocessing, explicit base models, zero-token responses, renderer metadata, and version-pinned artifact URIs\n\n## Test plan\n\n- uv run pytest --tb=short -q tests/unit/trajectories tests/unit/test_preprocessing_tokenize.py — 73 passed\n- uv run prek run --all-files — passed (ruff, ruff format, ty, uv.lock sync)\n- GitHub quality checks and install smoke test — passed\n\n## Serverless follow-up handoff\n\nDo not modify or deploy serverless-training in this PR. A later serverless task should pin ART to merged commit c503a059a1a792a2ecf84f087ff962348bd781cc, add its serverless-side regression for credential-free exchange preprocessing, and repeat staging validation against the pinned build.