### PR TITLE
perf: Submit Tinker training requests in the same clock cycle

### DIFF
--- a/src/art/tinker_native/backend.py
+++ b/src/art/tinker_native/backend.py
@@ -424,16 +424,15 @@ class TinkerNativeBackend:
                 model_input=datum.model_input, loss_fn_inputs=loss_fn_inputs
             )
 
-        forward_output = await self._tinker_train_call(
-            "forward_backward",
-            state.training_client.forward_backward(
-                [remove_mask(datum) for datum in datums],
-                loss_fn=loss_fn,
-                loss_fn_config=loss_fn_config,
-            ),
+        forward_future = state.training_client.forward_backward(
+            [remove_mask(datum) for datum in datums],
+            loss_fn=loss_fn,
+            loss_fn_config=loss_fn_config,
         )
-        optim_output = await self._tinker_train_call(
-            "optim_step", state.training_client.optim_step(adam_params)
+        optim_future = state.training_client.optim_step(adam_params)
+        forward_output, optim_output = await asyncio.gather(
+            self._tinker_train_call("forward_backward", forward_future),
+            self._tinker_train_call("optim_step", optim_future),
         )
 
         if forward_output.metrics:


### PR DESCRIPTION
Tinker assigns training requests to clock cycles when they are submitted. Waiting for `forward_backward` before submitting `optim_step` can leave the optimizer worker pool idle and move the update into a later cycle.

Benchmark (Tinker SDK 0.23.4, 20 counterbalanced paired trials):

| Scheduling | Median | Mean | IQR |
| --- | ---: | ---: | ---: |
| Sequential | 5.624s | 5.884s | 5.602–5.654s |
| Same cycle | 5.083s | 5.084s | 5.061–5.121s |

Paired median: 1.106x speedup and 0.538s saved per update.

Verification:
- `uv run --no-sync prek run --all-files`
- Existing Tinker-native unit tests (5 passed)