### PR TITLE
docs: document OrcaRouter as a hosted inference option

### DIFF
--- a/docs/features/mcp-rl.mdx
+++ b/docs/features/mcp-rl.mdx
@@ -42,6 +42,18 @@ scenario_collection = await generate_scenarios(
 )
 ```
 
+You can generate scenarios against [OrcaRouter](https://www.orcarouter.ai) the same way — point `generator_base_url` at `https://api.orcarouter.ai/v1` and use an OrcaRouter key (keys start with `sk-orca-`):
+
+```python
+scenario_collection = await generate_scenarios(
+    tools=tools_list,
+    num_scenarios=24,
+    show_preview=True,
+    generator_api_key="your_orcarouter_key",
+    generator_base_url="https://api.orcarouter.ai/v1",
+)
+```
+
 ART automatically generates diverse training scenarios that exercise different aspects of the MCP server: simple single-tool usage, complex multi-step workflows, edge cases and error handling, and creative combinations of available tools.
 
 ### 3. **RULER Evaluation**

--- a/docs/fundamentals/sft-training.mdx
+++ b/docs/fundamentals/sft-training.mdx
@@ -142,6 +142,12 @@ async def main():
         api_key="your-api-key",
         base_url="https://openrouter.ai/api/v1",
     )
+    # Or point the teacher at OrcaRouter:
+    #
+    # teacher_client = AsyncOpenAI(
+    #     api_key=os.getenv("ORCAROUTER_API_KEY"),
+    #     base_url="https://api.orcarouter.ai/v1",
+    # )
     # Small models often produce malformed JSON or miss fields.
     # Distilling from a larger model teaches consistent structured extraction.
     system_prompt = "Extract {name, role, company} as JSON from the text. Return only valid JSON."

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -433,6 +433,16 @@ class Model(
     )
     ``
 
+    Or, if you're pointing at [OrcaRouter](https://www.orcarouter.ai):
+
+    ``python model = art.Model(
+        name="gemini-2.5-pro", project="my-project",
+        inference_api_key=os.getenv("ORCAROUTER_API_KEY"),
+        inference_base_url="https://api.orcarouter.ai/v1",
+        inference_model_name="orcarouter/auto",
+    )
+    ``
+
     For trainable (`art.TrainableModel`) models the inference values will be
     populated automatically by `model.register(api)` so you generally don't need
     to think about them.


### PR DESCRIPTION
## Summary

This documents [OrcaRouter](https://www.orcarouter.ai) as a named hosted-inference option in the same places the existing OpenRouter examples live:

- `src/art/model.py` — added an OrcaRouter example block to the `Model` docstring, mirroring the existing OpenRouter block.
- `docs/features/mcp-rl.mdx` — added an OrcaRouter alternative to the scenario-generation snippet.
- `docs/fundamentals/sft-training.mdx` — added an OrcaRouter alternative to the distillation teacher-client snippet.

This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing OpenRouter provider is documented, so the `Model` docstring, the MCP-RL scenario-generation guide and the SFT teacher example stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Verification

- `python -m py_compile src/art/model.py` passes.
- `ruff check src/art/model.py` and `ruff format --check src/art/model.py` pass.
- Live check: `https://api.orcarouter.ai/v1` with `orcarouter/auto` returns a valid completion.
- Docstring/doc-only change (no runtime code path touched), so `ty` / pytest risk is nil.

I'm an engineer on the OrcaRouter team.
