### PR TITLE
[codex] Account for OpenAI Responses cached tokens

### DIFF
--- a/src/art/api_costs.py
+++ b/src/art/api_costs.py
@@ -206,9 +206,15 @@ def _extract_direct_response_cost(response: Any) -> float | None:
 def _extract_openai_token_counts(response: Any) -> _OpenAITokenUsage | None:
     usage = _response_usage(response)
     prompt_tokens = _read_usage_field(usage, "prompt_tokens")
+    if prompt_tokens is None:
+        prompt_tokens = _read_usage_field(usage, "input_tokens")
     completion_tokens = _read_usage_field(usage, "completion_tokens")
+    if completion_tokens is None:
+        completion_tokens = _read_usage_field(usage, "output_tokens")
     cached_prompt_tokens = (
-        _read_usage_nested_field(usage, "prompt_tokens_details", "cached_tokens") or 0.0
+        _read_usage_nested_field(usage, "prompt_tokens_details", "cached_tokens")
+        or _read_usage_nested_field(usage, "input_tokens_details", "cached_tokens")
+        or 0.0
     )
     if (
         prompt_tokens is None

--- a/tests/unit/test_track_api_cost.py
+++ b/tests/unit/test_track_api_cost.py
@@ -60,6 +60,40 @@ class _OpenAIResponse:
         self.model = model
 
 
+class _OpenAIResponsesUsage:
+    def __init__(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        *,
+        cached_tokens: int = 0,
+    ) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.input_tokens_details = type(
+            "InputTokensDetails",
+            (),
+            {"cached_tokens": cached_tokens},
+        )()
+
+
+class _OpenAIResponsesResponse:
+    def __init__(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        *,
+        cached_tokens: int = 0,
+        model: str | None = None,
+    ) -> None:
+        self.usage = _OpenAIResponsesUsage(
+            input_tokens,
+            output_tokens,
+            cached_tokens=cached_tokens,
+        )
+        self.model = model
+
+
 class _AnthropicUsage:
     def __init__(
         self,
@@ -161,6 +195,38 @@ class TestTrackApiCost:
 
         metrics = await builder.flush()
         assert metrics["costs/train/llm_judge/cached_openai"] == pytest.approx(0.00255)
+
+    @pytest.mark.asyncio
+    async def test_openai_cost_extraction_accounts_for_responses_cached_tokens(
+        self,
+    ) -> None:
+        builder = MetricsBuilder(cost_context="train")
+
+        @track_api_cost(
+            source="llm_judge/cached_openai_responses",
+            provider="openai",
+            model_name="openai/gpt-4.1",
+            prompt_price_per_million=2.0,
+            completion_price_per_million=8.0,
+            cached_prompt_price_per_million=0.5,
+        )
+        async def _judge() -> _OpenAIResponsesResponse:
+            return _OpenAIResponsesResponse(
+                input_tokens=2_000,
+                output_tokens=100,
+                cached_tokens=1_500,
+            )
+
+        token = builder.activate()
+        try:
+            await _judge()
+        finally:
+            token.var.reset(token)
+
+        metrics = await builder.flush()
+        assert metrics["costs/train/llm_judge/cached_openai_responses"] == pytest.approx(
+            0.00255
+        )
 
     @pytest.mark.asyncio
     async def test_anthropic_cost_extraction_uses_registered_model_pricing(


### PR DESCRIPTION
## Summary

- recognize OpenAI Responses-style usage fields in API cost extraction
- treat `input_tokens` / `output_tokens` as aliases for prompt / completion tokens
- read cached prompt tokens from `input_tokens_details.cached_tokens` as well as `prompt_tokens_details.cached_tokens`
- add a regression test that verifies cached-token pricing for Responses-style usage

## Why

ART already accounts for OpenAI cached prompt tokens when usage is shaped like Chat Completions: `prompt_tokens`, `completion_tokens`, and `prompt_tokens_details.cached_tokens`.

OpenAI Responses-style usage commonly uses `input_tokens`, `output_tokens`, and `input_tokens_details.cached_tokens`. Without those aliases, cached input tokens can be priced as uncached input or the response can fail provider usage extraction, depending on which fields are present.

This keeps the existing pricing model and only broadens the accepted usage spellings.

## Validation

- `uv run pytest tests/unit/test_track_api_cost.py::TestTrackApiCost -q` -> 16 passed
- `uv run ruff check src/art/api_costs.py tests/unit/test_track_api_cost.py`
- `python3.12 -m compileall -q src/art/api_costs.py tests/unit/test_track_api_cost.py`
- `git diff --check`

Note: the full `tests/unit/test_track_api_cost.py` file also runs two pipeline trainer integration tests that require `torch`; those failed in this fresh local uv environment because `torch` is not installed. The focused API-cost test class passed.

Context: this is part of a broader open-source effort to make prompt-cache costs measurable across eval and agent frameworks: https://github.com/Tanisha-Katara/cacheeconomics