### PR TITLE
Fix ART runtime compatibility with vLLM 0.25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,11 @@ jobs:
               [
                   str(runtime_python),
                   "-c",
-                  "import art_vllm_runtime, torch, vllm; print('runtime imports ok')",
+                  "import torch, vllm; "
+                  "from art_vllm_runtime.policy_spans import "
+                  "_patch_lora_update_coordinator; "
+                  "_patch_lora_update_coordinator(); "
+                  "print('runtime compatibility ok')",
               ],
               check=True,
           )

--- a/tests/integration/megatron/runtime_isolation/test_runtime_project_isolation.py
+++ b/tests/integration/megatron/runtime_isolation/test_runtime_project_isolation.py
@@ -248,6 +248,60 @@ def test_runtime_general_plugin_loads_full_patch_set() -> None:
     assert 'art = "art_vllm_runtime.patches:apply_vllm_runtime_patches"' in pyproject
 
 
+def test_lora_coordinator_supports_both_vllm_serving_layouts(
+    artifact_dir: Path,
+) -> None:
+    payload = _runtime_python(
+        """
+import json
+from types import SimpleNamespace
+import art_vllm_runtime.policy_spans as policy
+from vllm.entrypoints.openai.engine.serving import OpenAIServing
+
+policy._patch_lora_update_coordinator()
+legacy_patched = getattr(
+    OpenAIServing.__init__, "__art_lora_update_patched__", False
+)
+
+class GenerateBaseServing:
+    def __init__(self, models, engine_client):
+        self.models = models
+        self.engine_client = engine_client
+
+real_import_module = policy.importlib.import_module
+def import_module(name):
+    if name == "vllm.entrypoints.openai.engine.serving":
+        raise ModuleNotFoundError(name, name=name)
+    if name == "vllm.entrypoints.generate.base.serving":
+        return SimpleNamespace(GenerateBaseServing=GenerateBaseServing)
+    return real_import_module(name)
+
+policy.importlib.import_module = import_module
+policy._patch_lora_update_coordinator()
+models = SimpleNamespace()
+engine_client = SimpleNamespace()
+GenerateBaseServing(models, engine_client)
+print(json.dumps({
+    "legacy_patched": legacy_patched,
+    "new_patched": getattr(
+        GenerateBaseServing.__init__, "__art_lora_update_patched__", False
+    ),
+    "shared_coordinator": (
+        models._art_lora_update_coordinator
+        is engine_client._art_lora_update_coordinator
+    ),
+}))
+""",
+        artifact_dir,
+        "vllm_serving_layouts",
+    )
+    assert json.loads(payload.splitlines()[-1]) == {
+        "legacy_patched": True,
+        "new_patched": True,
+        "shared_coordinator": True,
+    }
+
+
 def test_runtime_patch_adds_gemma4_moe_topk_alias(artifact_dir: Path) -> None:
     payload = _runtime_python(
         "import json; "

--- a/vllm_runtime/src/art_vllm_runtime/policy_spans.py
+++ b/vllm_runtime/src/art_vllm_runtime/policy_spans.py
@@ -526,9 +526,16 @@ def _patch_openai_response_policy_spans() -> None:
 
 
 def _patch_lora_update_coordinator() -> None:
-    from vllm.entrypoints.openai.engine.serving import OpenAIServing
+    try:
+        module = importlib.import_module("vllm.entrypoints.openai.engine.serving")
+        serving_base = module.OpenAIServing
+    except ModuleNotFoundError as exc:
+        if exc.name != "vllm.entrypoints.openai.engine.serving":
+            raise
+        module = importlib.import_module("vllm.entrypoints.generate.base.serving")
+        serving_base = module.GenerateBaseServing
 
-    original_init = OpenAIServing.__init__
+    original_init = serving_base.__init__
     if not getattr(original_init, "__art_lora_update_patched__", False):
 
         def __init__(self: Any, *args: Any, **kwargs: Any) -> None:
@@ -536,7 +543,7 @@ def _patch_lora_update_coordinator() -> None:
             lora_update_coordinator(self.models, self.engine_client)
 
         __init__.__art_lora_update_patched__ = True  # type: ignore[attr-defined]
-        OpenAIServing.__init__ = __init__  # type: ignore[method-assign]
+        serving_base.__init__ = __init__
 
 
 def _patch_engine_request_admission() -> None:


### PR DESCRIPTION
## Summary

- support both the vLLM 0.23/0.24 `OpenAIServing` layout and the vLLM 0.25 `GenerateBaseServing` layout when installing ART's LoRA update coordinator
- fail closed when an unexpected nested import is missing instead of masking an incompatible runtime
- execute the CPU-safe compatibility patch in ART's release smoke check

## Root cause

Caladan's DeepSeek V4 image intentionally installs `art-vllm-runtime` without dependencies alongside vLLM 0.25.1. vLLM 0.25 moved the shared serving constructor from `vllm.entrypoints.openai.engine.serving.OpenAIServing` to `vllm.entrypoints.generate.base.serving.GenerateBaseServing`. ART imported only the old location, so the production canary crash-looped before model startup.

## Validation

- focused runtime layout/import/plugin tests: 3 passed
- related DSV4/runtime patch tests: 4 passed
- direct source checks against vLLM 0.23 and vLLM 0.25.1
- Ruff, format, ty, lock check, and pre-commit passed
- Caladan #89 disposable DeepSeek vLLM 0.25.1 image build executed the focused coordinator patch successfully before GPU startup

The full runtime-isolation file has 9 passing tests and 4 unrelated host-environment failures caused by vLLM INFO output contaminating JSON and GPU-sensitive TileLang imports on CPU.
