### PR TITLE
Support final-assistant SFT on ServerlessBackend

### DIFF
--- a/src/art/serverless/backend.py
+++ b/src/art/serverless/backend.py
@@ -548,18 +548,14 @@ class ServerlessBackend:
         Args:
             model: The trainable model to fine-tune.
             trajectories: Iterable of Trajectory objects.
-            config: SFT configuration with batch_size and learning rates.
+            config: SFT configuration with batch size, learning rates, and assistant
+                turn selection.
             dev_config: Developer configuration.
             verbose: Whether to print detailed logs.
 
         Yields:
             Dictionary containing training metrics for each batch.
         """
-        if config.assistant_turns == "last":
-            raise NotImplementedError(
-                "assistant_turns='last' currently requires LocalBackend"
-            )
-
         import json
         import tempfile
         import uuid
@@ -670,6 +666,7 @@ class ServerlessBackend:
             )
             sft_config["batch_size"] = batch_size
         sft_config["learning_rate"] = config.learning_rate
+        sft_config["assistant_turns"] = config.assistant_turns
         metric_logging = cast(
             SFTMetricLoggingConfig,
             dict(dev_config.get("metric_logging", {}) or {}),

--- a/src/art/serverless/client.py
+++ b/src/art/serverless/client.py
@@ -84,6 +84,7 @@ class ExperimentalTrainingConfig(TypedDict, total=False):
 class SFTTrainingConfig(TypedDict, total=False):
     batch_size: int | None
     learning_rate: float | list[float] | None
+    assistant_turns: Literal["all", "last"]
     metric_logging: SFTMetricLoggingConfig | None
 
 

--- a/tests/unit/test_serverless_pipeline_trainer_compat.py
+++ b/tests/unit/test_serverless_pipeline_trainer_compat.py
@@ -210,7 +210,7 @@ async def test_serverless_train_model_forwards_experimental_config() -> None:
 
 
 @pytest.mark.asyncio
-async def test_serverless_train_sft_forwards_metric_logging_config() -> None:
+async def test_serverless_train_sft_forwards_config() -> None:
     backend = _make_backend()
     model = TrainableModel(
         run_name="serverless-sft-config-payload",
@@ -271,7 +271,11 @@ async def test_serverless_train_sft_forwards_metric_logging_config() -> None:
                 async for _ in backend._train_sft(
                     model,
                     [trajectory],
-                    TrainSFTConfig(learning_rate=[1e-4], batch_size=2),
+                    TrainSFTConfig(
+                        learning_rate=[1e-4],
+                        batch_size=2,
+                        assistant_turns="last",
+                    ),
                     {
                         "metric_logging": {
                             "enabled": True,
@@ -285,34 +289,9 @@ async def test_serverless_train_sft_forwards_metric_logging_config() -> None:
     metric_logging = config["metric_logging"]
     assert config["learning_rate"] == [1e-4]
     assert config["batch_size"] == 2
+    assert config["assistant_turns"] == "last"
     assert metric_logging["enabled"] is True
     assert metric_logging["target_training_step"] == 1
-
-
-@pytest.mark.asyncio
-async def test_serverless_train_sft_rejects_last_assistant_mode() -> None:
-    backend = _make_backend()
-    model = TrainableModel(
-        run_name="serverless-sft-last-assistant",
-        name="serverless-sft-last-assistant",
-        project="pipeline-tests",
-        base_model="test-model",
-    )
-    trajectory = Trajectory(
-        messages_and_choices=[
-            {"role": "user", "content": "prompt"},
-            {"role": "assistant", "content": "answer"},
-        ],
-    )
-
-    with pytest.raises(NotImplementedError, match="currently requires LocalBackend"):
-        async for _ in backend._train_sft(
-            model,
-            [trajectory],
-            TrainSFTConfig(assistant_turns="last"),
-            {},
-        ):
-            pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Enable `TrainSFTConfig(assistant_turns="last")` on `ServerlessBackend` and `train_sft_from_file` by forwarding the resolved assistant-turn mode to the serverless training API.

Coordinated backend change: coreweave/serverless-training#296, which pins this PR's commit `a67ea555ff31730242eeb96a12ce6f96aa3a4649`.

## Changes

- remove the LocalBackend-only guard for final-assistant SFT
- add `assistant_turns` to the typed serverless SFT request config
- forward the resolved value for every serverless SFT request
- expose `assistant_turns` on `train_sft_from_file`, preserving the `"all"` default
- document final-assistant JSONL training
- replace the serverless rejection test and add file-helper forwarding coverage

## Test plan

- [x] `uv run pytest -q tests/unit/test_sft.py tests/unit/test_serverless_pipeline_trainer_compat.py` (20 passed)
- [x] `uv run prek run --all-files`
- [x] End-to-end H200 run through the serverless client implementation: two multi-turn trajectories completed one gradient step with 85 total tokens and 10 trainable tokens
- [x] File-helper unit coverage verifies `assistant_turns="last"` reaches `TrainSFTConfig`

## Rollout

Deploy coreweave/serverless-training#296 before releasing this ART change. An older backend may ignore the new nested config field and incorrectly train all assistant turns.
