### PR TITLE
Remove deprecated auto trajectory aliases

### DIFF
--- a/src/art/__init__.py
+++ b/src/art/__init__.py
@@ -105,8 +105,6 @@ from .trajectories import (
     TrajectoryExchanges,
     TrajectoryGroup,
     TrajectoryHistory,
-    auto_trajectory,  # ty: ignore[deprecated]
-    capture_auto_trajectory,  # ty: ignore[deprecated]
     current_trajectory,
     no_capture,
     trajectory,
@@ -129,8 +127,6 @@ from .yield_trajectory import capture_yielded_trajectory, yield_trajectory
 
 __all__ = [
     "dev",
-    "auto_trajectory",
-    "capture_auto_trajectory",
     "current_trajectory",
     "no_capture",
     "gather_trajectories",

--- a/src/art/auto_trajectory.py
+++ b/src/art/auto_trajectory.py
@@ -1,8 +1,0 @@
-"""Deprecated compatibility names for automatic trajectory capture."""
-
-from .trajectories import (
-    auto_trajectory,  # ty: ignore[deprecated]
-    capture_auto_trajectory,  # ty: ignore[deprecated]
-)
-
-__all__ = ["auto_trajectory", "capture_auto_trajectory"]

--- a/src/art/trajectories/__init__.py
+++ b/src/art/trajectories/__init__.py
@@ -934,28 +934,6 @@ async def trajectory_group(
     )
 
 
-@overload
-@deprecated("Use current_trajectory() instead.")
-def auto_trajectory(*, require: Literal[True]) -> Trajectory: ...
-
-
-@overload
-@deprecated("Use current_trajectory() instead.")
-def auto_trajectory(*, require: Literal[False] = False) -> Trajectory | None: ...
-
-
-@deprecated("Use current_trajectory() instead.")
-def auto_trajectory(*, require: bool = False) -> Trajectory | None:
-    return current_trajectory(require=require)
-
-
-@deprecated("Use trajectory() instead.")
-async def capture_auto_trajectory(
-    coroutine: Coroutine[Any, Any, object],
-) -> Trajectory:
-    return await trajectory(coroutine)
-
-
 def get_messages(messages_and_choices: MessagesAndChoices) -> Messages:
     from ._compat import messages_from_legacy_history
 
@@ -1000,7 +978,5 @@ __all__ = [
     "no_capture",
     "trajectory",
     "trajectory_group",
-    "auto_trajectory",
-    "capture_auto_trajectory",
     "get_messages",
 ]

--- a/tests/unit/test_auto_trajectory.py
+++ b/tests/unit/test_auto_trajectory.py
@@ -209,7 +209,7 @@ async def test_server():
     await runner.cleanup()
 
 
-async def test_auto_trajectory(test_server: None) -> None:
+async def test_trajectory_capture(test_server: None) -> None:
     message: ChatCompletionMessageParam = {"role": "user", "content": "Hi!"}
     tools: list[ChatCompletionToolParam] = [
         {
@@ -279,15 +279,11 @@ async def test_auto_trajectory(test_server: None) -> None:
             stream=True,
         ):
             pass
-        # Add ART support with a couple lines of optional code
-        if trajectory := art.auto_trajectory():  # ty: ignore[deprecated]
-            trajectory.reward = 1.0
+        if current := art.current_trajectory():
+            current.reward = 1.0
         return chat_completion.choices[0].message.content
 
-    # Use the capture_auto_trajectory utility to capture a trajectory automatically
-    trajectory = await art.capture_auto_trajectory(  # ty: ignore[deprecated]
-        say_hi()
-    )
+    trajectory = await art.trajectory(say_hi())
     exchanges = trajectory.exchanges.chat_completions
     assert len(exchanges) == 5
     assert exchanges[0].request["messages"] == [message]
@@ -300,7 +296,7 @@ async def test_auto_trajectory(test_server: None) -> None:
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning:pydantic")
-async def test_litellm_auto_trajectory(test_server: None) -> None:
+async def test_litellm_trajectory_capture(test_server: None) -> None:
     message: ChatCompletionMessageParam = {"role": "user", "content": "Hi!"}
     tools: list[ChatCompletionToolParam] = [
         {
@@ -357,15 +353,11 @@ async def test_litellm_auto_trajectory(test_server: None) -> None:
         )
         async for _ in stream:
             pass
-        # Add ART support with a couple lines of optional code
-        if trajectory := art.auto_trajectory():  # ty: ignore[deprecated]
-            trajectory.reward = 1.0
+        if current := art.current_trajectory():
+            current.reward = 1.0
         return choice.message.content
 
-    # Use the capture_auto_trajectory utility to capture a trajectory automatically
-    trajectory = await art.capture_auto_trajectory(  # ty: ignore[deprecated]
-        say_hi()
-    )
+    trajectory = await art.trajectory(say_hi())
     exchanges = trajectory.exchanges.chat_completions
     assert len(exchanges) == 3
     assert exchanges[0].request["messages"] == [message]


### PR DESCRIPTION
## Summary

- remove the deprecated `auto_trajectory()` and `capture_auto_trajectory()` aliases
- migrate the remaining capture tests to `current_trajectory()` and `trajectory()`
- remove the obsolete compatibility module and public exports

## Impact

This is an intentional cleanup of unused deprecated APIs. Current ART, Caladan, and serverless-training sources have no remaining callsites.

## Validation

- `uv run pytest -q tests/unit/test_auto_trajectory.py` — 2 passed
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run ty check ...`
- import assertions confirming the removed names are no longer exported