### PR TITLE
fix: Parse Qwen3.5 tool calls with the model-native grammar

### DIFF
--- a/src/art/megatron/model_support/handlers/qwen3_5.py
+++ b/src/art/megatron/model_support/handlers/qwen3_5.py
@@ -57,6 +57,9 @@ class Qwen35BaseHandler(DefaultDenseHandler):
     build_gdn_execution_spec = True
     native_vllm_lora_status = "validated"
 
+    def vllm_server_args(self) -> dict[str, object]:
+        return {"tool_call_parser": "qwen3_xml"}
+
     def identity_lora_model_config(self, base_config: Any) -> Any:
         return getattr(base_config, "text_config", base_config)
 

--- a/tests/integration/test_qwen_tool_parser_contract.py
+++ b/tests/integration/test_qwen_tool_parser_contract.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+import pytest
+
+_vllm_protocol = pytest.importorskip(
+    "vllm.entrypoints.openai.chat_completion.protocol"
+)
+_vllm_tool_parsers = pytest.importorskip("vllm.tool_parsers")
+
+
+_CONTRACT = json.loads(
+    (Path(__file__).parents[1] / "support/qwen_tool_parser_contract.json").read_text()
+)
+
+
+class _UnusedTokenizer:
+    def get_vocab(self) -> dict[str, int]:
+        return {}
+
+
+def test_qwen3_xml_matches_tinker_qwen35_tool_call_contract() -> None:
+    request = _vllm_protocol.ChatCompletionRequest(
+        model="Qwen/Qwen3.6-35B-A3B",
+        messages=[{"role": "user", "content": "Check the weather."}],
+        tools=_CONTRACT["tools"],
+        tool_choice="auto",
+    )
+    parser_type = _vllm_tool_parsers.ToolParserManager.get_tool_parser("qwen3_xml")
+    parser = parser_type(_UnusedTokenizer(), request.tools)  # type: ignore[arg-type]
+
+    parsed = parser.extract_tool_calls(_CONTRACT["model_output"], request)
+
+    assert parsed.tools_called is True
+    normalized_tool_calls = [
+        {
+            "name": tool_call.function.name,
+            "arguments": json.loads(tool_call.function.arguments),
+        }
+        for tool_call in parsed.tool_calls
+    ]
+    assert normalized_tool_calls == _CONTRACT["expected_tool_calls"]

--- a/tests/integration/test_qwen_tool_parser_contract.py
+++ b/tests/integration/test_qwen_tool_parser_contract.py
@@ -3,9 +3,7 @@ from pathlib import Path
 
 import pytest
 
-_vllm_protocol = pytest.importorskip(
-    "vllm.entrypoints.openai.chat_completion.protocol"
-)
+_vllm_protocol = pytest.importorskip("vllm.entrypoints.openai.chat_completion.protocol")
 _vllm_tool_parsers = pytest.importorskip("vllm.tool_parsers")
 
 

--- a/tests/support/qwen_tool_parser_contract.json
+++ b/tests/support/qwen_tool_parser_contract.json
@@ -1,0 +1,26 @@
+{
+  "model_output": "  reasoning  </think>\n\nAnswer first.\n\n<tool_call>\n<function=lookup_weather>\n<parameter=city>\nSan Francisco\n</parameter>\n<parameter=days>\n3\n</parameter>\n</function>\n</tool_call>",
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "lookup_weather",
+        "description": "Look up a weather forecast.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {"type": "string"},
+            "days": {"type": "integer"}
+          },
+          "required": ["city", "days"]
+        }
+      }
+    }
+  ],
+  "expected_tool_calls": [
+    {
+      "name": "lookup_weather",
+      "arguments": {"city": "San Francisco", "days": 3}
+    }
+  ]
+}

--- a/tests/unit/test_qwen_tool_parser_config.py
+++ b/tests/unit/test_qwen_tool_parser_config.py
@@ -2,6 +2,4 @@ from art.megatron.model_support.handlers.qwen3_5 import QWEN3_5_MOE_HANDLER
 
 
 def test_qwen35_uses_model_native_vllm_tool_parser() -> None:
-    assert QWEN3_5_MOE_HANDLER.vllm_server_args() == {
-        "tool_call_parser": "qwen3_xml"
-    }
+    assert QWEN3_5_MOE_HANDLER.vllm_server_args() == {"tool_call_parser": "qwen3_xml"}

--- a/tests/unit/test_qwen_tool_parser_config.py
+++ b/tests/unit/test_qwen_tool_parser_config.py
@@ -1,0 +1,7 @@
+from art.megatron.model_support.handlers.qwen3_5 import QWEN3_5_MOE_HANDLER
+
+
+def test_qwen35_uses_model_native_vllm_tool_parser() -> None:
+    assert QWEN3_5_MOE_HANDLER.vllm_server_args() == {
+        "tool_call_parser": "qwen3_xml"
+    }

--- a/tests/unit/test_tinker_renderers.py
+++ b/tests/unit/test_tinker_renderers.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import cast
 
 from tinker import EncodedTextChunk, ModelInput
@@ -7,6 +8,10 @@ from tinker_cookbook.tokenizer_utils import Tokenizer
 
 from art.tinker.renderers import get_renderer_name
 from art.tinker_native.data import convert_openai_messages_to_renderer_format
+
+_TOOL_PARSER_CONTRACT = json.loads(
+    (Path(__file__).parents[1] / "support/qwen_tool_parser_contract.json").read_text()
+)
 
 
 class FakeTokenizer:
@@ -95,22 +100,9 @@ def test_qwen3_5_generation_prompt_matches_hf_suffixes() -> None:
 
 def test_qwen3_5_parse_response_handles_xml_tool_calls() -> None:
     tokenizer = FakeTokenizer()
-    renderer = _get_test_renderer("qwen3_5", tokenizer)
+    renderer = _get_test_renderer("qwen3_5_disable_thinking", tokenizer)
 
-    response = tokenizer.encode(
-        "  reasoning  </think>\n\nAnswer first.\n\n"
-        "<tool_call>\n"
-        "<function=lookup_weather>\n"
-        "<parameter=city>\n"
-        "San Francisco\n"
-        "</parameter>\n"
-        "<parameter=days>\n"
-        "3\n"
-        "</parameter>\n"
-        "</function>\n"
-        "</tool_call>"
-        "<|im_end|>"
-    )
+    response = tokenizer.encode(f"{_TOOL_PARSER_CONTRACT['model_output']}<|im_end|>")
 
     message, success = renderer.parse_response(response)
 
@@ -120,12 +112,14 @@ def test_qwen3_5_parse_response_handles_xml_tool_calls() -> None:
         {"type": "text", "text": "Answer first.\n\n"},
     ]
     assert "unparsed_tool_calls" not in message
-    assert len(message["tool_calls"]) == 1
-    assert message["tool_calls"][0].function.name == "lookup_weather"
-    assert json.loads(message["tool_calls"][0].function.arguments) == {
-        "city": "San Francisco",
-        "days": 3,
-    }
+    normalized_tool_calls = [
+        {
+            "name": tool_call.function.name,
+            "arguments": json.loads(tool_call.function.arguments),
+        }
+        for tool_call in message["tool_calls"]
+    ]
+    assert normalized_tool_calls == _TOOL_PARSER_CONTRACT["expected_tool_calls"]
 
 
 def test_qwen3_5_to_openai_message_uses_mapping_tool_arguments() -> None:


### PR DESCRIPTION
Qwen3.5 emits tool calls using its native XML grammar, but the managed vLLM server currently inherits the generic parser selection. That makes tool-call interpretation depend on a parser whose grammar does not match the model output, and it also leaves Megatron and Tinker without an explicit compatibility contract.

The model handler is the right layer to own this choice: parser selection follows the model architecture, not an individual workload or Bench configuration. This configures Qwen3.5 handlers to start vLLM with `qwen3_xml`.

The tests use one representative model response as a shared contract. They verify that vLLM's Qwen parser and Tinker's Qwen3.5 renderer normalize the response into the same OpenAI-style tool call, and separately assert that the handler selects that parser. The useful mental model is therefore: one architecture-owned parser choice, with the two inference backends checked against the same observable output.

Verification:

- `uv run --no-sync pytest tests/unit/test_qwen_tool_parser_config.py tests/unit/test_tinker_renderers.py tests/integration/test_qwen_tool_parser_contract.py`
- `uv run --no-sync prek run --all-files`