### PR TITLE
Harden checkpoint slot and collective isolation

### DIFF
--- a/src/art/trainer_rank/_checkpoint.py
+++ b/src/art/trainer_rank/_checkpoint.py
@@ -12,6 +12,7 @@ import os
 from pathlib import Path, PurePosixPath, PureWindowsPath
 import shutil
 import struct
+import threading
 from typing import TYPE_CHECKING, Literal, TypedDict, cast
 import uuid
 
@@ -681,8 +682,8 @@ def _rank_zero_phase(
 def _finish(trainer: TrainerRank, prepared: _PreparedSave) -> None:
     from art.megatron.model_support.lora_disk import save_adapter_config
 
-    metadata = [item for values in _gather(prepared.shards) for item in values]
-    group = trainer._checkpoint_process_group
+    group = _ensure_finalize_group(trainer)
+    metadata = [item for values in _gather(prepared.shards, group) for item in values]
     identities: set[tuple[str, int]] = set()
     selected: list[LoraShardMeta] = []
     for item in sorted(metadata, key=lambda value: value.metadata.owner_rank):
@@ -754,7 +755,7 @@ def _finish(trainer: TrainerRank, prepared: _PreparedSave) -> None:
                 error = exc
             raise_distributed(error, "read checkpoint optimizer steps", group)
             step_values: dict[str, set[float]] = {}
-            for values in _gather(local_steps):
+            for values in _gather(local_steps, group):
                 for key, value in values.items():
                     step_values.setdefault(key, set()).add(value)
             if mismatched := {
@@ -875,16 +876,17 @@ def _finalize_checkpoint_save(
     output_dir: str,
     action: Literal["finish", "abort"],
 ) -> None:
-    with trainer._checkpoint_save_condition:
-        local = trainer._prepared_checkpoint_saves.get(output_dir)
-        sequence = None if local is None else local.sequence
-    states = _gather((action, output_dir, sequence), trainer._checkpoint_process_group)
-    if any(value != states[0] for value in states):
-        raise RuntimeError("Checkpoint save actions differ across ranks")
-    prepared = _claim_finalization(trainer, output_dir, action)
-    if prepared is None:
-        return
+    group = _ensure_finalize_group(trainer)
     with trainer._checkpoint_finalize_lock:
+        with trainer._checkpoint_save_condition:
+            local = trainer._prepared_checkpoint_saves.get(output_dir)
+            sequence = None if local is None else local.sequence
+        states = _gather((action, output_dir, sequence), group)
+        if any(value != states[0] for value in states):
+            raise RuntimeError("Checkpoint save actions differ across ranks")
+        prepared = _claim_finalization(trainer, output_dir, action)
+        if prepared is None:
+            return
         error: BaseException | None = None
         outcome = trainer._checkpoint_save_outcomes.get(output_dir)
         if outcome is None and action == "finish":
@@ -903,18 +905,14 @@ def _finalize_checkpoint_save(
         if _rank() == 0:
             paths.append(prepared.reservation)
         cleanup = _cleanup_paths(paths)
-        cleanup_failed = any(
-            _gather(cleanup is not None, trainer._checkpoint_process_group)
-        )
+        cleanup_failed = any(_gather(cleanup is not None, group))
         if cleanup is not None:
             error = BaseExceptionGroup(
                 "checkpoint finalization cleanup failed",
                 [*([error] if error is not None else []), cleanup],
             )
         try:
-            raise_distributed(
-                error, f"{action} checkpoint", trainer._checkpoint_process_group
-            )
+            raise_distributed(error, f"{action} checkpoint", group)
         finally:
             with trainer._checkpoint_save_condition:
                 trainer._checkpoint_finalizing_saves.pop(output_dir, None)
@@ -1002,9 +1000,11 @@ def _commit_slot(trainer: TrainerRank, source: str, destination: str) -> None:
                 continue
             slot = module._slot_modules[source_key]
             setattr(slot, "ref", destination_ref)
-            module._slot_keys[destination_ref] = source_key
-            if destination_key is not None and destination_key != source_key:
-                del module._slot_modules[destination_key]
+            target_key = destination_key or source_key
+            module._slot_keys[destination_ref] = target_key
+            if target_key != source_key:
+                module._slot_modules[target_key] = slot
+                del module._slot_modules[source_key]
 
 
 def _optimizer_state(
@@ -1275,9 +1275,32 @@ def export_lora(trainer: TrainerRank, output_dir: str, checkpoint_name: str) -> 
     return slot.revision
 
 
-def _ensure_group(trainer: TrainerRank) -> dist.ProcessGroup | None:
+def _ensure_groups(
+    trainer: TrainerRank,
+) -> tuple[dist.ProcessGroup | None, dist.ProcessGroup | None]:
     if not hasattr(trainer, "_checkpoint_process_group"):
         trainer._checkpoint_process_group = None
-    if _distributed() and trainer._checkpoint_process_group is None:
-        trainer._checkpoint_process_group = dist.new_group(backend="gloo")
-    return trainer._checkpoint_process_group
+    if not hasattr(trainer, "_checkpoint_finalize_process_group"):
+        trainer._checkpoint_finalize_process_group = None
+    if not hasattr(trainer, "_checkpoint_group_lock"):
+        trainer._checkpoint_group_lock = threading.Lock()
+    if _distributed():
+        with trainer._checkpoint_group_lock:
+            if trainer._checkpoint_process_group is None:
+                trainer._checkpoint_process_group = dist.new_group(backend="gloo")
+            if trainer._checkpoint_finalize_process_group is None:
+                trainer._checkpoint_finalize_process_group = dist.new_group(
+                    backend="gloo"
+                )
+    return (
+        trainer._checkpoint_process_group,
+        trainer._checkpoint_finalize_process_group,
+    )
+
+
+def _ensure_group(trainer: TrainerRank) -> dist.ProcessGroup | None:
+    return _ensure_groups(trainer)[0]
+
+
+def _ensure_finalize_group(trainer: TrainerRank) -> dist.ProcessGroup | None:
+    return _ensure_groups(trainer)[1]

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -639,6 +639,8 @@ class TrainerRank:
         self._checkpoint_prefetches: dict[str, asyncio.Task[PreparedCheckpoint]] = {}
         self._checkpoint_mutation_tail: asyncio.Task[None] | None = None
         self._checkpoint_process_group: dist.ProcessGroup | None = None
+        self._checkpoint_finalize_process_group: dist.ProcessGroup | None = None
+        self._checkpoint_group_lock = threading.Lock()
         self._checkpoint_prepare_lock = threading.Lock()
         self._checkpoint_finalize_lock = threading.Lock()
         self._checkpoint_save_condition = threading.Condition()
@@ -1193,6 +1195,7 @@ class TrainerRank:
 
         ref = self._slot_ref(name)
         self._guard_slot_can_load(ref)
+        self._compact_lora_slot_keys()
         return load_lora_slot_into_model(
             self.runtime.model,
             ref,
@@ -1200,6 +1203,24 @@ class TrainerRank:
             alpha=alpha,
             requires_grad=True,
         )
+
+    def _compact_lora_slot_keys(self) -> None:
+        from art.megatron.lora import LoRA
+
+        for chunk in self.runtime.model:
+            for module in chunk.modules():
+                if not isinstance(module, LoRA):
+                    continue
+                slots = [
+                    (ref, module._slot_modules[key])
+                    for ref, key in module._slot_keys.items()
+                ]
+                module._slot_keys = {
+                    ref: f"slot_{index}" for index, (ref, _slot) in enumerate(slots)
+                }
+                module._slot_modules = torch.nn.ModuleDict(
+                    {f"slot_{index}": slot for index, (_ref, slot) in enumerate(slots)}
+                )
 
     def _prepare_adapter_model(
         self,

--- a/tests/integration/megatron/lora/test_dynamic_lora_slots.py
+++ b/tests/integration/megatron/lora/test_dynamic_lora_slots.py
@@ -24,6 +24,7 @@ from art.trainer_rank import (  # noqa: E402
 from art.trainer_rank._checkpoint import (  # noqa: E402
     LocalOptimizerState,
     OptimizerConfig,
+    _commit_slot,
 )
 from art.trainer_rank._impl import (  # noqa: E402
     _CheckpointSlot,
@@ -105,6 +106,41 @@ def test_dynamic_lora_slots_capture_recompute_context_and_step_independently() -
         )
         _assert_step_updates_only(ref_a, ref_b, lora, trainer)
         _assert_reload_replaces_slot_optimizer(ref_a, lora, trainer)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required.")
+def test_checkpoint_reload_does_not_alias_the_next_slot() -> None:
+    with _single_rank_model_parallel():
+        device = torch.device("cuda")
+        first = LoRA("first", 4, 5, 2, 32, torch.float32, device)
+        second = LoRA("second", 4, 5, 2, 32, torch.float32, device)
+        trainer = _trainer_for(first, device)
+        trainer.runtime.model = [torch.nn.Sequential(first, second)]
+
+        def adapter(
+            seed: int, *, include_second: bool = True
+        ) -> dict[str, torch.Tensor]:
+            return _adapter("first", rank=2, seed=seed) | (
+                _adapter("second", rank=2, seed=seed + 10) if include_second else {}
+            )
+
+        def stage(destination: str, state: dict[str, torch.Tensor]) -> None:
+            temporary = f"temporary-{destination}"
+            trainer._load_checkpoint_slot(temporary, state, alpha=32.0)
+            _commit_slot(trainer, temporary, destination)
+
+        stage("A", adapter(1))
+        stage("B", adapter(2))
+        slot_b = second._slot(trainer._slot_ref("B"))
+        assert slot_b is not None
+        expected_b = slot_b.A_T.detach().clone()
+        stage("A", adapter(3, include_second=False))
+        stage("C", adapter(4))
+
+        slot_b = second._slot(trainer._slot_ref("B"))
+        slot_c = second._slot(trainer._slot_ref("C"))
+        assert slot_b is not None and slot_c is not None and slot_b is not slot_c
+        torch.testing.assert_close(slot_b.A_T, expected_b)
 
 
 @pytest.mark.parametrize("tp_size", (2, 4))


### PR DESCRIPTION
## Summary

- prevent repeated checkpoint loads from reusing a live LoRA module key and aliasing two path-keyed checkpoints
- move checkpoint finalization onto a dedicated Gloo process group so off-queue durability work cannot collide with training or preparation collectives
- cover reload-then-load with a real LoRA module

## Root cause

Replacing a loaded checkpoint left a hole in the `ModuleDict` key sequence while new slots were named from the mapping length. The next load could overwrite the replacement slot. Separately, two finalization gathers accidentally used the default NCCL group, and the remaining finalization collectives shared the preparation/load Gloo group.

## Scope

The fix remains entirely under `art.trainer_rank` plus its focused integration test. It does not modify PipelineTrainer, Megatron training/runtime, model handlers, or ambient LoRA publication.

## Validation

- 105 focused TrainerRank tests passed
- ruff, formatting, ty, and lock checks passed
- GPU regression and 2×H200 checks run in CI
