### PR TITLE
Harden distributed checkpoint finalization

### DIFF
--- a/src/art/trainer_rank/_checkpoint.py
+++ b/src/art/trainer_rank/_checkpoint.py
@@ -899,6 +899,8 @@ def _finalize_checkpoint_save(
                 else finalized.outcome
             )
         states = _gather((action, output_dir, sequence, outcome), group)
+        if any(not isinstance(value, tuple) or len(value) != 4 for value in states):
+            raise RuntimeError("Checkpoint finalization protocol is out of sync")
         if any(value[:3] != states[0][:3] for value in states):
             raise RuntimeError("Checkpoint save actions differ across ranks")
         outcomes = {value[3] for value in states}
@@ -945,22 +947,51 @@ def _finalize_checkpoint_save(
                     paths.append(prepared.reservation)
                 cleanup = _cleanup_paths(paths)
             try:
-                cleanup_failed = any(_gather(cleanup is not None, group))
+                failures = _gather(
+                    (
+                        None if error is None else repr(error),
+                        None if cleanup is None else repr(cleanup),
+                    ),
+                    group,
+                )
             except BaseException as exc:
-                failures = [
+                local_failures = [
                     *([error] if error is not None else []),
                     *([cleanup] if cleanup is not None else []),
                     exc,
                 ]
+                if len(local_failures) == 1:
+                    raise local_failures[0]
                 raise BaseExceptionGroup(
-                    "checkpoint finalization and coordination failed", failures
+                    "checkpoint finalization and coordination failed", local_failures
                 ) from None
-            if cleanup is not None:
-                error = BaseExceptionGroup(
-                    "checkpoint finalization cleanup failed",
-                    [*([error] if error is not None else []), cleanup],
+            if any(
+                not isinstance(failure, tuple)
+                or len(failure) != 2
+                or any(
+                    value is not None and not isinstance(value, str)
+                    for value in failure
                 )
-            raise_distributed(error, f"{action} checkpoint", group)
+                for failure in failures
+            ):
+                raise RuntimeError("Checkpoint finalization protocol is out of sync")
+            cleanup_failed = any(
+                cleanup_error is not None for _, cleanup_error in failures
+            )
+            local_failures = [
+                *([error] if error is not None else []),
+                *([cleanup] if cleanup is not None else []),
+            ]
+            if local_failures:
+                if len(local_failures) == 1:
+                    raise local_failures[0]
+                raise BaseExceptionGroup(
+                    "checkpoint finalization failed", local_failures
+                )
+            if remote := next((failure for failure in failures if any(failure)), None):
+                raise RuntimeError(
+                    f"Another rank failed to {action} checkpoint: {remote}"
+                )
         finally:
             with trainer._checkpoint_save_condition:
                 trainer._checkpoint_finalizing_saves.pop(output_dir, None)

--- a/src/art/trainer_rank/_checkpoint.py
+++ b/src/art/trainer_rank/_checkpoint.py
@@ -889,29 +889,30 @@ def _finalize_checkpoint_save(
             return
         error: BaseException | None = None
         outcome = trainer._checkpoint_save_outcomes.get(output_dir)
-        if outcome is None and action == "finish":
-            try:
-                _finish(trainer, prepared)
-            except BaseException as exc:
-                error = exc
-        if outcome is None:
-            outcome = action if error is None else "abort"
-            with trainer._checkpoint_save_condition:
-                trainer._checkpoint_save_outcomes[output_dir] = outcome
-                if outcome == "abort":
-                    trainer._checkpoint_save_skipped.add(prepared.sequence)
-            _advance_save_queue(trainer, prepared.sequence)
-        paths = [prepared.snapshot]
-        if _rank() == 0:
-            paths.append(prepared.reservation)
-        cleanup = _cleanup_paths(paths)
-        cleanup_failed = any(_gather(cleanup is not None, group))
-        if cleanup is not None:
-            error = BaseExceptionGroup(
-                "checkpoint finalization cleanup failed",
-                [*([error] if error is not None else []), cleanup],
-            )
+        cleanup_failed = True
         try:
+            if outcome is None and action == "finish":
+                try:
+                    _finish(trainer, prepared)
+                except BaseException as exc:
+                    error = exc
+            if outcome is None:
+                outcome = action if error is None else "abort"
+                with trainer._checkpoint_save_condition:
+                    trainer._checkpoint_save_outcomes[output_dir] = outcome
+                    if outcome == "abort":
+                        trainer._checkpoint_save_skipped.add(prepared.sequence)
+                _advance_save_queue(trainer, prepared.sequence)
+            paths = [prepared.snapshot]
+            if _rank() == 0:
+                paths.append(prepared.reservation)
+            cleanup = _cleanup_paths(paths)
+            cleanup_failed = any(_gather(cleanup is not None, group))
+            if cleanup is not None:
+                error = BaseExceptionGroup(
+                    "checkpoint finalization cleanup failed",
+                    [*([error] if error is not None else []), cleanup],
+                )
             raise_distributed(error, f"{action} checkpoint", group)
         finally:
             with trainer._checkpoint_save_condition:

--- a/src/art/trainer_rank/_checkpoint.py
+++ b/src/art/trainer_rank/_checkpoint.py
@@ -86,6 +86,12 @@ class _PreparedSave:
     optimizer: OptimizerConfig | None
 
 
+@dataclass(frozen=True)
+class _FinalizedSave:
+    sequence: int
+    outcome: Literal["finish", "abort"]
+
+
 type _SlotSnapshot = tuple[
     tuple[
         "LoRA",
@@ -545,8 +551,7 @@ def prepare_checkpoint_save(
         assert prepared is not None
         with trainer._checkpoint_save_condition:
             trainer._prepared_checkpoint_saves[output_dir] = prepared
-            if output_dir in trainer._completed_checkpoint_saves:
-                trainer._completed_checkpoint_saves.remove(output_dir)
+            trainer._finalized_checkpoint_saves.pop(output_dir, None)
             trainer._checkpoint_preparing_saves.discard(output_dir)
             trainer._checkpoint_save_condition.notify_all()
 
@@ -848,7 +853,7 @@ def _claim_finalization(
         while True:
             prepared = trainer._prepared_checkpoint_saves.get(output_dir)
             if prepared is None:
-                if output_dir in trainer._completed_checkpoint_saves:
+                if output_dir in trainer._finalized_checkpoint_saves:
                     return None
                 if action == "abort":
                     return None
@@ -880,34 +885,76 @@ def _finalize_checkpoint_save(
     with trainer._checkpoint_finalize_lock:
         with trainer._checkpoint_save_condition:
             local = trainer._prepared_checkpoint_saves.get(output_dir)
-            sequence = None if local is None else local.sequence
-        states = _gather((action, output_dir, sequence), group)
-        if any(value != states[0] for value in states):
+            finalized = trainer._finalized_checkpoint_saves.get(output_dir)
+            sequence = (
+                local.sequence
+                if local is not None
+                else None
+                if finalized is None
+                else finalized.sequence
+            )
+            outcome = (
+                trainer._checkpoint_save_outcomes.get(output_dir)
+                if finalized is None
+                else finalized.outcome
+            )
+        states = _gather((action, output_dir, sequence, outcome), group)
+        if any(value[:3] != states[0][:3] for value in states):
             raise RuntimeError("Checkpoint save actions differ across ranks")
-        prepared = _claim_finalization(trainer, output_dir, action)
-        if prepared is None:
-            return
+        outcomes = {value[3] for value in states}
+        if len(outcomes) != 1:
+            raise RuntimeError("Checkpoint save outcomes differ across ranks")
+        if sequence is None:
+            if action == "abort":
+                return
+            raise RuntimeError(f"Checkpoint save was not prepared: {output_dir}")
+        finalized_ranks = _gather(finalized is not None, group)
+        if all(finalized_ranks):
+            if outcome == "finish" or action == "abort":
+                return
+            raise RuntimeError(f"Checkpoint save was already {outcome}ed: {output_dir}")
+        if outcome is not None and outcome != action:
+            raise RuntimeError(f"Checkpoint save was already {outcome}ed: {output_dir}")
+        prepared = (
+            _claim_finalization(trainer, output_dir, action)
+            if finalized is None
+            else None
+        )
+        assert prepared is not None or finalized is not None
         error: BaseException | None = None
-        outcome = trainer._checkpoint_save_outcomes.get(output_dir)
         cleanup_failed = True
         try:
-            if outcome is None and action == "finish":
+            if finalized is None and outcome is None and action == "finish":
                 try:
+                    assert prepared is not None
                     _finish(trainer, prepared)
                 except BaseException as exc:
                     error = exc
-            if outcome is None:
+            if finalized is None and outcome is None:
+                assert prepared is not None
                 outcome = action if error is None else "abort"
                 with trainer._checkpoint_save_condition:
                     trainer._checkpoint_save_outcomes[output_dir] = outcome
                     if outcome == "abort":
                         trainer._checkpoint_save_skipped.add(prepared.sequence)
                 _advance_save_queue(trainer, prepared.sequence)
-            paths = [prepared.snapshot]
-            if _rank() == 0:
-                paths.append(prepared.reservation)
-            cleanup = _cleanup_paths(paths)
-            cleanup_failed = any(_gather(cleanup is not None, group))
+            cleanup = None
+            if prepared is not None:
+                paths = [prepared.snapshot]
+                if _rank() == 0:
+                    paths.append(prepared.reservation)
+                cleanup = _cleanup_paths(paths)
+            try:
+                cleanup_failed = any(_gather(cleanup is not None, group))
+            except BaseException as exc:
+                failures = [
+                    *([error] if error is not None else []),
+                    *([cleanup] if cleanup is not None else []),
+                    exc,
+                ]
+                raise BaseExceptionGroup(
+                    "checkpoint finalization and coordination failed", failures
+                ) from None
             if cleanup is not None:
                 error = BaseExceptionGroup(
                     "checkpoint finalization cleanup failed",
@@ -920,8 +967,10 @@ def _finalize_checkpoint_save(
                 if not cleanup_failed:
                     trainer._prepared_checkpoint_saves.pop(output_dir, None)
                     trainer._checkpoint_save_outcomes.pop(output_dir, None)
-                    if outcome == "finish":
-                        trainer._completed_checkpoint_saves.append(output_dir)
+                    assert outcome is not None
+                    trainer._finalized_checkpoint_saves[output_dir] = _FinalizedSave(
+                        sequence, outcome
+                    )
                 trainer._checkpoint_save_condition.notify_all()
 
 

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from art.trainer_rank._checkpoint import (
         LocalOptimizerState,
         PreparedCheckpoint,
+        _FinalizedSave,
         _PreparedSave,
     )
 
@@ -651,7 +652,7 @@ class TrainerRank:
         self._checkpoint_finalizing_saves: dict[str, Literal["finish", "abort"]] = {}
         self._checkpoint_save_outcomes: dict[str, Literal["finish", "abort"]] = {}
         self._prepared_checkpoint_saves: dict[str, _PreparedSave] = {}
-        self._completed_checkpoint_saves: list[str] = []
+        self._finalized_checkpoint_saves: dict[str, _FinalizedSave] = {}
         self._pending_slot_graphs: dict[
             LoRASlotRef, list[weakref.ReferenceType[torch.Tensor]]
         ] = {}

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -878,7 +878,8 @@ class TrainerRank:
             source = await asyncio.shield(prefetch)
         except BaseException as exc:
             error = exc
-        _checkpoint.raise_distributed(error, "prepare checkpoint")
+        group = _checkpoint._ensure_group(self)
+        _checkpoint.raise_distributed(error, "prepare checkpoint", group)
         assert source is not None
         _checkpoint.load_checkpoint(self, source, logical_path)
         self._checkpoint_prefetches.pop(key, None)
@@ -895,6 +896,11 @@ class TrainerRank:
     def _slot_state_error(message: str) -> TrainerRankSlotStateError:
         return TrainerRankSlotStateError(message)
 
+    def _checkpoint_group(self) -> dist.ProcessGroup | None:
+        from ._checkpoint import _ensure_group
+
+        return _ensure_group(self)
+
     def _validate_checkpoint_adapter_config(
         self,
         name: str,
@@ -905,7 +911,7 @@ class TrainerRank:
         config = None if adapter_config is None else deepcopy(dict(adapter_config))
         if dist.is_available() and dist.is_initialized():
             gathered: list[dict[str, object] | None] = [None] * dist.get_world_size()
-            dist.all_gather_object(gathered, config)
+            dist.all_gather_object(gathered, config, group=self._checkpoint_group())
             if any(value != config for value in gathered):
                 raise ValueError(
                     f"Adapter config for checkpoint slot {name!r} differs across ranks"
@@ -1234,7 +1240,7 @@ class TrainerRank:
         expected = set(templates)
         if dist.is_available() and dist.is_initialized():
             gathered: list[set[str] | None] = [None] * dist.get_world_size()
-            dist.all_gather_object(gathered, expected)
+            dist.all_gather_object(gathered, expected, group=self._checkpoint_group())
             expected = set().union(*(value for value in gathered if value is not None))
         if unknown := sorted(keys - expected):
             preview = ", ".join(repr(key) for key in unknown[:8])
@@ -1316,7 +1322,7 @@ class TrainerRank:
             else [None] * dist.get_world_size()
         )
         if dist.is_available() and dist.is_initialized():
-            dist.all_gather_object(gathered, local_keys)
+            dist.all_gather_object(gathered, local_keys, group=self._checkpoint_group())
         covered = set().union(*(keys for keys in gathered if keys is not None))
         if loaded_sites < 1 or covered != expected_keys:
             raise TrainerRankSlotStateError(

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -788,7 +788,9 @@ async def test_checkpoint_prefetch_failures_are_coordinated(
             raise OSError("rank-local prefetch failed")
         return object()
 
-    def coordinated(error: BaseException | None, phase: str) -> None:
+    def coordinated(
+        error: BaseException | None, phase: str, _group: object | None = None
+    ) -> None:
         assert phase == "prepare checkpoint"
         assert isinstance(error, OSError) is local_failure
         raise RuntimeError("a rank failed to prepare checkpoint")
@@ -907,7 +909,14 @@ def test_checkpoint_slot_adapter_config_rejects_cross_rank_mismatch(
     monkeypatch.setattr("art.trainer_rank.dist.is_initialized", lambda: True)
     monkeypatch.setattr("art.trainer_rank.dist.get_world_size", lambda: 2)
 
-    def gather(output: list[object], value: object) -> None:
+    checkpoint_group = cast(dist.ProcessGroup, object())
+    trainer._checkpoint_process_group = checkpoint_group
+    trainer._checkpoint_finalize_process_group = cast(dist.ProcessGroup, object())
+
+    def gather(
+        output: list[object], value: object, *, group: object | None = None
+    ) -> None:
+        assert group is checkpoint_group
         revision = value[1] if isinstance(value, tuple) and len(value) == 2 else None
         output[:] = [value, ({"different": True}, revision)]
 
@@ -947,7 +956,17 @@ def test_slot_load_canonicalizes_only_local_incoming_adapter(
     monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
     monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 2)
 
-    def gather_expected(values: list[set[str] | None], local: set[str]) -> None:
+    checkpoint_group = cast(dist.ProcessGroup, object())
+    trainer._checkpoint_process_group = checkpoint_group
+    trainer._checkpoint_finalize_process_group = cast(dist.ProcessGroup, object())
+
+    def gather_expected(
+        values: list[set[str] | None],
+        local: set[str],
+        *,
+        group: object | None = None,
+    ) -> None:
+        assert group is checkpoint_group
         values[:] = [local, {"remote_weight"}]
 
     monkeypatch.setattr(torch.distributed, "all_gather_object", gather_expected)
@@ -1351,6 +1370,35 @@ def test_checkpoint_cleanup_failure_can_be_retried(
     assert "save" not in trainer._prepared_checkpoint_saves
     assert not prepared.snapshot.exists()
     assert not prepared.reservation.exists()
+
+
+def test_checkpoint_cleanup_gather_failure_releases_finalizer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from art.trainer_rank import _checkpoint
+
+    trainer = _save_state_trainer()
+    prepared = _prepared_save(tmp_path, 0)
+    trainer._prepared_checkpoint_saves = {"save": prepared}
+    original = _checkpoint._gather
+    failed = False
+
+    def fail_once(
+        value: object, group: dist.ProcessGroup | None = None
+    ) -> tuple[object, ...]:
+        nonlocal failed
+        if isinstance(value, bool) and not failed:
+            failed = True
+            raise RuntimeError("injected cleanup gather failure")
+        return original(value, group)
+
+    monkeypatch.setattr(_checkpoint, "_finish", lambda *_: None)
+    monkeypatch.setattr(_checkpoint, "_gather", fail_once)
+    with pytest.raises(RuntimeError, match="cleanup gather"):
+        finish_checkpoint_save(trainer, "save")
+    assert "save" not in trainer._checkpoint_finalizing_saves
+    finish_checkpoint_save(trainer, "save")
+    assert "save" not in trainer._prepared_checkpoint_saves
 
 
 def test_checkpoint_prepare_preserves_foreign_reservation(tmp_path: Path) -> None:

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -38,6 +38,7 @@ from art.trainer_rank._checkpoint import (
     OptimizerConfig,
     PreparedCheckpoint,
     _file_digest,
+    _FinalizedSave,
     _manifest_digest,
     _merge_component,
     _PreparedSave,
@@ -1399,6 +1400,74 @@ def test_checkpoint_cleanup_gather_failure_releases_finalizer(
     assert "save" not in trainer._checkpoint_finalizing_saves
     finish_checkpoint_save(trainer, "save")
     assert "save" not in trainer._prepared_checkpoint_saves
+
+
+def test_checkpoint_asymmetric_cleanup_gather_can_converge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from art.trainer_rank import _checkpoint
+
+    completed = _save_state_trainer()
+    retained = _save_state_trainer()
+    retained_root = tmp_path / "retained"
+    retained_root.mkdir()
+    retained_save = _prepared_save(retained_root, 0)
+    completed._finalized_checkpoint_saves["save"] = _FinalizedSave(0, "finish")
+    retained._prepared_checkpoint_saves["save"] = retained_save
+    retained._checkpoint_save_outcomes["save"] = "finish"
+    boolean_gathers = 0
+
+    def mixed(
+        value: object, _group: dist.ProcessGroup | None = None
+    ) -> tuple[object, ...]:
+        nonlocal boolean_gathers
+        if isinstance(value, bool):
+            boolean_gathers += 1
+            return (True, False) if boolean_gathers % 2 else (False, False)
+        return (value, value)
+
+    monkeypatch.setattr(_checkpoint, "_gather", mixed)
+    finish_checkpoint_save(completed, "save")
+    finish_checkpoint_save(retained, "save")
+    assert "save" in completed._finalized_checkpoint_saves
+    assert "save" in retained._finalized_checkpoint_saves
+    assert "save" not in retained._prepared_checkpoint_saves
+
+
+def test_checkpoint_cleanup_gather_preserves_finish_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from art.trainer_rank import _checkpoint
+
+    trainer = _save_state_trainer()
+    prepared = _prepared_save(tmp_path, 0)
+    trainer._prepared_checkpoint_saves = {"save": prepared}
+    original = _checkpoint._gather
+    boolean_gathers = 0
+
+    def fail_cleanup(
+        value: object, group: dist.ProcessGroup | None = None
+    ) -> tuple[object, ...]:
+        nonlocal boolean_gathers
+        if isinstance(value, bool):
+            boolean_gathers += 1
+            if boolean_gathers == 2:
+                raise RuntimeError("cleanup collective failed")
+        return original(value, group)
+
+    def fail_finish(*_: object) -> None:
+        raise ValueError("snapshot failed")
+
+    monkeypatch.setattr(_checkpoint, "_finish", fail_finish)
+    monkeypatch.setattr(
+        _checkpoint, "_cleanup_paths", lambda *_: OSError("unlink failed")
+    )
+    monkeypatch.setattr(_checkpoint, "_gather", fail_cleanup)
+    with pytest.raises(BaseExceptionGroup) as raised:
+        finish_checkpoint_save(trainer, "save")
+    assert any(isinstance(error, ValueError) for error in raised.value.exceptions)
+    assert any(isinstance(error, OSError) for error in raised.value.exceptions)
+    assert any(isinstance(error, RuntimeError) for error in raised.value.exceptions)
 
 
 def test_checkpoint_prepare_preserves_foreign_reservation(tmp_path: Path) -> None:

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -1388,7 +1388,7 @@ def test_checkpoint_cleanup_gather_failure_releases_finalizer(
         value: object, group: dist.ProcessGroup | None = None
     ) -> tuple[object, ...]:
         nonlocal failed
-        if isinstance(value, bool) and not failed:
+        if isinstance(value, tuple) and len(value) == 2 and not failed:
             failed = True
             raise RuntimeError("injected cleanup gather failure")
         return original(value, group)
@@ -1415,15 +1415,12 @@ def test_checkpoint_asymmetric_cleanup_gather_can_converge(
     completed._finalized_checkpoint_saves["save"] = _FinalizedSave(0, "finish")
     retained._prepared_checkpoint_saves["save"] = retained_save
     retained._checkpoint_save_outcomes["save"] = "finish"
-    boolean_gathers = 0
 
     def mixed(
         value: object, _group: dist.ProcessGroup | None = None
     ) -> tuple[object, ...]:
-        nonlocal boolean_gathers
         if isinstance(value, bool):
-            boolean_gathers += 1
-            return (True, False) if boolean_gathers % 2 else (False, False)
+            return (True, False)
         return (value, value)
 
     monkeypatch.setattr(_checkpoint, "_gather", mixed)
@@ -1443,16 +1440,12 @@ def test_checkpoint_cleanup_gather_preserves_finish_error(
     prepared = _prepared_save(tmp_path, 0)
     trainer._prepared_checkpoint_saves = {"save": prepared}
     original = _checkpoint._gather
-    boolean_gathers = 0
 
     def fail_cleanup(
         value: object, group: dist.ProcessGroup | None = None
     ) -> tuple[object, ...]:
-        nonlocal boolean_gathers
-        if isinstance(value, bool):
-            boolean_gathers += 1
-            if boolean_gathers == 2:
-                raise RuntimeError("cleanup collective failed")
+        if isinstance(value, tuple) and len(value) == 2:
+            raise RuntimeError("cleanup collective failed")
         return original(value, group)
 
     def fail_finish(*_: object) -> None:


### PR DESCRIPTION
## Summary
- release checkpoint finalizer ownership even when cleanup-result gathering fails
- make asymmetric cleanup completion converge through compact `(sequence, outcome)` tombstones
- fuse terminal cleanup/error propagation into one stream-aligned collective
- preserve snapshot, filesystem, and collective failures together
- use ART checkpoint Gloo groups for checkpoint validation/control collectives instead of the ambient default process group

## Scope
TrainerRank-only hardening after #792. No PipelineTrainer, ambient Megatron training, runtime, or LoRA publication changes. Production delta: +88 lines.

## Validation
- `uv run prek run --all-files`
- 129 focused TrainerRank/checkpoint tests passed (6 skipped)
- asymmetric cleanup, retry, error preservation, FIFO, and concurrent-finalization regressions pass
- independent Codex review and focused re-reviews: clean
- Claude Fable 5 initial findings addressed; final focused re-review: clean
- fresh full CI and 2×H200 gate passed