### PR TITLE
Expose assistant-turn selection for file SFT

### DIFF
--- a/docs/fundamentals/sft-training.mdx
+++ b/docs/fundamentals/sft-training.mdx
@@ -112,11 +112,16 @@ async def main():
         peak_lr=2e-4,
         schedule_type="cosine",
         warmup_ratio=0.1,
+        assistant_turns="last",
         verbose=True,
     )
 
 asyncio.run(main())
 ```
+
+Set `assistant_turns="last"` to calculate loss only on the final assistant
+message in each JSONL row. Earlier assistant messages remain available as
+context. If omitted, the helper trains on all assistant turns.
 
 ## Distillation
 

--- a/src/art/utils/sft.py
+++ b/src/art/utils/sft.py
@@ -353,6 +353,7 @@ async def train_sft_from_file(
     verbose: bool = False,
     shuffle_buffer_size: int = 10000,
     log_metrics: bool = True,
+    assistant_turns: Literal["all", "last"] = "all",
 ) -> None:
     """
     Train a model using supervised fine-tuning from a JSONL file.
@@ -377,6 +378,9 @@ async def train_sft_from_file(
         shuffle_buffer_size: Size of shuffle buffer. Default: 10000.
                              Larger values give better shuffling but use more memory.
         log_metrics: Whether to log SFT optimizer metrics. Default: True.
+        assistant_turns: Which assistant turns contribute to the training loss.
+            Use "last" to train only on the final assistant turn in each trajectory.
+            Default: "all".
 
     Example:
         await train_sft_from_file(
@@ -385,6 +389,7 @@ async def train_sft_from_file(
             epochs=3,
             batch_size=4,
             peak_lr=2e-4,
+            assistant_turns="last",
         )
     """
     from art.types import TrainSFTConfig
@@ -444,6 +449,7 @@ async def train_sft_from_file(
     config = TrainSFTConfig(
         learning_rate=learning_rates,
         batch_size=batch_size,
+        assistant_turns=assistant_turns,
     )
 
     await model.train_sft(

--- a/tests/unit/test_sft.py
+++ b/tests/unit/test_sft.py
@@ -3,13 +3,18 @@
 import json
 from pathlib import Path
 import tempfile
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
+from art import TrainableModel
 from art.utils.sft import (
     create_lr_schedule,
     create_sft_dataset_iterator,
     iterate_file,
+    train_sft_from_file,
 )
 
 
@@ -84,6 +89,32 @@ def test_iterate_file_deterministic():
 
     finally:
         jsonl_file.unlink()
+
+
+@pytest.mark.asyncio
+async def test_train_sft_from_file_forwards_assistant_turns():
+    """Test that file-based SFT can train only on the final assistant turn."""
+    jsonl_file = create_temp_jsonl(2)
+    train_sft = AsyncMock()
+    model = cast(
+        TrainableModel[Any, dict[str, Any]],
+        SimpleNamespace(train_sft=train_sft),
+    )
+
+    try:
+        await train_sft_from_file(
+            model=model,
+            file_path=str(jsonl_file),
+            batch_size=2,
+            assistant_turns="last",
+        )
+    finally:
+        jsonl_file.unlink()
+
+    await_args = train_sft.await_args
+    assert await_args is not None
+    config = await_args.args[1]
+    assert config.assistant_turns == "last"
 
 
 def test_lr_schedule_warmup_not_zero():


### PR DESCRIPTION
## Summary

Expose `assistant_turns` on `train_sft_from_file` so JSONL-based SFT can select final-assistant-only loss masking.

This is a follow-up to #771, which added final-assistant support to `ServerlessBackend`. Coordinated Serverless Training pin: coreweave/serverless-training#297.

## Changes

- add `assistant_turns: Literal["all", "last"] = "all"` to `train_sft_from_file`
- forward the value into the internally constructed `TrainSFTConfig`
- preserve the existing `"all"` default and positional argument order
- document JSONL training with `assistant_turns="last"`
- add file-helper forwarding coverage

## Test plan

- [x] `uv run pytest -q tests/unit/test_sft.py tests/unit/test_serverless_pipeline_trainer_compat.py` (20 passed)
- [x] `uv run prek run --all-files`
- [x] Installed this exact commit through the Serverless Training lockfile and verified the helper signature
