### PR TITLE
Fix multi-turn reasoning tokenization, LoRA recompile churn, and checkpoint slot refs

### DIFF
--- a/docs/features/additional-histories.mdx
+++ b/docs/features/additional-histories.mdx
@@ -27,6 +27,12 @@ Each trajectory can contain:
 
 Some models, like Qwen 3, use chat templates that remove special tokens (such as `<think>`) from previous turns in multi-turn conversations. This can interfere with training when you want the model to learn from its thinking process across all turns.
 
+ART-managed inference and SFT paths preserve prior-turn thinking by default when
+the model's chat template supports it. You can override that behavior explicitly
+with `chat_template_kwargs={"preserve_thinking": False}`. Additional histories
+remain useful for custom or externally managed templates that do not expose a
+prior-thinking preservation option.
+
 By splitting each turn into a separate history, you can preserve these tokens for training:
 
 ```python

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -16,6 +16,10 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, AsyncIterator, Iterable, Literal, cast
 import warnings
 
+from art.utils.chat_template import (
+    chat_template_with_preserved_thinking,
+    configure_preserved_thinking_chat_template,
+)
 from art.utils.lifecycle import (
     PROCESS_SHUTDOWN_TIMEOUT_SECONDS,
     process_shutdown_timeout,
@@ -242,6 +246,14 @@ def _apply_configured_chat_template_server_args(
         chat_template = _model_support_default_chat_template(
             base_model, internal_config
         )
+    if chat_template is None and base_model is not None and base_model.startswith(
+        ("Qwen/Qwen3-", "Qwen/Qwen3.5-", "OpenPipe/Qwen3-")
+    ):
+        tokenizer = AutoTokenizer.from_pretrained(base_model)
+        default = getattr(tokenizer, "chat_template", None)
+        preserved = chat_template_with_preserved_thinking(default)
+        if preserved != default:
+            chat_template = cast(str, preserved)
     if chat_template is None:
         return
     server_args = dict(config_dict.get("server_args", {}))
@@ -269,7 +281,9 @@ def _tokenizer_cache_key(
 def _load_training_tokenizer(base_model: str) -> PreTrainedTokenizerBase:
     return cast(
         PreTrainedTokenizerBase,
-        AutoTokenizer.from_pretrained(base_model),
+        configure_preserved_thinking_chat_template(
+            AutoTokenizer.from_pretrained(base_model)
+        ),
     )
 
 
@@ -1130,7 +1144,9 @@ class LocalBackend:
     ) -> tuple[str, str]:
         config_dict: dict = dict(config or {})
         internal_config = cast(dev.InternalModelConfig, model._internal_config or {})
-        _apply_configured_chat_template_server_args(config_dict, internal_config)
+        _apply_configured_chat_template_server_args(
+            config_dict, internal_config, base_model=model.base_model
+        )
         if self._model_uses_expert_replay(model):
             engine_args = dict(config_dict.get("engine_args", {}))
             engine_args["enable_return_routed_experts"] = True

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -246,8 +246,10 @@ def _apply_configured_chat_template_server_args(
         chat_template = _model_support_default_chat_template(
             base_model, internal_config
         )
-    if chat_template is None and base_model is not None and base_model.startswith(
-        ("Qwen/Qwen3-", "Qwen/Qwen3.5-", "OpenPipe/Qwen3-")
+    if (
+        chat_template is None
+        and base_model is not None
+        and base_model.startswith(("Qwen/Qwen3-", "Qwen/Qwen3.5-", "OpenPipe/Qwen3-"))
     ):
         tokenizer = AutoTokenizer.from_pretrained(base_model)
         default = getattr(tokenizer, "chat_template", None)

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -241,6 +241,17 @@ def _apply_configured_chat_template_server_args(
     *,
     base_model: str | None = None,
 ) -> None:
+    server_args = dict(config_dict.get("server_args", {}))
+    if server_args.get("chat_template") is not None:
+        if chat_template_content_format := internal_config.get(
+            "chat_template_content_format"
+        ):
+            server_args.setdefault(
+                "chat_template_content_format",
+                chat_template_content_format,
+            )
+        config_dict["server_args"] = server_args
+        return
     chat_template = _configured_chat_template_server_arg(internal_config)
     if chat_template is None and base_model is not None:
         chat_template = _model_support_default_chat_template(
@@ -251,14 +262,22 @@ def _apply_configured_chat_template_server_args(
         and base_model is not None
         and base_model.startswith(("Qwen/Qwen3-", "Qwen/Qwen3.5-", "OpenPipe/Qwen3-"))
     ):
-        tokenizer = AutoTokenizer.from_pretrained(base_model)
-        default = getattr(tokenizer, "chat_template", None)
-        preserved = chat_template_with_preserved_thinking(default)
-        if preserved != default:
-            chat_template = cast(str, preserved)
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(base_model)
+        except OSError as error:
+            warnings.warn(
+                f"Could not load {base_model!r} to configure prior-thinking "
+                f"preservation: {error}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        else:
+            default = getattr(tokenizer, "chat_template", None)
+            preserved = chat_template_with_preserved_thinking(default)
+            if preserved != default:
+                chat_template = cast(str, preserved)
     if chat_template is None:
         return
-    server_args = dict(config_dict.get("server_args", {}))
     server_args.setdefault("chat_template", chat_template)
     if chat_template_content_format := internal_config.get(
         "chat_template_content_format"

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -257,14 +257,10 @@ def _apply_configured_chat_template_server_args(
         chat_template = _model_support_default_chat_template(
             base_model, internal_config
         )
-    if (
-        chat_template is None
-        and base_model is not None
-        and base_model.startswith(("Qwen/Qwen3-", "Qwen/Qwen3.5-", "OpenPipe/Qwen3-"))
-    ):
+    if chat_template is None and _should_probe_preserve_thinking_template(base_model):
         try:
             tokenizer = AutoTokenizer.from_pretrained(base_model)
-        except OSError as error:
+        except (OSError, ValueError) as error:
             warnings.warn(
                 f"Could not load {base_model!r} to configure prior-thinking "
                 f"preservation: {error}",
@@ -287,6 +283,13 @@ def _apply_configured_chat_template_server_args(
             chat_template_content_format,
         )
     config_dict["server_args"] = server_args
+
+
+def _should_probe_preserve_thinking_template(base_model: str | None) -> bool:
+    if base_model is None:
+        return False
+    model_name = base_model.rstrip("/").rsplit("/", 1)[-1]
+    return model_name.startswith(("Qwen3-", "Qwen3.5-"))
 
 
 def _tokenizer_cache_key(

--- a/src/art/megatron/training/compile.py
+++ b/src/art/megatron/training/compile.py
@@ -15,6 +15,7 @@ _DYNAMO_CONFIG = cast(Any, dynamo_config)
 
 
 def _configure_dynamo() -> None:
+    """Set the process-wide Dynamo policy required by dynamic LoRA slots."""
     # Dynamic checkpoint slots register differently shaped projection parameters
     # behind one LoRA.forward code object. Let automatic dynamic shapes generalize
     # those parameter dimensions instead of compiling once per projection site.

--- a/src/art/megatron/training/compile.py
+++ b/src/art/megatron/training/compile.py
@@ -5,10 +5,20 @@ from typing import Any, cast
 
 from megatron.core.transformer.transformer_layer import TransformerLayer
 import torch
+from torch._dynamo import config as dynamo_config
 
 from art.megatron.compile_workarounds import install_torch_compile_workarounds
 from art.megatron.provider import ProviderBundle
 from art.megatron.training.model_chunks import ModelChunks
+
+_DYNAMO_CONFIG = cast(Any, dynamo_config)
+
+
+def _configure_dynamo() -> None:
+    # Dynamic checkpoint slots register differently shaped projection parameters
+    # behind one LoRA.forward code object. Let automatic dynamic shapes generalize
+    # those parameter dimensions instead of compiling once per projection site.
+    _DYNAMO_CONFIG.force_parameter_static_shapes = False
 
 
 def compile_enabled() -> bool:
@@ -70,6 +80,7 @@ def configure_training_compile(
         enabled and not compile_workaround_config.disable_compile
     )
     if transformer_layers_compiled:
+        _configure_dynamo()
         for chunk in model:
             _compile_transformer_layers(chunk)
     return transformer_layers_compiled

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -675,13 +675,16 @@ class Model(
         if self.trainable:
             body["return_token_ids"] = True
             body["return_tokens_as_token_ids"] = True
-        chat_template_kwargs = (
+        configured_chat_template_kwargs = (
             internal_config.get("chat_template_kwargs")
             if internal_config is not None
             else None
         )
-        if chat_template_kwargs is not None:
-            body["chat_template_kwargs"] = dict(chat_template_kwargs)
+        if self.trainable or configured_chat_template_kwargs is not None:
+            body["chat_template_kwargs"] = {
+                "preserve_thinking": True,
+                **(configured_chat_template_kwargs or {}),
+            }
         if not body:
             return None
         return body

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -668,6 +668,7 @@ class Model(
         return "none"
 
     def _default_chat_completion_extra_body(self) -> dict[str, Any] | None:
+        """Defaults for ART-managed inference while preserving caller overrides."""
         internal_config = getattr(self, "_internal_config", None)
         if internal_config is None and not self.trainable:
             return None
@@ -680,7 +681,7 @@ class Model(
             if internal_config is not None
             else None
         )
-        if self.trainable or configured_chat_template_kwargs is not None:
+        if self.trainable or internal_config is not None:
             body["chat_template_kwargs"] = {
                 "preserve_thinking": True,
                 **(configured_chat_template_kwargs or {}),

--- a/src/art/preprocessing/tokenize.py
+++ b/src/art/preprocessing/tokenize.py
@@ -4,7 +4,6 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from functools import cached_property
 from itertools import takewhile
-import json
 import math
 import random
 from typing import TYPE_CHECKING, Any, Generator, Literal, Protocol, cast
@@ -33,6 +32,7 @@ from ..types import MessagesAndChoices
 from ..utils.chat_template import (
     default_chat_template_kwargs_for_tokenizer,
     merge_chat_template_kwargs,
+    normalize_tool_call_arguments_for_chat_template,
 )
 from .moe_routing import (
     MoeRouteArray,
@@ -323,34 +323,9 @@ def _normalize_tool_call_arguments_for_chat_template(
     tokenizer: _SFTTokenizer,
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    chat_template = tokenizer.chat_template
-    assert isinstance(chat_template, str)
-    if "tool_call.arguments|items" not in chat_template:
-        return messages
-
-    normalized_messages: list[dict[str, Any]] = []
-    for message in messages:
-        tool_calls = message.get("tool_calls")
-        if tool_calls is None:
-            normalized_messages.append(message)
-            continue
-
-        assert isinstance(tool_calls, list)
-        normalized_tool_calls = []
-        for tool_call in tool_calls:
-            assert isinstance(tool_call, dict)
-            function = tool_call["function"]
-            assert isinstance(function, dict)
-            arguments_json = function["arguments"]
-            assert isinstance(arguments_json, str)
-            arguments = json.loads(arguments_json)
-            assert isinstance(arguments, dict)
-            normalized_tool_calls.append(
-                {**tool_call, "function": {**function, "arguments": arguments}}
-            )
-        normalized_messages.append({**message, "tool_calls": normalized_tool_calls})
-
-    return normalized_messages
+    return normalize_tool_call_arguments_for_chat_template(
+        messages, tokenizer.chat_template
+    )
 
 
 def _messages_for_chat_template(

--- a/src/art/tau_bench/rollout.py
+++ b/src/art/tau_bench/rollout.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 import json
 import os
+import time
 from typing import Any, cast, overload
 
 from openai import AsyncOpenAI, BadRequestError
@@ -74,6 +75,7 @@ async def rollout(
     retrieval_config: str | None = None,
     retrieval_config_kwargs: dict[str, Any] | None = None,
 ) -> Trajectory:
+    started = time.perf_counter()
     client = _get_default_client(client)
     task_id = scenario.task.id
     async with client.environment(
@@ -88,6 +90,7 @@ async def rollout(
         retrieval_config=retrieval_config,
         retrieval_config_kwargs=retrieval_config_kwargs,
     ) as env:
+        environment_startup = time.perf_counter() - started
         chat_completion_kwargs = chat_completion_kwargs or {}
         openai_client, model_name, cost_model = _completion_client_and_model(
             base_url_or_model,
@@ -116,6 +119,7 @@ async def rollout(
                 if max_turns is not None and num_turns >= max_turns:
                     break
                 try:
+                    policy_started = time.perf_counter()
                     chat_completion = await openai_client.chat.completions.create(
                         messages=messages,
                         model=model_name,
@@ -123,6 +127,14 @@ async def rollout(
                         tool_choice="auto",
                         tools=tools,
                         **chat_completion_kwargs,
+                    )
+                    policy_latency = time.perf_counter() - policy_started
+                    trajectory.metrics["latency/policy"] = (
+                        trajectory.metrics.get("latency/policy", 0.0) + policy_latency
+                    )
+                    trajectory.metrics["latency/policy_max"] = max(
+                        trajectory.metrics.get("latency/policy_max", 0.0),
+                        policy_latency,
                     )
                 except BadRequestError as exc:
                     if _is_max_tokens_error(exc):
@@ -134,6 +146,15 @@ async def rollout(
                     chat_completion.usage,
                     assert_costs=assert_costs,
                 )
+                if chat_completion.usage is not None:
+                    trajectory.metrics["tokens/prompt"] = (
+                        trajectory.metrics.get("tokens/prompt", 0.0)
+                        + chat_completion.usage.prompt_tokens
+                    )
+                    trajectory.metrics["tokens/completion"] = (
+                        trajectory.metrics.get("tokens/completion", 0.0)
+                        + chat_completion.usage.completion_tokens
+                    )
                 choice = chat_completion.choices[0]
                 messages.append(
                     cast(
@@ -145,7 +166,13 @@ async def rollout(
                 if tool_calls:
                     for tool_call in tool_calls:
                         action = _tool_call_action(tool_call)
+                        environment_started = time.perf_counter()
                         step = await client.step_environment(env.id, action)
+                        environment_latency = time.perf_counter() - environment_started
+                        trajectory.metrics["latency/environment"] = (
+                            trajectory.metrics.get("latency/environment", 0.0)
+                            + environment_latency
+                        )
                         messages.append(
                             {
                                 "role": "tool",
@@ -156,9 +183,15 @@ async def rollout(
                         trajectory.reward += step.reward
                         terminated = step.terminated
                 else:
+                    environment_started = time.perf_counter()
                     step = await client.step_environment(
                         env.id,
                         choice.message.content or "",
+                    )
+                    environment_latency = time.perf_counter() - environment_started
+                    trajectory.metrics["latency/environment"] = (
+                        trajectory.metrics.get("latency/environment", 0.0)
+                        + environment_latency
                     )
                     if "user_message_cost" in step.info:
                         trajectory.metrics["cost/user"] += step.info[
@@ -182,6 +215,8 @@ async def rollout(
                 ):
                     break
         trajectory.metrics["num_turns"] = num_turns
+        trajectory.metrics["latency/environment_startup"] = environment_startup
+        trajectory.metrics["latency/active"] = time.perf_counter() - started
         return trajectory
 
 

--- a/src/art/trainer_rank/_checkpoint.py
+++ b/src/art/trainer_rank/_checkpoint.py
@@ -1038,7 +1038,7 @@ def _localized(
 
 
 def _slot_snapshot(trainer: TrainerRank) -> _SlotSnapshot:
-    from art.megatron.lora import LoRA
+    from art.megatron.lora import LoRA, LoRASlotRef
 
     return tuple(
         (

--- a/src/art/trajectories/_history.py
+++ b/src/art/trajectories/_history.py
@@ -601,7 +601,8 @@ def chat_completions_histories(
                 )
             ]
             prompt_lineage_keys = [
-                _chat_message_key(message, visible_only=True) for message in prompt
+                _chat_message_key(message, visible_only=not reconcile)
+                for message in prompt
             ]
             choices = _ordered_choices(
                 exchange.response.choices, protocol="Chat Completions"
@@ -636,8 +637,8 @@ def chat_completions_histories(
                     for index in range(len(prompt))
                 ],
                 equivalent=lambda left, right: (
-                    _chat_message_key(left, visible_only=True)
-                    == _chat_message_key(right, visible_only=True)
+                    _chat_message_key(left, visible_only=not reconcile)
+                    == _chat_message_key(right, visible_only=not reconcile)
                 ),
                 continuation=source_continuation,
                 prompt_keys=prompt_lineage_keys,
@@ -666,7 +667,7 @@ def chat_completions_histories(
                     )
                 )
             output_lineage_keys = [
-                [_chat_message_key(output[0], visible_only=True)]
+                [_chat_message_key(output[0], visible_only=not reconcile)]
                 for _, output, _ in outputs
             ]
             _extend_branches(

--- a/src/art/trajectories/_history.py
+++ b/src/art/trajectories/_history.py
@@ -612,11 +612,11 @@ def chat_completions_histories(
             exact_continuation = lambda branch: _chat_exact_generation_extends(
                 branch, prompt_ids, len(prompt), token_cache
             )
-            continuation = lambda branch: (
+            continuation = lambda branch: reconcile or (
                 _chat_retains_sampled_reasoning(
                     branch, prompt_ids, len(prompt), token_cache
                 )
-                and (reconcile or exact_continuation(branch))
+                and exact_continuation(branch)
             )
             source_continuation = lambda branch: (
                 reconcile

--- a/src/art/trajectories/_history.py
+++ b/src/art/trajectories/_history.py
@@ -612,11 +612,14 @@ def chat_completions_histories(
             exact_continuation = lambda branch: _chat_exact_generation_extends(
                 branch, prompt_ids, len(prompt), token_cache
             )
-            continuation = lambda branch: reconcile or (
-                _chat_retains_sampled_reasoning(
-                    branch, prompt_ids, len(prompt), token_cache
+            continuation = lambda branch: (
+                reconcile
+                or (
+                    _chat_retains_sampled_reasoning(
+                        branch, prompt_ids, len(prompt), token_cache
+                    )
+                    and exact_continuation(branch)
                 )
-                and exact_continuation(branch)
             )
             source_continuation = lambda branch: (
                 reconcile

--- a/src/art/trajectories/_history.py
+++ b/src/art/trajectories/_history.py
@@ -528,6 +528,10 @@ def normalize_chat_message(message: Mapping[str, object]) -> dict[str, object]:
 
     data = copy.deepcopy(dict(message))
     data.pop("annotations", None)
+    if data.get("reasoning_content") is not None and not data.get("reasoning"):
+        data["reasoning"] = data.pop("reasoning_content")
+    elif data.get("reasoning_content") == data.get("reasoning"):
+        data.pop("reasoning_content", None)
     if data.get("role") == "assistant" and data.get("content") is None:
         data["content"] = ""
     elif data.get("content") is None:

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -3393,12 +3393,11 @@ def _tokenize_chat_view(
         kwargs.setdefault("enable_thinking", thinking.get("type") == "enabled")
         if budget := thinking.get("budget_tokens"):
             kwargs.setdefault("thinking_budget", budget)
-    template = (
-        chat_template
-        or history.chat_template
-        or config.chat_template
-        or getattr(resolved_tokenizer, "chat_template", None)
-    )
+    template = chat_template or history.chat_template or config.chat_template
+    if template is None:
+        tokenizer_template = getattr(resolved_tokenizer, "chat_template", None)
+        if isinstance(tokenizer_template, str):
+            template = tokenizer_template
     if kwargs.get("preserve_thinking") is True:
         template = chat_template_with_preserved_thinking(template)
     messages = normalize_tool_call_arguments_for_chat_template(messages, template)

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -21,6 +21,11 @@ from openai.types.chat.chat_completion import Choice
 from openai.types.responses import Response
 from pydantic import BaseModel
 
+from ..utils.chat_template import (
+    chat_template_with_preserved_thinking,
+    configure_preserved_thinking_chat_template,
+    normalize_tool_call_arguments_for_chat_template,
+)
 from . import (
     AnthropicMessagesHistory,
     ChatCompletionsExchange,
@@ -972,7 +977,7 @@ def _cached_tokenizer(base_model: str, revision: str | None) -> Tokenizer:
             from ..megatron.dsv4.tokenizer import get_dsv4_tokenizer
 
             tokenizer = get_dsv4_tokenizer(cast("PreTrainedTokenizerBase", tokenizer))
-        return _as_tokenizer(tokenizer)
+        return _as_tokenizer(configure_preserved_thinking_chat_template(tokenizer))
     except Exception as exc:
         raise ValueError(
             f"Could not load tokenizer for {base_model!r}; pass base_model explicitly"
@@ -1380,9 +1385,16 @@ def _template_ids(
         kwargs.setdefault("enable_thinking", thinking.get("type") == "enabled")
         if budget := thinking.get("budget_tokens"):
             kwargs.setdefault("thinking_budget", budget)
-    template = chat_template or request.get("chat_template") or config.chat_template
+    template = (
+        chat_template
+        or request.get("chat_template")
+        or config.chat_template
+        or getattr(tokenizer, "chat_template", None)
+    )
+    if kwargs.get("preserve_thinking") is True:
+        template = chat_template_with_preserved_thinking(template)
     result = tokenizer.apply_chat_template(
-        messages,
+        normalize_tool_call_arguments_for_chat_template(messages, template),
         tools=tools,
         tokenize=True,
         add_generation_prompt=not completed,
@@ -3381,7 +3393,15 @@ def _tokenize_chat_view(
         kwargs.setdefault("enable_thinking", thinking.get("type") == "enabled")
         if budget := thinking.get("budget_tokens"):
             kwargs.setdefault("thinking_budget", budget)
-    template = chat_template or history.chat_template or config.chat_template
+    template = (
+        chat_template
+        or history.chat_template
+        or config.chat_template
+        or getattr(resolved_tokenizer, "chat_template", None)
+    )
+    if kwargs.get("preserve_thinking") is True:
+        template = chat_template_with_preserved_thinking(template)
+    messages = normalize_tool_call_arguments_for_chat_template(messages, template)
     ends_with_assistant = bool(messages) and messages[-1].get("role") == "assistant"
 
     def render(
@@ -3718,9 +3738,18 @@ def _tokenize_chat_view(
                     if encoded_data is not None
                     else None
                 )
+                encoded_ids = _ids(encoded) if encoded is not None else []
                 if (
                     encoded is not None
-                    and _ids(encoded) == rendered
+                    and (
+                        encoded_ids == rendered
+                        or (
+                            exact_prefix_length
+                            and len(encoded_ids) == len(rendered)
+                            and encoded_ids[exact_prefix_length:]
+                            == rendered[exact_prefix_length:]
+                        )
+                    )
                     and isinstance(raw_offsets, list)
                     and len(raw_offsets) == len(rendered)
                 ):
@@ -3966,8 +3995,33 @@ def _tokenize_chat_view(
         complete_sampled_message = (
             sampled
             and source is not None
-            and _source_covers_complete_sampled_message(message, source)
+            and _source_covers_complete_sampled_message(
+                history.messages[message_index], source
+            )
         )
+        if (
+            complete_sampled_message
+            and full_exact is not None
+            and message_index in marked_bounds
+            and isinstance(getattr(source, "exchange", None), ChatCompletionsExchange)
+            and marked_bounds[message_index][1] - marked_bounds[message_index][0]
+            != len(full_exact)
+        ):
+            prefix = render(messages[:message_index], add_generation_prompt=True)
+            completed = render(
+                messages[: message_index + 1], add_generation_prompt=False
+            )
+
+            def matches_rendered_prefix(probe: Sequence[int]) -> bool:
+                return rendered[: len(probe)] == list(probe) or bool(
+                    exact_prefix_length
+                    and len(probe) >= exact_prefix_length
+                    and rendered[exact_prefix_length : len(probe)]
+                    == list(probe[exact_prefix_length:])
+                )
+
+            if matches_rendered_prefix(prefix) and matches_rendered_prefix(completed):
+                marked_bounds[message_index] = (len(prefix), len(completed))
         source_boundary = False
         generation_start: int | None = None
         sampled_bounds: tuple[int, int] | None = None
@@ -4068,7 +4122,7 @@ def _tokenize_chat_view(
         if sampled and not content_bounds_proven:
             raise ValueError(
                 "Could not uniquely locate or prove the sampled content boundary "
-                "with this tokenizer"
+                f"for history message {message_index} with this tokenizer"
             )
         if (
             sampled

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -4007,10 +4007,15 @@ def _tokenize_chat_view(
             and marked_bounds[message_index][1] - marked_bounds[message_index][0]
             != len(full_exact)
         ):
-            prefix = render(messages[:message_index], add_generation_prompt=True)
-            completed = render(
-                messages[: message_index + 1], add_generation_prompt=False
-            )
+            try:
+                prefix = render(messages[:message_index], add_generation_prompt=True)
+                completed = render(
+                    messages[: message_index + 1], add_generation_prompt=False
+                )
+            except Exception:
+                marked_bounds.pop(message_index, None)
+                marked_part_bounds.pop(message_index, None)
+                prefix = completed = None
 
             def matches_rendered_prefix(probe: Sequence[int]) -> bool:
                 return rendered[: len(probe)] == list(probe) or bool(
@@ -4020,8 +4025,15 @@ def _tokenize_chat_view(
                     == list(probe[exact_prefix_length:])
                 )
 
-            if matches_rendered_prefix(prefix) and matches_rendered_prefix(completed):
+            if (
+                prefix is not None
+                and completed is not None
+                and matches_rendered_prefix(prefix)
+                and matches_rendered_prefix(completed)
+            ):
                 marked_bounds[message_index] = (len(prefix), len(completed))
+                # The marker-derived per-part offsets describe the old render.
+                marked_part_bounds.pop(message_index, None)
         source_boundary = False
         generation_start: int | None = None
         sampled_bounds: tuple[int, int] | None = None

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -481,7 +481,18 @@ def _chat_choice_output_tokens(
     values = _chat_logprob_entries(choice)
     message = _dump(choice.message)
     if token_ids == [] and (
-        values or any(message.get(key) for key in ("content", "refusal", "tool_calls"))
+        values
+        or any(
+            message.get(key)
+            for key in (
+                "content",
+                "refusal",
+                "reasoning",
+                "reasoning_content",
+                "tool_calls",
+                "function_call",
+            )
+        )
     ):
         token_ids = None
     pair_ids, pair_logprobs = _pairs(values, field="Chat Completions logprobs")
@@ -3155,7 +3166,9 @@ def _tokenize_exact_projected_chat_history(
 
 def _chat_message_parts(message: Mapping[str, object]) -> list[tuple[str, str]]:
     parts: list[tuple[str, str]] = []
-    reasoning = message.get("reasoning") or message.get("reasoning_content")
+    reasoning = message.get("reasoning")
+    if not isinstance(reasoning, str) or not reasoning:
+        reasoning = message.get("reasoning_content")
     if isinstance(reasoning, str) and reasoning:
         parts.append(("reasoning", reasoning))
     if content := _content_text(message.get("content")):
@@ -3529,7 +3542,9 @@ def _tokenize_chat_view(
             == exchange.request.get("chat_template_kwargs")
         )
 
+    canonical_rendered = rendered
     exact_prefix_length = 0
+    canonical_prefix_length = 0
     if (
         chat_template is None
         and chat_template_kwargs is None
@@ -3554,6 +3569,7 @@ def _tokenize_chat_view(
                         *rendered[len(rendered_prompt) :],
                     ]
                     exact_prefix_length = len(source_prompt)
+                    canonical_prefix_length = len(rendered_prompt)
                     break
 
     positions_by_first_token: dict[int, list[int]] = {}
@@ -3618,21 +3634,28 @@ def _tokenize_chat_view(
         direct_bounds = []
 
     def differing_span(probe: Sequence[int]) -> tuple[int, int] | None:
+        baseline = canonical_rendered if canonical_prefix_length else rendered
         prefix = 0
         while (
-            prefix < len(rendered)
+            prefix < len(baseline)
             and prefix < len(probe)
-            and rendered[prefix] == probe[prefix]
+            and baseline[prefix] == probe[prefix]
         ):
             prefix += 1
         suffix = 0
         while (
-            suffix < len(rendered) - prefix
+            suffix < len(baseline) - prefix
             and suffix < len(probe) - prefix
-            and rendered[-suffix - 1] == probe[-suffix - 1]
+            and baseline[-suffix - 1] == probe[-suffix - 1]
         ):
             suffix += 1
-        end = len(rendered) - suffix
+        end = len(baseline) - suffix
+        if canonical_prefix_length:
+            if prefix < canonical_prefix_length:
+                return None
+            delta = exact_prefix_length - canonical_prefix_length
+            prefix += delta
+            end += delta
         return (prefix, end) if prefix < end else None
 
     marked_bounds: dict[int, tuple[int, int]] = {}

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -4034,6 +4034,9 @@ def _tokenize_chat_view(
                 marked_bounds[message_index] = (len(prefix), len(completed))
                 # The marker-derived per-part offsets describe the old render.
                 marked_part_bounds.pop(message_index, None)
+            else:
+                marked_bounds.pop(message_index, None)
+                marked_part_bounds.pop(message_index, None)
         source_boundary = False
         generation_start: int | None = None
         sampled_bounds: tuple[int, int] | None = None

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -3633,8 +3633,30 @@ def _tokenize_chat_view(
     ):
         direct_bounds = []
 
+    def canonical_render_to_rendered(probe: Sequence[int]) -> list[int] | None:
+        if not exact_prefix_length:
+            return list(probe)
+        if (
+            len(probe) < canonical_prefix_length
+            or list(probe[:canonical_prefix_length])
+            != canonical_rendered[:canonical_prefix_length]
+        ):
+            return None
+        return [
+            *rendered[:exact_prefix_length],
+            *probe[canonical_prefix_length:],
+        ]
+
+    def canonical_span_to_rendered(start: int, end: int) -> tuple[int, int] | None:
+        if not exact_prefix_length:
+            return start, end
+        if start < canonical_prefix_length:
+            return None
+        delta = exact_prefix_length - canonical_prefix_length
+        return start + delta, end + delta
+
     def differing_span(probe: Sequence[int]) -> tuple[int, int] | None:
-        baseline = canonical_rendered if canonical_prefix_length else rendered
+        baseline = canonical_rendered if exact_prefix_length else rendered
         prefix = 0
         while (
             prefix < len(baseline)
@@ -3650,13 +3672,8 @@ def _tokenize_chat_view(
         ):
             suffix += 1
         end = len(baseline) - suffix
-        if canonical_prefix_length:
-            if prefix < canonical_prefix_length:
-                return None
-            delta = exact_prefix_length - canonical_prefix_length
-            prefix += delta
-            end += delta
-        return (prefix, end) if prefix < end else None
+        span = canonical_span_to_rendered(prefix, end)
+        return span if span is not None and span[0] < span[1] else None
 
     marked_bounds: dict[int, tuple[int, int]] = {}
     marked_part_bounds: dict[int, list[tuple[int, int]]] = {}
@@ -3787,16 +3804,16 @@ def _tokenize_chat_view(
                 if (
                     encoded is not None
                     and (
-                        encoded_ids == rendered
+                        encoded_ids == canonical_rendered
                         or (
                             exact_prefix_length
-                            and len(encoded_ids) == len(rendered)
-                            and encoded_ids[exact_prefix_length:]
-                            == rendered[exact_prefix_length:]
+                            and len(encoded_ids) == len(canonical_rendered)
+                            and encoded_ids[canonical_prefix_length:]
+                            == canonical_rendered[canonical_prefix_length:]
                         )
                     )
                     and isinstance(raw_offsets, list)
-                    and len(raw_offsets) == len(rendered)
+                    and len(raw_offsets) == len(encoded_ids)
                 ):
                     offsets: list[tuple[int, int]] = []
                     for value in raw_offsets:
@@ -3807,7 +3824,7 @@ def _tokenize_chat_view(
                         ):
                             break
                         offsets.append((value[0], value[1]))
-                    if len(offsets) == len(rendered):
+                    if len(offsets) == len(encoded_ids):
                         token_bounds: dict[tuple[int, int], tuple[int, int]] = {}
                         token_cursor = 0
                         for key, (char_start, char_end) in sorted(
@@ -3840,10 +3857,19 @@ def _tokenize_chat_view(
                                 if (message_index, part_index) in token_bounds
                             ]
                             if len(bounds) == part_count:
-                                marked_part_bounds[message_index] = bounds
+                                rendered_bounds = [
+                                    canonical_span_to_rendered(*bound)
+                                    for bound in bounds
+                                ]
+                                if any(bound is None for bound in rendered_bounds):
+                                    continue
+                                translated = cast(
+                                    list[tuple[int, int]], rendered_bounds
+                                )
+                                marked_part_bounds[message_index] = translated
                                 marked_bounds[message_index] = (
-                                    bounds[0][0],
-                                    bounds[-1][1],
+                                    translated[0][0],
+                                    translated[-1][1],
                                 )
         for message_index, bounds in list(marked_part_bounds.items()):
             whitespace_parts = [
@@ -3868,6 +3894,11 @@ def _tokenize_chat_view(
                         add_generation_prompt=not ends_with_assistant,
                     )
                 except Exception:
+                    marked_bounds.pop(message_index, None)
+                    marked_part_bounds.pop(message_index, None)
+                    break
+                empty_render = canonical_render_to_rendered(empty_render)
+                if empty_render is None:
                     marked_bounds.pop(message_index, None)
                     marked_part_bounds.pop(message_index, None)
                     break
@@ -3913,13 +3944,17 @@ def _tokenize_chat_view(
                         )
                     except Exception:
                         continue
+                    rendered_prefix = canonical_render_to_rendered(prefix)
+                    rendered_completed = canonical_render_to_rendered(completed)
                     if (
                         completed[: len(prefix)] == prefix
-                        and rendered[: len(completed)] == completed
+                        and rendered_prefix is not None
+                        and rendered_completed is not None
+                        and rendered[: len(rendered_completed)] == rendered_completed
                     ):
                         probed_bounds[message_index] = (
-                            len(prefix),
-                            len(prefix),
+                            len(rendered_prefix),
+                            len(rendered_prefix),
                         )
                 continue
             if any(part == "tool_call" for part, _ in parts):
@@ -3954,9 +3989,13 @@ def _tokenize_chat_view(
                 except Exception:
                     prefix = []
                 local = part_ids(parts[0][1])
-                if rendered == [*prefix, *local]:
+                rendered_prefix = canonical_render_to_rendered(prefix)
+                if rendered_prefix is not None and rendered == [
+                    *rendered_prefix,
+                    *local,
+                ]:
                     probed_bounds[message_index] = (
-                        len(prefix),
+                        len(rendered_prefix),
                         len(rendered),
                     )
                     continue
@@ -3967,13 +4006,16 @@ def _tokenize_chat_view(
                     )
                 except Exception:
                     completed = []
+                rendered_completed = canonical_render_to_rendered(completed)
                 if (
                     completed == [*prefix, *local]
-                    and rendered[: len(completed)] == completed
+                    and rendered_prefix is not None
+                    and rendered_completed is not None
+                    and rendered[: len(rendered_completed)] == rendered_completed
                 ):
                     probed_bounds[message_index] = (
-                        len(prefix),
-                        len(completed),
+                        len(rendered_prefix),
+                        len(rendered_completed),
                     )
                     continue
             probe_messages = deepcopy(messages)
@@ -4042,21 +4084,29 @@ def _tokenize_chat_view(
                 marked_part_bounds.pop(message_index, None)
                 prefix = completed = None
 
-            def matches_rendered_prefix(probe: Sequence[int]) -> bool:
-                return rendered[: len(probe)] == list(probe) or bool(
-                    exact_prefix_length
-                    and len(probe) >= exact_prefix_length
-                    and rendered[exact_prefix_length : len(probe)]
-                    == list(probe[exact_prefix_length:])
-                )
-
+            rendered_prefix = (
+                canonical_render_to_rendered(prefix) if prefix is not None else None
+            )
+            rendered_completed = (
+                canonical_render_to_rendered(completed)
+                if completed is not None
+                else None
+            )
+            corrected_bounds = (
+                canonical_span_to_rendered(len(prefix), len(completed))
+                if prefix is not None and completed is not None
+                else None
+            )
             if (
                 prefix is not None
                 and completed is not None
-                and matches_rendered_prefix(prefix)
-                and matches_rendered_prefix(completed)
+                and rendered_prefix is not None
+                and rendered_completed is not None
+                and corrected_bounds is not None
+                and rendered[: len(rendered_prefix)] == rendered_prefix
+                and rendered[: len(rendered_completed)] == rendered_completed
             ):
-                marked_bounds[message_index] = (len(prefix), len(completed))
+                marked_bounds[message_index] = corrected_bounds
                 # The marker-derived per-part offsets describe the old render.
                 marked_part_bounds.pop(message_index, None)
             else:
@@ -4093,15 +4143,20 @@ def _tokenize_chat_view(
                     prompt_render = probe_render(
                         messages[:message_index], add_generation_prompt=True
                     )
+                    rendered_prompt = (
+                        canonical_render_to_rendered(prompt_render)
+                        if prompt_render is not None
+                        else None
+                    )
                     if (
-                        prompt_render is None
-                        or rendered[: len(prompt_render)] != prompt_render
+                        rendered_prompt is None
+                        or rendered[: len(rendered_prompt)] != rendered_prompt
                     ):
                         raise ValueError(
                             "Could not locate a sampled history message in the "
                             "rendered history"
                         )
-                    generation_start = len(prompt_render)
+                    generation_start = len(rendered_prompt)
                     sampled_bounds = (generation_start, len(rendered))
                 else:
                     raise ValueError(

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -3400,15 +3400,17 @@ def _tokenize_chat_view(
             template = tokenizer_template
     if kwargs.get("preserve_thinking") is True:
         template = chat_template_with_preserved_thinking(template)
-    messages = normalize_tool_call_arguments_for_chat_template(messages, template)
     ends_with_assistant = bool(messages) and messages[-1].get("role") == "assistant"
 
     def render(
         selected_messages: list[dict[str, Any]], *, add_generation_prompt: bool
     ) -> list[int]:
+        render_messages = normalize_tool_call_arguments_for_chat_template(
+            selected_messages, template
+        )
         return _ids(
             resolved_tokenizer.apply_chat_template(
-                selected_messages,
+                render_messages,
                 tools=history.tools,
                 tokenize=True,
                 add_generation_prompt=add_generation_prompt,
@@ -3416,6 +3418,16 @@ def _tokenize_chat_view(
                 **kwargs,
             )
         )
+
+    def probe_render(
+        selected_messages: list[dict[str, Any]], *, add_generation_prompt: bool
+    ) -> list[int] | None:
+        try:
+            return render(
+                selected_messages, add_generation_prompt=add_generation_prompt
+            )
+        except Exception:
+            return None
 
     rendered = render(messages, add_generation_prompt=not ends_with_assistant)
     if any(
@@ -3429,21 +3441,24 @@ def _tokenize_chat_view(
         for message in without_reasoning:
             message.pop("reasoning", None)
         if (
-            render(
+            probe_render(
                 without_reasoning,
                 add_generation_prompt=not ends_with_assistant,
             )
             == rendered
         ):
-            messages = deepcopy(messages)
-            for message in messages:
+            aliased_messages = deepcopy(messages)
+            for message in aliased_messages:
                 reasoning = message.pop("reasoning", None)
                 if isinstance(reasoning, str) and reasoning:
                     message.setdefault("reasoning_content", reasoning)
-            rendered = render(
-                messages,
+            aliased_render = probe_render(
+                aliased_messages,
                 add_generation_prompt=not ends_with_assistant,
             )
+            if aliased_render is not None:
+                messages = aliased_messages
+                rendered = aliased_render
     if any(
         message.get("role") == "assistant"
         and isinstance(message.get("refusal"), str)
@@ -3454,14 +3469,14 @@ def _tokenize_chat_view(
         for message in without_refusals:
             message.pop("refusal", None)
         if (
-            render(
+            probe_render(
                 without_refusals,
                 add_generation_prompt=not ends_with_assistant,
             )
             == rendered
         ):
-            messages = deepcopy(messages)
-            for message in messages:
+            merged_messages = deepcopy(messages)
+            for message in merged_messages:
                 refusal = message.pop("refusal", None)
                 if not isinstance(refusal, str) or not refusal:
                     continue
@@ -3479,10 +3494,13 @@ def _tokenize_chat_view(
                     raise ValueError(
                         "Cannot render an assistant refusal with this content shape"
                     )
-            rendered = render(
-                messages,
+            merged_render = probe_render(
+                merged_messages,
                 add_generation_prompt=not ends_with_assistant,
             )
+            if merged_render is not None:
+                messages = merged_messages
+                rendered = merged_render
 
     prompt_cache: dict[int, list[int] | None] = {}
     output_cache: dict[int, tuple[list[int] | None, list[float]]] = {}
@@ -3524,10 +3542,13 @@ def _tokenize_chat_view(
                 continue
             source_prompt = source_prompt_tokens(source)
             if source_prompt and source_matches_context(source):
-                rendered_prompt = render(
+                rendered_prompt = probe_render(
                     messages[:message_index], add_generation_prompt=True
                 )
-                if rendered[: len(rendered_prompt)] == rendered_prompt:
+                if (
+                    rendered_prompt is not None
+                    and rendered[: len(rendered_prompt)] == rendered_prompt
+                ):
                     rendered = [
                         *source_prompt,
                         *rendered[len(rendered_prompt) :],
@@ -3669,14 +3690,16 @@ def _tokenize_chat_view(
         if markers:
             try:
                 marked_text = resolved_tokenizer.apply_chat_template(
-                    marked_messages,
+                    normalize_tool_call_arguments_for_chat_template(
+                        marked_messages, template
+                    ),
                     tools=history.tools,
                     tokenize=False,
                     add_generation_prompt=not ends_with_assistant,
                     **({"chat_template": template} if template is not None else {}),
                     **kwargs,
                 )
-            except (TypeError, NotImplementedError):
+            except Exception:
                 marked_text = None
             if isinstance(marked_text, str):
                 marker_pattern = re.compile(
@@ -3729,7 +3752,7 @@ def _tokenize_chat_view(
                         add_special_tokens=False,
                         return_offsets_mapping=True,
                     )
-                except (TypeError, NotImplementedError):
+                except Exception:
                     encoded = None
                 encoded_data = _string_dict(encoded)
                 raw_offsets = (
@@ -4064,10 +4087,13 @@ def _tokenize_chat_view(
                     generation_start = len(source_prompt)
                     sampled_bounds = (generation_start, len(rendered))
                 elif sampled_message_count == 1:
-                    prompt_render = render(
+                    prompt_render = probe_render(
                         messages[:message_index], add_generation_prompt=True
                     )
-                    if rendered[: len(prompt_render)] != prompt_render:
+                    if (
+                        prompt_render is None
+                        or rendered[: len(prompt_render)] != prompt_render
+                    ):
                         raise ValueError(
                             "Could not locate a sampled history message in the "
                             "rendered history"

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -3899,50 +3899,30 @@ def _tokenize_chat_view(
                             len(prefix),
                         )
                 continue
-            if parts and all(part == "tool_call" for part, _ in parts):
+            if any(part == "tool_call" for part, _ in parts):
                 probe_messages = deepcopy(messages)
-                tool_calls = probe_messages[message_index].get("tool_calls")
-                if isinstance(tool_calls, list):
-                    existing_values: set[str] = set()
-                    for existing_call in tool_calls:
-                        if not isinstance(existing_call, dict):
-                            continue
-                        existing_function = existing_call.get("function")
-                        if isinstance(existing_function, dict):
-                            existing_values.update(
-                                value
-                                for value in existing_function.values()
-                                if isinstance(value, str)
-                            )
-                    for call_index, call in enumerate(tool_calls):
-                        if not isinstance(call, dict):
-                            continue
-                        raw_function = call.get("function")
-                        if not isinstance(raw_function, dict):
-                            continue
-                        function = cast(dict[str, Any], raw_function)
-                        probe_name = (
-                            f"art_trajectory_probe_{id(probe_messages):x}_{call_index}"
+                for part_index, slots in enumerate(
+                    _chat_message_text_slot_groups(probe_messages[message_index])
+                ):
+                    for slot_index, (container, key) in enumerate(slots):
+                        original = str(container[key])
+                        leading = original[: len(original) - len(original.lstrip())]
+                        trailing = original[len(original.rstrip()) :]
+                        marker = (
+                            f"art_trajectory_probe_{id(probe_messages):x}_"
+                            f"{part_index}_{slot_index}"
                         )
-                        probe_arguments = json.dumps({probe_name: True})
-                        while (
-                            probe_name in existing_values
-                            or probe_arguments in existing_values
-                        ):
-                            probe_name += "_"
-                            probe_arguments = json.dumps({probe_name: True})
-                        function["name"] = probe_name
-                        function["arguments"] = probe_arguments
-                    try:
-                        probe = render(
-                            probe_messages,
-                            add_generation_prompt=not ends_with_assistant,
+                        replacement = (
+                            json.dumps({marker: True}) if key == "arguments" else marker
                         )
-                    except Exception:
-                        probe = []
-                    if span := differing_span(probe):
-                        probed_bounds[message_index] = span
-                        continue
+                        container[key] = leading + replacement + trailing
+                probe = probe_render(
+                    probe_messages,
+                    add_generation_prompt=not ends_with_assistant,
+                )
+                if probe is not None and (span := differing_span(probe)):
+                    probed_bounds[message_index] = span
+                    continue
             if len(parts) == 1:
                 try:
                     prefix = render(
@@ -4169,7 +4149,7 @@ def _tokenize_chat_view(
             and full_exact is None
             and message_index in probed_bounds
             and parts
-            and all(part == "tool_call" for part, _ in parts)
+            and any(part == "tool_call" for part, _ in parts)
         ):
             assert source is not None and sampled_bounds is not None
             start, end = sampled_bounds

--- a/src/art/utils/chat_template.py
+++ b/src/art/utils/chat_template.py
@@ -109,7 +109,7 @@ def normalize_tool_call_arguments_for_chat_template(
             if isinstance(arguments, str):
                 assert isinstance(function, dict)
                 try:
-                    arguments = json.loads(arguments)
+                    arguments = json.loads(arguments) if arguments.strip() else {}
                 except json.JSONDecodeError as error:
                     raise ValueError(
                         "tool-call arguments are not valid JSON"

--- a/src/art/utils/chat_template.py
+++ b/src/art/utils/chat_template.py
@@ -63,17 +63,22 @@ def merge_chat_template_kwargs(
 def _template_requires_structured_tool_arguments(chat_template: object) -> bool:
     if not isinstance(chat_template, str):
         return False
-    if re.search(r"\barguments\s*\|\s*items\b", chat_template):
+    arguments_access = (
+        r"(?:\b(?:tool_call|tc)\s*\.\s*(?:function\s*\.\s*)?arguments\b"
+        r"|(?<![.\w])arguments\b)"
+    )
+    if re.search(rf"{arguments_access}\s*\|\s*items\b", chat_template):
         return True
-    if re.search(r"\barguments\s*\.\s*items\s*\(", chat_template):
+    if re.search(rf"{arguments_access}\s*\.\s*items\s*\(", chat_template):
         return True
     aliases = re.findall(
-        r"{%[-+]?\s*set\s+([A-Za-z_]\w*)\s*=\s*[^%]*\barguments\b[^%]*[-+]?%}",
+        r"{%[-+]?\s*set\s+([A-Za-z_]\w*)\s*=\s*([^%]*)[-+]?%}",
         chat_template,
     )
     return any(
-        re.search(rf"\b{re.escape(alias)}\s*\.\s*items\s*\(", chat_template)
-        for alias in aliases
+        re.search(arguments_access, expression)
+        and re.search(rf"\b{re.escape(alias)}\s*\.\s*items\s*\(", chat_template)
+        for alias, expression in aliases
     )
 
 

--- a/src/art/utils/chat_template.py
+++ b/src/art/utils/chat_template.py
@@ -1,9 +1,36 @@
+import json
 from typing import Any
 
 THINKING_CHAT_TEMPLATE_KWARGS: dict[str, Any] = {
     "enable_thinking": False,
     "preserve_thinking": True,
 }
+_QWEN_DROP_PRIOR_THINKING = "{%- if loop.index0 > ns.last_query_index %}"
+_QWEN_PRESERVE_PRIOR_THINKING = (
+    "{%- if (preserve_thinking is defined and preserve_thinking is true) or "
+    "(loop.index0 > ns.last_query_index) %}"
+)
+
+
+def chat_template_with_preserved_thinking(chat_template: object) -> object:
+    """Add Qwen's newer opt-in prior-turn reasoning gate to older templates."""
+    if (
+        not isinstance(chat_template, str)
+        or "enable_thinking" not in chat_template
+        or chat_template.count(_QWEN_DROP_PRIOR_THINKING) != 1
+    ):
+        return chat_template
+    return chat_template.replace(
+        _QWEN_DROP_PRIOR_THINKING, _QWEN_PRESERVE_PRIOR_THINKING
+    )
+
+
+def configure_preserved_thinking_chat_template(tokenizer: object) -> object:
+    chat_template = getattr(tokenizer, "chat_template", None)
+    configured = chat_template_with_preserved_thinking(chat_template)
+    if configured != chat_template:
+        setattr(tokenizer, "chat_template", configured)
+    return tokenizer
 
 
 def default_chat_template_kwargs_for_template(
@@ -30,3 +57,50 @@ def merge_chat_template_kwargs(
     overrides: dict[str, Any] | None,
 ) -> dict[str, Any]:
     return {**(defaults or {}), **(overrides or {})}
+
+
+def _template_requires_structured_tool_arguments(chat_template: object) -> bool:
+    if not isinstance(chat_template, str):
+        return False
+    if "arguments|items" in chat_template.replace(" ", ""):
+        return True
+    return "arguments" in chat_template and ".items(" in chat_template
+
+
+def normalize_tool_call_arguments_for_chat_template(
+    messages: list[dict[str, Any]],
+    chat_template: object,
+) -> list[dict[str, Any]]:
+    """Give chat templates the structured tool arguments they require.
+
+    Templates that interpolate the raw JSON string must keep string arguments,
+    so only templates that iterate structured arguments trigger normalization.
+    """
+    if not _template_requires_structured_tool_arguments(chat_template):
+        return messages
+    normalized: list[dict[str, Any]] = []
+    for message in messages:
+        calls = message.get("tool_calls")
+        if not isinstance(calls, list):
+            normalized.append(message)
+            continue
+        normalized_calls = []
+        for call in calls:
+            function = call.get("function") if isinstance(call, dict) else None
+            arguments = (
+                function.get("arguments") if isinstance(function, dict) else None
+            )
+            if isinstance(arguments, str):
+                assert isinstance(function, dict)
+                try:
+                    arguments = json.loads(arguments)
+                except json.JSONDecodeError as error:
+                    raise ValueError(
+                        "tool-call arguments are not valid JSON"
+                    ) from error
+                if not isinstance(arguments, dict):
+                    raise ValueError("tool-call arguments must decode to a JSON object")
+                call = {**call, "function": {**function, "arguments": arguments}}
+            normalized_calls.append(call)
+        normalized.append({**message, "tool_calls": normalized_calls})
+    return normalized

--- a/src/art/utils/chat_template.py
+++ b/src/art/utils/chat_template.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Any
 
 THINKING_CHAT_TEMPLATE_KWARGS: dict[str, Any] = {
@@ -62,9 +63,18 @@ def merge_chat_template_kwargs(
 def _template_requires_structured_tool_arguments(chat_template: object) -> bool:
     if not isinstance(chat_template, str):
         return False
-    if "arguments|items" in chat_template.replace(" ", ""):
+    if re.search(r"\barguments\s*\|\s*items\b", chat_template):
         return True
-    return "arguments" in chat_template and ".items(" in chat_template
+    if re.search(r"\barguments\s*\.\s*items\s*\(", chat_template):
+        return True
+    aliases = re.findall(
+        r"{%[-+]?\s*set\s+([A-Za-z_]\w*)\s*=\s*[^%]*\barguments\b[^%]*[-+]?%}",
+        chat_template,
+    )
+    return any(
+        re.search(rf"\b{re.escape(alias)}\s*\.\s*items\s*\(", chat_template)
+        for alias in aliases
+    )
 
 
 def normalize_tool_call_arguments_for_chat_template(

--- a/src/art/utils/chat_template.py
+++ b/src/art/utils/chat_template.py
@@ -64,7 +64,8 @@ def _template_requires_structured_tool_arguments(chat_template: object) -> bool:
     if not isinstance(chat_template, str):
         return False
     arguments_access = (
-        r"(?:\b(?:tool_call|tc)\s*\.\s*(?:function\s*\.\s*)?arguments\b"
+        r"(?:(?<![.\w])(?:tool_call|tc)\s*\.\s*"
+        r"(?:function\s*\.\s*)?arguments\b"
         r"|(?<![.\w])arguments\b)"
     )
     if re.search(rf"{arguments_access}\s*\|\s*items\b", chat_template):

--- a/tests/integration/megatron/model_support/test_compile_flags.py
+++ b/tests/integration/megatron/model_support/test_compile_flags.py
@@ -1,3 +1,7 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
 import torch
 from torch._dynamo.testing import CompileCounter
 
@@ -5,6 +9,7 @@ from art.megatron.model_support.handlers.gemma4 import (
     GEMMA4_DENSE_HANDLER,
     GEMMA4_MOE_HANDLER,
 )
+from art.megatron.training import compile as compile_module
 from art.megatron.training.compile import _configure_dynamo
 
 
@@ -50,6 +55,31 @@ def test_dynamic_projection_parameters_reuse_compiled_graph() -> None:
         )
     finally:
         torch._dynamo.reset()
+
+
+def test_disabled_training_compile_does_not_change_dynamo_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SimpleNamespace(
+        disable_compile=False,
+        flags=(),
+        unconditional_flags=(),
+    )
+    bundle = SimpleNamespace(
+        handler=SimpleNamespace(
+            compile_workaround_config=lambda _provider: config,
+        )
+    )
+    monkeypatch.setattr(compile_module, "compile_enabled", lambda: False)
+    monkeypatch.setattr(
+        compile_module,
+        "_configure_dynamo",
+        lambda: pytest.fail("disabled compilation must not mutate Dynamo config"),
+    )
+
+    assert not compile_module.configure_training_compile(
+        model=[], provider=object(), provider_bundle=cast(Any, bundle)
+    )
 
 
 def test_gemma4_wide_global_attention_uses_lower_triton_stage_count() -> None:

--- a/tests/integration/megatron/model_support/test_compile_flags.py
+++ b/tests/integration/megatron/model_support/test_compile_flags.py
@@ -1,7 +1,55 @@
+import torch
+from torch._dynamo.testing import CompileCounter
+
 from art.megatron.model_support.handlers.gemma4 import (
     GEMMA4_DENSE_HANDLER,
     GEMMA4_MOE_HANDLER,
 )
+from art.megatron.training.compile import _configure_dynamo
+
+
+class _DynamicProjection(torch.nn.Module):
+    def __init__(self, width: int) -> None:
+        super().__init__()
+        self.a = torch.nn.Parameter(torch.randn(2, 4))
+        self.b = torch.nn.Parameter(torch.randn(4, width))
+
+    @torch.compiler.disable
+    def active_parameters(
+        self,
+    ) -> tuple[torch.nn.Parameter, torch.nn.Parameter]:
+        return self.a, self.b
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        a, b = self.active_parameters()
+        return (value @ a) @ b
+
+
+def test_dynamic_projection_parameters_reuse_compiled_graph() -> None:
+    torch._dynamo.reset()
+    counter = CompileCounter()
+    try:
+        with torch._dynamo.config.patch(
+            force_parameter_static_shapes=True, recompile_limit=32
+        ):
+            _configure_dynamo()
+            assert not torch._dynamo.config.force_parameter_static_shapes
+            compiled = [
+                torch.compile(_DynamicProjection(width), backend=counter)
+                for width in (8, 4, 16, 32, 12, 20, 24, 28, 36, 40)
+            ]
+            outputs = [projection(torch.ones(1, 2)) for projection in compiled]
+        assert [tuple(output.shape) for output in outputs] == [
+            (1, projection.b.shape[1]) for projection in compiled
+        ]
+        assert counter.frame_count <= 2
+        sum(output.sum() for output in outputs).backward()
+        assert all(
+            projection.a.grad is not None and projection.b.grad is not None
+            for projection in compiled
+        )
+    finally:
+        torch._dynamo.reset()
 
 
 def test_gemma4_wide_global_attention_uses_lower_triton_stage_count() -> None:

--- a/tests/unit/test_local_sft.py
+++ b/tests/unit/test_local_sft.py
@@ -9,6 +9,7 @@ import torch
 
 from art import TrainableModel, Trajectory
 from art.local import LocalBackend
+from art.local.backend import _apply_configured_chat_template_server_args
 from art.preprocessing.tokenize import SFTBatch
 from art.types import TrainSFTConfig
 
@@ -20,6 +21,52 @@ def _trajectory(content: str) -> Trajectory:
             {"role": "assistant", "content": content},
         ]
     )
+
+
+def test_qwen_rollout_server_uses_preserve_thinking_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    template = (
+        "{% if enable_thinking %}think{% endif %}"
+        "{%- if loop.index0 > ns.last_query_index %}reasoning{% endif %}"
+    )
+    tokenizer = type("Tokenizer", (), {"chat_template": template})()
+    monkeypatch.setattr(
+        "art.local.backend._model_support_default_chat_template",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        "art.local.backend.AutoTokenizer.from_pretrained",
+        lambda _model: tokenizer,
+    )
+    config: dict[str, Any] = {}
+
+    _apply_configured_chat_template_server_args(
+        config, {}, base_model="Qwen/Qwen3.5-4B"
+    )
+
+    configured = config["server_args"]["chat_template"]
+    assert "preserve_thinking is defined and preserve_thinking is true" in configured
+
+
+def test_non_qwen_rollout_server_does_not_load_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "art.local.backend._model_support_default_chat_template",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        "art.local.backend.AutoTokenizer.from_pretrained",
+        lambda _model: pytest.fail("non-Qwen templates should not be loaded eagerly"),
+    )
+    config: dict[str, Any] = {}
+
+    _apply_configured_chat_template_server_args(
+        config, {}, base_model="meta-llama/Llama-3.1-8B-Instruct"
+    )
+
+    assert config == {}
 
 
 @contextmanager

--- a/tests/unit/test_local_sft.py
+++ b/tests/unit/test_local_sft.py
@@ -23,8 +23,10 @@ def _trajectory(content: str) -> Trajectory:
     )
 
 
+@pytest.mark.parametrize("base_model", ("Qwen/Qwen3.5-4B", "unsloth/Qwen3-4B"))
 def test_qwen_rollout_server_uses_preserve_thinking_template(
     monkeypatch: pytest.MonkeyPatch,
+    base_model: str,
 ) -> None:
     template = (
         "{% if enable_thinking %}think{% endif %}"
@@ -41,9 +43,7 @@ def test_qwen_rollout_server_uses_preserve_thinking_template(
     )
     config: dict[str, Any] = {}
 
-    _apply_configured_chat_template_server_args(
-        config, {}, base_model="Qwen/Qwen3.5-4B"
-    )
+    _apply_configured_chat_template_server_args(config, {}, base_model=base_model)
 
     configured = config["server_args"]["chat_template"]
     assert "preserve_thinking is defined and preserve_thinking is true" in configured
@@ -98,11 +98,11 @@ def test_qwen_template_load_failure_is_a_warned_fallback(
     )
     monkeypatch.setattr(
         "art.local.backend.AutoTokenizer.from_pretrained",
-        lambda _model: (_ for _ in ()).throw(OSError("offline")),
+        lambda _model: (_ for _ in ()).throw(ValueError("bad tokenizer")),
     )
     config: dict[str, Any] = {}
 
-    with pytest.warns(RuntimeWarning, match="offline"):
+    with pytest.warns(RuntimeWarning, match="bad tokenizer"):
         _apply_configured_chat_template_server_args(
             config, {}, base_model="Qwen/Qwen3.5-4B"
         )

--- a/tests/unit/test_local_sft.py
+++ b/tests/unit/test_local_sft.py
@@ -69,6 +69,47 @@ def test_non_qwen_rollout_server_does_not_load_template(
     assert config == {}
 
 
+def test_explicit_server_template_avoids_tokenizer_loading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "art.local.backend._model_support_default_chat_template",
+        lambda *_args: pytest.fail("explicit template should win before model support"),
+    )
+    monkeypatch.setattr(
+        "art.local.backend.AutoTokenizer.from_pretrained",
+        lambda _model: pytest.fail("explicit template should avoid hub access"),
+    )
+    config: dict[str, Any] = {"server_args": {"chat_template": "explicit"}}
+
+    _apply_configured_chat_template_server_args(
+        config, {}, base_model="Qwen/Qwen3.5-4B"
+    )
+
+    assert config == {"server_args": {"chat_template": "explicit"}}
+
+
+def test_qwen_template_load_failure_is_a_warned_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "art.local.backend._model_support_default_chat_template",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        "art.local.backend.AutoTokenizer.from_pretrained",
+        lambda _model: (_ for _ in ()).throw(OSError("offline")),
+    )
+    config: dict[str, Any] = {}
+
+    with pytest.warns(RuntimeWarning, match="offline"):
+        _apply_configured_chat_template_server_args(
+            config, {}, base_model="Qwen/Qwen3.5-4B"
+        )
+
+    assert config == {}
+
+
 @contextmanager
 def _local_sft_patches(
     backend: LocalBackend,

--- a/tests/unit/test_model_openai_client_costs.py
+++ b/tests/unit/test_model_openai_client_costs.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 
-from art import TrainableModel
+from art import Model, TrainableModel
 from art.costs import build_cost_calculator, get_model_pricing
 from art.model import _OpenAIChatCompletionsProxy
 
@@ -226,4 +226,34 @@ class TestModelOpenAIClientCosts:
             "return_token_ids": True,
             "return_tokens_as_token_ids": True,
             "chat_template_kwargs": {"preserve_thinking": True},
+        }
+
+    def test_art_managed_model_preserves_prior_thinking_by_default(self) -> None:
+        model = Model(name="test-model", project="test-project")
+        object.__setattr__(model, "_internal_config", {})
+
+        assert model._default_chat_completion_extra_body() == {
+            "chat_template_kwargs": {"preserve_thinking": True}
+        }
+
+    def test_unmanaged_model_does_not_receive_template_kwargs(self) -> None:
+        model = Model(name="test-model", project="test-project")
+
+        assert model._default_chat_completion_extra_body() is None
+
+    def test_configured_preserve_thinking_false_overrides_managed_default(
+        self,
+    ) -> None:
+        model = TrainableModel(
+            run_name="test-run",
+            name="test-run",
+            project="test-project",
+            base_model="test-model",
+            _internal_config={"chat_template_kwargs": {"preserve_thinking": False}},
+        )
+
+        assert model._default_chat_completion_extra_body() == {
+            "return_token_ids": True,
+            "return_tokens_as_token_ids": True,
+            "chat_template_kwargs": {"preserve_thinking": False},
         }

--- a/tests/unit/test_model_openai_client_costs.py
+++ b/tests/unit/test_model_openai_client_costs.py
@@ -213,3 +213,17 @@ class TestModelOpenAIClientCosts:
                 "preserve_thinking": True,
             },
         }
+
+    def test_trainable_model_preserves_prior_thinking_by_default(self) -> None:
+        model = TrainableModel(
+            run_name="test-run",
+            name="test-run",
+            project="test-project",
+            base_model="test-model",
+        )
+
+        assert model._default_chat_completion_extra_body() == {
+            "return_token_ids": True,
+            "return_tokens_as_token_ids": True,
+            "chat_template_kwargs": {"preserve_thinking": True},
+        }

--- a/tests/unit/test_preprocessing_tokenize.py
+++ b/tests/unit/test_preprocessing_tokenize.py
@@ -23,10 +23,13 @@ pytest.importorskip("transformers")
     (
         "{{ tool_call.arguments | items }}",
         "{% for key, value in tool_call.arguments.items() %}",
+        "{{ arguments | items }}",
+        "{% for key, value in arguments.items() %}",
         (
             "{% set structured = tool_call.arguments %}"
             "{% for key, value in structured.items() %}"
         ),
+        "{% set structured = tc.arguments %}{{ structured.items() }}",
     ),
 )
 def test_structured_tool_argument_templates_are_normalized(template: str) -> None:
@@ -51,12 +54,30 @@ def test_unrelated_items_iteration_does_not_normalize_tool_arguments() -> None:
     ]
     gpt_oss_style = (
         "{% for name, schema in tools.items() %}{{ name }}{{ schema.arguments }}"
-        "{% endfor %}{{ tool_call.arguments }}"
+        "{{ schema.arguments|items }}{% endfor %}{{ tool_call.arguments }}"
     )
 
     normalized = normalize_tool_call_arguments_for_chat_template(
         messages, gpt_oss_style
     )
+
+    assert normalized is messages
+
+
+def test_schema_argument_alias_does_not_normalize_tool_arguments() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"function": {"name": "lookup", "arguments": '{"id": 3}'}}],
+        }
+    ]
+    schema_style = (
+        "{% set structured = tool.parameters.arguments %}"
+        "{% for key, value in structured.items() %}{{ key }}{{ value }}{% endfor %}"
+        "{{ tool_call.arguments }}"
+    )
+
+    normalized = normalize_tool_call_arguments_for_chat_template(messages, schema_style)
 
     assert normalized is messages
 

--- a/tests/unit/test_preprocessing_tokenize.py
+++ b/tests/unit/test_preprocessing_tokenize.py
@@ -45,6 +45,21 @@ def test_structured_tool_argument_templates_are_normalized(template: str) -> Non
     assert normalized[0]["tool_calls"][0]["function"]["arguments"] == {"id": 3}
 
 
+def test_empty_structured_tool_arguments_are_normalized() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"function": {"name": "lookup", "arguments": ""}}],
+        }
+    ]
+
+    normalized = normalize_tool_call_arguments_for_chat_template(
+        messages, "{{ tool_call.arguments | items }}"
+    )
+
+    assert normalized[0]["tool_calls"][0]["function"]["arguments"] == {}
+
+
 def test_unrelated_items_iteration_does_not_normalize_tool_arguments() -> None:
     messages = [
         {

--- a/tests/unit/test_preprocessing_tokenize.py
+++ b/tests/unit/test_preprocessing_tokenize.py
@@ -11,10 +11,54 @@ from art.types import MessagesAndChoices, TrainSFTConfig
 from art.utils.chat_template import (
     chat_template_with_preserved_thinking,
     default_chat_template_kwargs_for_template,
+    normalize_tool_call_arguments_for_chat_template,
 )
 
 pytest.importorskip("torch")
 pytest.importorskip("transformers")
+
+
+@pytest.mark.parametrize(
+    "template",
+    (
+        "{{ tool_call.arguments | items }}",
+        "{% for key, value in tool_call.arguments.items() %}",
+        (
+            "{% set structured = tool_call.arguments %}"
+            "{% for key, value in structured.items() %}"
+        ),
+    ),
+)
+def test_structured_tool_argument_templates_are_normalized(template: str) -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"function": {"name": "lookup", "arguments": '{"id": 3}'}}],
+        }
+    ]
+
+    normalized = normalize_tool_call_arguments_for_chat_template(messages, template)
+
+    assert normalized[0]["tool_calls"][0]["function"]["arguments"] == {"id": 3}
+
+
+def test_unrelated_items_iteration_does_not_normalize_tool_arguments() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"function": {"name": "lookup", "arguments": '{"id": 3}'}}],
+        }
+    ]
+    gpt_oss_style = (
+        "{% for name, schema in tools.items() %}{{ name }}{{ schema.arguments }}"
+        "{% endfor %}{{ tool_call.arguments }}"
+    )
+
+    normalized = normalize_tool_call_arguments_for_chat_template(
+        messages, gpt_oss_style
+    )
+
+    assert normalized is messages
 
 
 class _FakeTokenizer:

--- a/tests/unit/test_preprocessing_tokenize.py
+++ b/tests/unit/test_preprocessing_tokenize.py
@@ -8,6 +8,10 @@ from transformers.tokenization_utils_base import BatchEncoding
 from art.preprocessing.tokenize import tokenize_sft_batch
 from art.trajectories import Trajectory
 from art.types import MessagesAndChoices, TrainSFTConfig
+from art.utils.chat_template import (
+    chat_template_with_preserved_thinking,
+    default_chat_template_kwargs_for_template,
+)
 
 pytest.importorskip("torch")
 pytest.importorskip("transformers")
@@ -166,6 +170,34 @@ class _NonPrefixStableTokenizer(_LastAssistantTokenizer):
         ):
             return f"<changed>{rendered}"
         return rendered
+
+
+def test_legacy_qwen_template_gains_opt_in_thinking_preservation() -> None:
+    template = (
+        "{% if enable_thinking %}think{% endif %}"
+        "{%- if loop.index0 > ns.last_query_index %}reasoning{% endif %}"
+    )
+
+    configured = chat_template_with_preserved_thinking(template)
+
+    assert isinstance(configured, str)
+    assert "preserve_thinking is defined and preserve_thinking is true" in configured
+    assert default_chat_template_kwargs_for_template(configured) == {
+        "enable_thinking": False,
+        "preserve_thinking": True,
+    }
+
+
+def test_native_or_unrecognized_thinking_templates_are_unchanged() -> None:
+    native = (
+        "{% if enable_thinking %}think{% endif %}"
+        "{%- if (preserve_thinking is defined and preserve_thinking is true) or "
+        "(loop.index0 > ns.last_query_index) %}reasoning{% endif %}"
+    )
+    unrelated = "{%- if loop.index0 > ns.last_query_index %}content{% endif %}"
+
+    assert chat_template_with_preserved_thinking(native) == native
+    assert chat_template_with_preserved_thinking(unrelated) == unrelated
 
 
 def test_tokenize_sft_batch_masks_response_tokens_without_unsloth_import() -> None:

--- a/tests/unit/test_preprocessing_tokenize.py
+++ b/tests/unit/test_preprocessing_tokenize.py
@@ -82,6 +82,28 @@ def test_schema_argument_alias_does_not_normalize_tool_arguments() -> None:
     assert normalized is messages
 
 
+@pytest.mark.parametrize(
+    "schema_style",
+    (
+        "{{ schema.tool_call.arguments | items }}",
+        ("{% set structured = schema.tool_call.arguments %}{{ structured.items() }}"),
+    ),
+)
+def test_nested_schema_tool_call_arguments_do_not_trigger_normalization(
+    schema_style: str,
+) -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"function": {"arguments": '{"id": 3}'}}],
+        }
+    ]
+
+    normalized = normalize_tool_call_arguments_for_chat_template(messages, schema_style)
+
+    assert normalized is messages
+
+
 class _FakeTokenizer:
     chat_template = ""
     eos_token = "\x00"
@@ -251,6 +273,37 @@ def test_legacy_qwen_template_gains_opt_in_thinking_preservation() -> None:
         "enable_thinking": False,
         "preserve_thinking": True,
     }
+
+
+def test_legacy_qwen_template_renders_prior_reasoning_when_preserved() -> None:
+    import jinja2
+
+    legacy = (
+        "{% set _enable = enable_thinking | default(false) %}"
+        "{% set ns = namespace(last_query_index=2) %}"
+        "{% for message in messages %}"
+        "{%- if loop.index0 > ns.last_query_index %}"
+        "{{ message.reasoning | default('') }}"
+        "{% endif %}{{ message.content }}"
+        "{% endfor %}"
+    )
+    configured = chat_template_with_preserved_thinking(legacy)
+    assert isinstance(configured, str)
+    messages = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "reasoning": "prior-thought", "content": "first"},
+        {"role": "user", "content": "two"},
+        {"role": "assistant", "reasoning": "current-thought", "content": "second"},
+    ]
+
+    rendered = (
+        jinja2.Environment()
+        .from_string(configured)
+        .render(messages=messages, preserve_thinking=True)
+    )
+
+    assert "prior-thought" in rendered
+    assert "current-thought" in rendered
 
 
 def test_native_or_unrecognized_thinking_templates_are_unchanged() -> None:

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -303,6 +303,13 @@ async def test_rollout_supports_string_model_args(
 
     assert trajectory.reward == 1.0
     assert trajectory.metrics["cost/user"] == 0.25
+    assert trajectory.metrics["latency/environment_startup"] >= 0
+    assert trajectory.metrics["latency/policy"] >= 0
+    assert trajectory.metrics["latency/policy_max"] >= 0
+    assert trajectory.metrics["latency/environment"] >= 0
+    assert trajectory.metrics["latency/active"] >= 0
+    assert trajectory.metrics["tokens/prompt"] == 10
+    assert trajectory.metrics["tokens/completion"] == 5
     assert client.deleted == ["env-1"]
     assert client.create_kwargs["user_llm"] == "gpt-4.1-2025-04-14"
 

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -11,7 +11,7 @@ import json
 from pathlib import Path
 import threading
 import time
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -42,12 +42,14 @@ from art.trainer_rank._checkpoint import (
     _manifest_digest,
     _merge_component,
     _PreparedSave,
+    _slot_snapshot,
     _validate_save_state,
     abort_checkpoint_save,
     finish_checkpoint_save,
     materialize_lora,
     prepare_checkpoint,
     prepare_checkpoint_save,
+    validate_checkpoint,
 )
 from art.trainer_rank._impl import (
     _anchor_disconnected_outputs,
@@ -1024,7 +1026,9 @@ def test_checkpoint_save_rejects_accumulated_gradients() -> None:
         _validate_save_state(trainer, "student")
 
 
-def _canonical_checkpoint(root: Path) -> CheckpointManifest:
+def _canonical_checkpoint(
+    root: Path, *, with_optimizer: bool = True
+) -> CheckpointManifest:
     from safetensors.torch import save_file
 
     root.mkdir()
@@ -1038,24 +1042,29 @@ def _canonical_checkpoint(root: Path) -> CheckpointManifest:
     (root / "adapter_config.json").write_text(json.dumps(config))
     key = "layer.q_proj.lora_A.weight"
     save_file({key: torch.ones(1, 2)}, root / "adapter_model.safetensors")
-    (root / "optimizer").mkdir()
     files = []
-    for component in ("master", "exp_avg", "exp_avg_sq"):
-        relative = f"optimizer/{component}.safetensors"
-        save_file({key: torch.ones(1, 2)}, root / relative)
-        files.append(relative)
+    if with_optimizer:
+        (root / "optimizer").mkdir()
+        for component in ("master", "exp_avg", "exp_avg_sq"):
+            relative = f"optimizer/{component}.safetensors"
+            save_file({key: torch.ones(1, 2)}, root / relative)
+            files.append(relative)
     manifest: CheckpointManifest = {
         "format_version": 1,
         "base_model_name_or_path": "test/model",
-        "optimizer": OptimizerConfig(
-            learning_rate=1e-3,
-            beta1=0.9,
-            beta2=0.99,
-            eps=1e-8,
-            weight_decay=0.1,
+        "optimizer": (
+            OptimizerConfig(
+                learning_rate=1e-3,
+                beta1=0.9,
+                beta2=0.99,
+                eps=1e-8,
+                weight_decay=0.1,
+            )
+            if with_optimizer
+            else None
         ),
-        "parameters": {key: files},
-        "steps": {key: 3.0},
+        "parameters": {key: files} if with_optimizer else {},
+        "steps": {key: 3.0} if with_optimizer else {},
         "files": {},
         "digest": "",
     }
@@ -1066,6 +1075,96 @@ def _canonical_checkpoint(root: Path) -> CheckpointManifest:
     manifest["digest"] = _manifest_digest(manifest)
     (root / "checkpoint.json").write_text(json.dumps(manifest))
     return manifest
+
+
+def test_weights_only_checkpoint_validation_is_canonical(tmp_path: Path) -> None:
+    root = tmp_path / "checkpoint"
+    manifest = _canonical_checkpoint(root, with_optimizer=False)
+
+    assert validate_checkpoint(root) == manifest
+    with pytest.raises(RuntimeError, match="does not contain optimizer state"):
+        validate_checkpoint(root, require_optimizer=True)
+
+
+def test_weights_only_load_replaces_stale_optimizer_and_recreates_it_lazily(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from art.trainer_rank import _checkpoint as checkpoint_module
+
+    root = tmp_path / "checkpoint"
+    _canonical_checkpoint(root, with_optimizer=False)
+    source = prepare_checkpoint(str(root))
+    assert source.manifest is not None and source.manifest["optimizer"] is None
+
+    trainer = TrainerRank(_runtime())
+    config = cast(Any, source.config)
+    old = torch.nn.Parameter(torch.zeros(1, 2))
+    trainer._checkpoint_slots["student"] = _CheckpointSlot((old,), config)
+    stale = trainer._dynamic_optimizer("student", AdamParams(learning_rate=1e-3))
+    replacement = torch.nn.Parameter(torch.ones(1, 2))
+    key = source.keys[0]
+    monkeypatch.setattr(
+        trainer, "_local_lora_adapter_templates", lambda: {key: replacement}
+    )
+    monkeypatch.setattr(trainer, "_load_checkpoint_slot", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr(
+        trainer,
+        "_validate_checkpoint_consistency",
+        lambda *_args: (replacement,),
+    )
+    monkeypatch.setattr(trainer, "_validate_loaded_checkpoint_config", lambda *_: None)
+    monkeypatch.setattr(checkpoint_module, "_slot_snapshot", lambda _trainer: ())
+    monkeypatch.setattr(checkpoint_module, "_commit_slot", lambda *_args: None)
+    monkeypatch.setattr(
+        checkpoint_module,
+        "_optimizer_state",
+        lambda *_args: pytest.fail("weights-only load read optimizer state"),
+    )
+
+    checkpoint_module.load_checkpoint(trainer, source, "student")
+
+    slot = trainer._checkpoint_slots["student"]
+    assert slot.params == (replacement,)
+    assert slot.optimizer is None
+    assert stale is not slot.optimizer
+
+    replacement.grad = torch.ones_like(replacement)
+    monkeypatch.setattr(
+        trainer,
+        "_reduce_dynamic_grads",
+        lambda params, **_kwargs: tuple(item.grad.float() for item in params),
+    )
+    result = trainer.optim_step(
+        checkpoints=["student"],
+        params=AdamParams(learning_rate=1e-3, weight_decay=0),
+    )
+
+    assert result["update_successful"] == 1
+    assert slot.optimizer is not None
+    assert slot.optimizer is not stale
+
+
+def test_checkpoint_snapshot_handles_existing_slot_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class LoRA(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            slot = torch.nn.Linear(1, 1)
+            slot.ref = object()  # type: ignore[attr-defined]
+            self._slot_keys = {slot.ref: "slot_0"}  # type: ignore[attr-defined]
+            self._slot_modules = torch.nn.ModuleDict({"slot_0": slot})
+
+    module = ModuleType("art.megatron.lora")
+    module.LoRA = LoRA  # type: ignore[attr-defined]
+    module.LoRASlotRef = object  # type: ignore[attr-defined]
+    monkeypatch.setitem(__import__("sys").modules, "art.megatron.lora", module)
+    lora = LoRA()
+
+    snapshot = _slot_snapshot(TrainerRank(_runtime(lora)))
+
+    assert len(snapshot) == 1
+    assert snapshot[0][3] == {"slot_0": lora._slot_modules["slot_0"].ref}  # type: ignore[attr-defined]
 
 
 @pytest.mark.parametrize(
@@ -1684,8 +1783,11 @@ def test_checkpoint_load_failure_is_collective_and_transactional(
 
 
 @pytest.mark.skipif(find_spec("megatron") is None, reason="requires Megatron")
-def test_real_checkpoint_codec_restores_exact_next_optimizer_step(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    "with_optimizer", (False, True), ids=("weights-only", "optimizer")
+)
+def test_real_checkpoint_codec_round_trips_with_optional_optimizer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, with_optimizer: bool
 ) -> None:
     from art.megatron import lora as lora_module
     from art.megatron.lora import LoRA
@@ -1736,9 +1838,10 @@ def test_real_checkpoint_codec_restores_exact_next_optimizer_step(
         return trainer
 
     original = make_trainer()
-    for parameter in original._checkpoint_slots["student"].params:
-        parameter.grad = torch.full_like(parameter, 0.25)
-    original.optim_step(params=adam)
+    if with_optimizer:
+        for parameter in original._checkpoint_slots["student"].params:
+            parameter.grad = torch.full_like(parameter, 0.25)
+        original.optim_step(params=adam)
     output = tmp_path / "exact"
     original.save_checkpoint(str(output), "student")
     original.save_checkpoint(str(output), "student")
@@ -1746,7 +1849,8 @@ def test_real_checkpoint_codec_restores_exact_next_optimizer_step(
     assert not (tmp_path / ".exact.reserved").exists()
     prepared = prepare_checkpoint(str(output))
     assert prepared.manifest is not None
-    assert prepared.manifest["optimizer"] is not None
+    assert validate_checkpoint(output) == prepared.manifest
+    assert (prepared.manifest["optimizer"] is not None) is with_optimizer
 
     restored_lora = LoRA("layer.q_proj", 3, 4, 2, 2, torch.float32, torch.device("cpu"))
     restored = TrainerRank(_runtime(restored_lora))
@@ -1756,6 +1860,9 @@ def test_real_checkpoint_codec_restores_exact_next_optimizer_step(
         lambda params, **_kwargs: tuple(item.grad.float() for item in params),
     )
     checkpoint_module.load_checkpoint(restored, prepared, "student")
+    assert (
+        restored._checkpoint_slots["student"].optimizer is not None
+    ) is with_optimizer
 
     for trainer in (original, restored):
         for parameter in trainer._checkpoint_slots["student"].params:

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -1151,13 +1151,13 @@ def test_checkpoint_snapshot_handles_existing_slot_refs(
         def __init__(self) -> None:
             super().__init__()
             slot = torch.nn.Linear(1, 1)
-            slot.ref = object()  # type: ignore[attr-defined]
+            setattr(slot, "ref", object())
             self._slot_keys = {slot.ref: "slot_0"}  # type: ignore[attr-defined]
             self._slot_modules = torch.nn.ModuleDict({"slot_0": slot})
 
     module = ModuleType("art.megatron.lora")
-    module.LoRA = LoRA  # type: ignore[attr-defined]
-    module.LoRASlotRef = object  # type: ignore[attr-defined]
+    setattr(module, "LoRA", LoRA)
+    setattr(module, "LoRASlotRef", object)
     monkeypatch.setitem(__import__("sys").modules, "art.megatron.lora", module)
     lora = LoRA()
 

--- a/tests/unit/trajectories/test_history.py
+++ b/tests/unit/trajectories/test_history.py
@@ -1544,6 +1544,45 @@ def test_chat_template_stripped_reasoning_splits_exact_histories() -> None:
         trajectory.tokenize()
 
 
+def test_chat_reasoning_retokenization_reconciles_when_text_is_preserved() -> None:
+    first = _chat([{"role": "user", "content": "one"}], "first")
+    first_data = first.response.model_dump(mode="python")
+    first_data["prompt_token_ids"] = [1]
+    first_data["choices"][0]["message"]["reasoning"] = "thought-one"
+    first_data["choices"][0]["token_ids"] = [2, 101]
+    first.response = ChatCompletion.model_validate(first_data)
+
+    second = _chat(
+        [
+            {"role": "user", "content": "one"},
+            {
+                "role": "assistant",
+                "content": "first",
+                "reasoning": "thought-one",
+            },
+            {"role": "user", "content": "two"},
+        ],
+        "second",
+        offset=1,
+    )
+    second_data = second.response.model_dump(mode="python")
+    second_data["prompt_token_ids"] = [1, 500, 3]
+    second_data["choices"][0]["token_ids"] = [4]
+    second.response = ChatCompletion.model_validate(second_data)
+    trajectory = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second])
+    )
+
+    assert len(trajectory.chat_completions_histories()) == 2
+    reconciled = trajectory.chat_completions_history(
+        reconcile_text_equivalent_tokenizations=True
+    )
+    source = reconciled.message_sources[1]
+    assert source is not None
+    assert source.exchange is first
+    assert source.choice_index == 0
+
+
 def test_chat_reasoning_split_does_not_reuse_divergent_sampled_source() -> None:
     first = _chat([{"role": "user", "content": "one"}], "first")
     first_data = first.response.model_dump(mode="python")

--- a/tests/unit/trajectories/test_history.py
+++ b/tests/unit/trajectories/test_history.py
@@ -1608,7 +1608,9 @@ def test_chat_reasoning_split_does_not_reuse_divergent_sampled_source() -> None:
         exchanges=TrajectoryExchanges(chat_completions=[first, second])
     )
 
-    histories = trajectory.chat_completions_histories()
+    histories = trajectory.chat_completions_histories(
+        reconcile_text_equivalent_tokenizations=True
+    )
 
     source = histories[1].message_sources[1]
     assert source is not None

--- a/tests/unit/trajectories/test_history.py
+++ b/tests/unit/trajectories/test_history.py
@@ -1583,6 +1583,45 @@ def test_chat_reasoning_retokenization_reconciles_when_text_is_preserved() -> No
     assert source.choice_index == 0
 
 
+def test_chat_reasoning_reconciliation_aliases_reasoning_content() -> None:
+    first = _chat([{"role": "user", "content": "one"}], "first")
+    first_data = first.response.model_dump(mode="python")
+    first_data["prompt_token_ids"] = [1]
+    first_data["choices"][0]["message"]["reasoning"] = "thought-one"
+    first_data["choices"][0]["token_ids"] = [2, 101]
+    first.response = ChatCompletion.model_validate(first_data)
+
+    second = _chat(
+        [
+            {"role": "user", "content": "one"},
+            {
+                "role": "assistant",
+                "content": "first",
+                "reasoning_content": "thought-one",
+            },
+            {"role": "user", "content": "two"},
+        ],
+        "second",
+        offset=1,
+    )
+    second_data = second.response.model_dump(mode="python")
+    second_data["prompt_token_ids"] = [1, 500, 3]
+    second_data["choices"][0]["token_ids"] = [4]
+    second.response = ChatCompletion.model_validate(second_data)
+    trajectory = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second])
+    )
+
+    reconciled = trajectory.chat_completions_history(
+        reconcile_text_equivalent_tokenizations=True
+    )
+
+    source = reconciled.message_sources[1]
+    assert source is not None
+    assert source.exchange is first
+    assert source.choice_index == 0
+
+
 def test_chat_reasoning_split_does_not_reuse_divergent_sampled_source() -> None:
     first = _chat([{"role": "user", "content": "one"}], "first")
     first_data = first.response.model_dump(mode="python")

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -3063,10 +3063,13 @@ def test_chat_rerender_normalizes_tool_arguments(arguments: object) -> None:
 
 
 @pytest.mark.parametrize("reasoning", (None, "think"), ids=("tool-only", "reasoning"))
+@pytest.mark.parametrize(
+    "exact_prompt", ([1], [900, 10]), ids=("shorter-prompt", "changed-prompt")
+)
 def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens(
-    reasoning: str | None,
+    reasoning: str | None, exact_prompt: list[int]
 ) -> None:
-    exchange = _chat_exchange([1], [2])
+    exchange = _chat_exchange(exact_prompt, [2])
     data = exchange.response.model_dump(mode="python")
     choice = data["choices"][0]
     choice.pop("token_ids")
@@ -3127,9 +3130,13 @@ def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens
     tokenized = history.tokenize(tokenizer=Tokenizer())
 
     sampled_tokens = [*([15, 16] if reasoning else []), 20, 25, 30, 31]
-    assert tokenized.tokens == [1, *sampled_tokens, 26]
-    assert tokenized.flags[1:-1] == [tr.TokenFlag.SAMPLED] * len(sampled_tokens)
-    assert all(math.isnan(value) for value in tokenized.logprobs[1:-1])
+    assert tokenized.tokens == [*exact_prompt, *sampled_tokens, 26]
+    assert tokenized.flags[: len(exact_prompt)] == [tr.TokenFlag.EXACT] * len(
+        exact_prompt
+    )
+    sampled = slice(len(exact_prompt), -1)
+    assert tokenized.flags[sampled] == [tr.TokenFlag.SAMPLED] * len(sampled_tokens)
+    assert all(math.isnan(value) for value in tokenized.logprobs[sampled])
 
 
 def test_reasoning_probe_failure_does_not_override_authoritative_render() -> None:
@@ -4933,6 +4940,23 @@ def test_empty_sampled_messages_need_no_content_boundary() -> None:
     ]
 
 
+def test_reasoning_only_choice_treats_empty_token_ids_as_missing() -> None:
+    from art.trajectories import _tokenize
+
+    exchange = _chat_exchange([], [])
+    data = exchange.response.model_dump(mode="python")
+    choice = data["choices"][0]
+    choice["logprobs"] = None
+    choice["message"] = {
+        "role": "assistant",
+        "reasoning": "unfinished thought",
+        "content": None,
+    }
+    parsed = ChatCompletion.model_validate(data).choices[0]
+
+    assert _tokenize._chat_choice_output_tokens(parsed)[0] is None
+
+
 def test_empty_sampled_message_inserts_exact_control_token() -> None:
     exchange = _chat_exchange([], [2])
     exchange.response.choices[0].message.content = ""
@@ -5088,6 +5112,23 @@ def test_renderer_reasoning_content_alias_preserves_reasoning() -> None:
         tr.TokenFlag.SAMPLED,
         tr.TokenFlag.SAMPLED,
     ]
+
+
+def test_nonstring_reasoning_uses_reasoning_content_slot() -> None:
+    from art.trajectories import _tokenize
+
+    message = {
+        "role": "assistant",
+        "reasoning": [{"type": "thinking", "thinking": "structured"}],
+        "reasoning_content": "think",
+        "content": "answer",
+    }
+
+    assert _tokenize._chat_message_parts(message) == [
+        ("reasoning", "think"),
+        ("content", "answer"),
+    ]
+    assert len(_tokenize._chat_message_text_slot_groups(message)) == 2
 
 
 def test_trimmed_render_preserves_authoritative_textual_logprob_tokens() -> None:

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -3062,6 +3062,94 @@ def test_chat_rerender_normalizes_tool_arguments(arguments: object) -> None:
     assert rendered_arguments == [{"id": 3}]
 
 
+def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens() -> (
+    None
+):
+    exchange = _chat_exchange([1], [2])
+    data = exchange.response.model_dump(mode="python")
+    choice = data["choices"][0]
+    choice.pop("token_ids")
+    choice["logprobs"] = None
+    choice["message"] = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": '{"x":1}'},
+            }
+        ],
+    }
+    exchange.response = ChatCompletion.model_validate(data)
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[exchange])
+    ).chat_completions_history()
+
+    class Tokenizer:
+        chat_template = "{% set args = tc.arguments %}{{ args.items() }}"
+
+        def __call__(self, text: str, **kwargs: object) -> list[int]:
+            del kwargs
+            return {"turn 0": [1], "lookup": [20], '{"x":1}': [30, 31]}[text]
+
+        def apply_chat_template(
+            self, messages: list[dict[str, Any]], **kwargs: object
+        ) -> list[int]:
+            del kwargs
+            if messages[-1]["role"] != "assistant":
+                return [1, 10]
+            function = messages[-1]["tool_calls"][0]["function"]
+            assert isinstance(function["arguments"], dict)
+            if function["name"] != "lookup":
+                return [1, 10, 98, 25, 99, 26]
+            return [1, 10, 20, 25, 30, 31, 26]
+
+    tokenized = history.tokenize(tokenizer=Tokenizer())
+
+    assert tokenized.tokens == [1, 20, 25, 30, 31, 26]
+    assert tokenized.flags[1:5] == [tr.TokenFlag.SAMPLED] * 4
+    assert all(math.isnan(value) for value in tokenized.logprobs[1:5])
+
+
+def test_reasoning_probe_failure_does_not_override_authoritative_render() -> None:
+    exchange = _chat_exchange([], [])
+    data = exchange.response.model_dump(mode="python")
+    choice = data["choices"][0]
+    choice.pop("prompt_token_ids")
+    choice.pop("token_ids")
+    choice["logprobs"] = None
+    choice["message"] = {
+        "role": "assistant",
+        "reasoning": "think",
+        "content": "answer",
+    }
+    exchange.response = ChatCompletion.model_validate(data)
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[exchange])
+    ).chat_completions_history()
+
+    class Tokenizer:
+        def __call__(self, text: str, **kwargs: object) -> list[int]:
+            del kwargs
+            return {"turn 0": [1], "think": [20], "answer": [30]}[text]
+
+        def apply_chat_template(
+            self, messages: list[dict[str, Any]], **kwargs: object
+        ) -> list[int]:
+            del kwargs
+            if messages[-1]["role"] != "assistant":
+                return [1]
+            if not messages[-1].get("reasoning"):
+                raise ValueError("speculative render rejected")
+            return [1, 20, 30]
+
+    tokenized = history.tokenize(tokenizer=Tokenizer())
+
+    assert tokenized.tokens == [1, 20, 30]
+    assert tokenized.flags[1:] == [tr.TokenFlag.SAMPLED] * 2
+
+
 @pytest.mark.parametrize("arguments", ("not-json", "[]"))
 def test_chat_rerender_rejects_invalid_tool_arguments(arguments: str) -> None:
     history = tr.ChatCompletionsHistory(

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -3062,9 +3062,10 @@ def test_chat_rerender_normalizes_tool_arguments(arguments: object) -> None:
     assert rendered_arguments == [{"id": 3}]
 
 
-def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens() -> (
-    None
-):
+@pytest.mark.parametrize("reasoning", (None, "think"), ids=("tool-only", "reasoning"))
+def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens(
+    reasoning: str | None,
+) -> None:
     exchange = _chat_exchange([1], [2])
     data = exchange.response.model_dump(mode="python")
     choice = data["choices"][0]
@@ -3072,6 +3073,7 @@ def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens
     choice["logprobs"] = None
     choice["message"] = {
         "role": "assistant",
+        "reasoning": reasoning,
         "content": None,
         "tool_calls": [
             {
@@ -3091,7 +3093,12 @@ def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens
 
         def __call__(self, text: str, **kwargs: object) -> list[int]:
             del kwargs
-            return {"turn 0": [1], "lookup": [20], '{"x":1}': [30, 31]}[text]
+            return {
+                "turn 0": [1],
+                "think": [15, 16],
+                "lookup": [20],
+                '{"x":1}': [30, 31],
+            }[text]
 
         def apply_chat_template(
             self, messages: list[dict[str, Any]], **kwargs: object
@@ -3101,15 +3108,28 @@ def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens
                 return [1, 10]
             function = messages[-1]["tool_calls"][0]["function"]
             assert isinstance(function["arguments"], dict)
-            if function["name"] != "lookup":
-                return [1, 10, 98, 25, 99, 26]
-            return [1, 10, 20, 25, 30, 31, 26]
+            if (
+                function["name"] != "lookup"
+                or messages[-1].get("reasoning") != reasoning
+            ):
+                return [1, 10, 95, 96, 98, 25, 99, 26]
+            return [
+                1,
+                10,
+                *([15, 16] if reasoning else []),
+                20,
+                25,
+                30,
+                31,
+                26,
+            ]
 
     tokenized = history.tokenize(tokenizer=Tokenizer())
 
-    assert tokenized.tokens == [1, 20, 25, 30, 31, 26]
-    assert tokenized.flags[1:5] == [tr.TokenFlag.SAMPLED] * 4
-    assert all(math.isnan(value) for value in tokenized.logprobs[1:5])
+    sampled_tokens = [*([15, 16] if reasoning else []), 20, 25, 30, 31]
+    assert tokenized.tokens == [1, *sampled_tokens, 26]
+    assert tokenized.flags[1:-1] == [tr.TokenFlag.SAMPLED] * len(sampled_tokens)
+    assert all(math.isnan(value) for value in tokenized.logprobs[1:-1])
 
 
 def test_reasoning_probe_failure_does_not_override_authoritative_render() -> None:

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -3064,10 +3064,14 @@ def test_chat_rerender_normalizes_tool_arguments(arguments: object) -> None:
 
 @pytest.mark.parametrize("reasoning", (None, "think"), ids=("tool-only", "reasoning"))
 @pytest.mark.parametrize(
-    "exact_prompt", ([1], [900, 10]), ids=("shorter-prompt", "changed-prompt")
+    ("canonical_prompt", "exact_prompt"),
+    (([1, 10], [1]), ([1, 10], [900, 10]), ([], [900])),
+    ids=("shorter-prompt", "changed-prompt", "inserted-prompt"),
 )
 def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens(
-    reasoning: str | None, exact_prompt: list[int]
+    reasoning: str | None,
+    canonical_prompt: list[int],
+    exact_prompt: list[int],
 ) -> None:
     exchange = _chat_exchange(exact_prompt, [2])
     data = exchange.response.model_dump(mode="python")
@@ -3108,17 +3112,16 @@ def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens
         ) -> list[int]:
             del kwargs
             if messages[-1]["role"] != "assistant":
-                return [1, 10]
+                return canonical_prompt
             function = messages[-1]["tool_calls"][0]["function"]
             assert isinstance(function["arguments"], dict)
             if (
                 function["name"] != "lookup"
                 or messages[-1].get("reasoning") != reasoning
             ):
-                return [1, 10, 95, 96, 98, 25, 99, 26]
+                return [*canonical_prompt, 95, 96, 98, 25, 99, 26]
             return [
-                1,
-                10,
+                *canonical_prompt,
                 *([15, 16] if reasoning else []),
                 20,
                 25,
@@ -3447,13 +3450,13 @@ def test_reconciled_reasoning_preserves_complete_outputs_after_prefix_retokeniza
     first = _chat_exchange([], [])
     first_messages = [{"role": "user", "content": "one"}]
     first.request["messages"] = cast(list[ChatCompletionMessageParam], first_messages)
-    first_prompt = cast(
+    canonical_first_prompt = cast(
         list[int],
         tokenizer.apply_chat_template(
             first_messages, add_generation_prompt=True, tokenize=True
         ),
     )
-    first_prompt[0] = 900
+    first_prompt = [900, *canonical_first_prompt]
     first_message = {
         "role": "assistant",
         "reasoning": "thought-one",
@@ -3467,7 +3470,7 @@ def test_reconciled_reasoning_preserves_complete_outputs_after_prefix_retokeniza
             tokenize=True,
         ),
     )
-    first_output = first_completed[len(first_prompt) :]
+    first_output = first_completed[len(canonical_first_prompt) :]
     first_output[5] = 901
     first_data = first.response.model_dump(mode="python")
     first_data["choices"][0]["message"] = first_message
@@ -3491,13 +3494,13 @@ def test_reconciled_reasoning_preserves_complete_outputs_after_prefix_retokeniza
         {"role": "user", "content": "two"},
     ]
     second.request["messages"] = cast(list[ChatCompletionMessageParam], second_messages)
-    second_prompt = cast(
+    canonical_second_prompt = cast(
         list[int],
         tokenizer.apply_chat_template(
             second_messages, add_generation_prompt=True, tokenize=True
         ),
     )
-    second_prompt[0] = 900
+    second_prompt = [900, *canonical_second_prompt]
     second_message = {
         "role": "assistant",
         "reasoning": "thought-two",
@@ -3511,7 +3514,7 @@ def test_reconciled_reasoning_preserves_complete_outputs_after_prefix_retokeniza
             tokenize=True,
         ),
     )
-    second_output = second_completed[len(second_prompt) :]
+    second_output = second_completed[len(canonical_second_prompt) :]
     second_data = second.response.model_dump(mode="python")
     second_data["choices"][0]["message"] = second_message
     second_data["choices"][0]["prompt_token_ids"] = second_prompt

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -1112,6 +1112,31 @@ def test_fallback_upgrades_legacy_qwen_template_when_preservation_is_requested()
     assert "preserve_thinking is defined and preserve_thinking is true" in configured
 
 
+def test_tokenizer_dict_chat_template_fallback_is_not_forwarded() -> None:
+    history = tr.ChatCompletionsHistory(
+        model="test/model",
+        messages=[{"role": "assistant", "content": "answer"}],
+        message_sources=[None],
+    )
+
+    class Tokenizer:
+        chat_template = {"default": "{{ message.content }}"}
+
+        def __call__(self, text: str, *, add_special_tokens: bool = False) -> list[int]:
+            del text, add_special_tokens
+            return [11]
+
+        def apply_chat_template(
+            self, messages: list[dict[str, Any]], **kwargs: object
+        ) -> list[int]:
+            assert "chat_template" not in kwargs
+            return [10, 11] if messages[-1]["role"] == "assistant" else [10]
+
+    tokenized = history.tokenize(tokenizer=Tokenizer())
+
+    assert tokenized.tokens == [10, 11]
+
+
 def test_fallback_uses_template_overrides_and_nan_logprobs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -3401,8 +3401,9 @@ def test_chat_prefix_retokenization_splits_unless_reconciled(
     assert grouped.trajectories[0].tokens == tokenized.tokens
 
 
+@pytest.mark.parametrize("length_changing_prompt", (False, True))
 def test_reconciled_reasoning_preserves_complete_outputs_after_prefix_retokenization(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, length_changing_prompt: bool
 ) -> None:
     class Tokenizer:
         chat_template = "{{ preserve_thinking }}"
@@ -3456,7 +3457,10 @@ def test_reconciled_reasoning_preserves_complete_outputs_after_prefix_retokeniza
             first_messages, add_generation_prompt=True, tokenize=True
         ),
     )
-    first_prompt = [900, *canonical_first_prompt]
+    first_prompt = list(canonical_first_prompt)
+    first_prompt[0] = 900
+    if length_changing_prompt:
+        first_prompt.insert(1, 902)
     first_message = {
         "role": "assistant",
         "reasoning": "thought-one",
@@ -3500,7 +3504,10 @@ def test_reconciled_reasoning_preserves_complete_outputs_after_prefix_retokeniza
             second_messages, add_generation_prompt=True, tokenize=True
         ),
     )
-    second_prompt = [900, *canonical_second_prompt]
+    second_prompt = list(canonical_second_prompt)
+    second_prompt[0] = 900
+    if length_changing_prompt:
+        second_prompt.insert(1, 902)
     second_message = {
         "role": "assistant",
         "reasoning": "thought-two",

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -9,7 +9,7 @@ from statistics import median
 import sys
 from time import perf_counter
 from types import ModuleType, SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 from anthropic.types import ImageBlockParam, Message, MessageParam
 from openai.types import Completion
@@ -1087,6 +1087,29 @@ class _FakeTokenizer:
     ) -> list[int]:
         self.calls.append(kwargs)
         return [10, 11] if messages[-1]["role"] == "assistant" else [10]
+
+
+def test_fallback_upgrades_legacy_qwen_template_when_preservation_is_requested() -> (
+    None
+):
+    template = (
+        "{% if enable_thinking %}think{% endif %}"
+        "{%- if loop.index0 > ns.last_query_index %}reasoning{% endif %}"
+    )
+    history = tr.ChatCompletionsHistory(
+        model="test/model",
+        messages=[{"role": "assistant", "content": "answer"}],
+        message_sources=[None],
+        chat_template=template,
+        chat_template_kwargs={"preserve_thinking": True},
+    )
+    tokenizer = _FakeTokenizer()
+
+    history.tokenize(tokenizer=tokenizer)
+
+    configured = tokenizer.calls[0]["chat_template"]
+    assert isinstance(configured, str)
+    assert "preserve_thinking is defined and preserve_thinking is true" in configured
 
 
 def test_fallback_uses_template_overrides_and_nan_logprobs(
@@ -2963,6 +2986,87 @@ def test_responses_terminal_generation_without_output_items_survives_rerender() 
     ]
 
 
+@pytest.mark.parametrize(
+    "arguments", ('{"id": 3}', {"id": 3}), ids=("json-string", "mapping")
+)
+def test_chat_rerender_normalizes_tool_arguments(arguments: object) -> None:
+    history = tr.ChatCompletionsHistory(
+        model="test/model",
+        messages=[
+            {"role": "user", "content": "question"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": arguments},
+                    }
+                ],
+            },
+        ],
+        message_sources=[None, None],
+    )
+    rendered_arguments: list[object] = []
+
+    class Tokenizer:
+        chat_template = (
+            "{% set _args = tc.arguments %}"
+            "{% for k, v in _args.items() %}{{ k }}{{ v }}{% endfor %}"
+        )
+
+        def __call__(self, text: str, **kwargs: object) -> list[int]:
+            del text, kwargs
+            return [3]
+
+        def apply_chat_template(
+            self, messages: list[dict[str, Any]], **kwargs: object
+        ) -> list[int]:
+            del kwargs
+            for message in messages:
+                for call in message.get("tool_calls", []):
+                    arguments = call["function"]["arguments"]
+                    assert isinstance(arguments, dict)
+                    rendered_arguments.append(arguments)
+            return [1, 2, 3] if messages[-1]["role"] == "assistant" else [1, 2]
+
+    tokenized = history.tokenize(tokenizer=Tokenizer())
+
+    assert tokenized.tokens == [1, 2, 3]
+    assert rendered_arguments == [{"id": 3}]
+
+
+@pytest.mark.parametrize("arguments", ("not-json", "[]"))
+def test_chat_rerender_rejects_invalid_tool_arguments(arguments: str) -> None:
+    history = tr.ChatCompletionsHistory(
+        model="test/model",
+        messages=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": "lookup", "arguments": arguments}}
+                ],
+            }
+        ],
+        message_sources=[None],
+    )
+
+    class Tokenizer:
+        chat_template = "{{ tool_call.arguments|items }}"
+
+        def __call__(self, text: str, **kwargs: object) -> list[int]:
+            del text, kwargs
+            return []
+
+        def apply_chat_template(self, *args: object, **kwargs: object) -> list[int]:
+            raise AssertionError("invalid arguments must fail before rendering")
+
+    with pytest.raises(ValueError, match="tool-call arguments"):
+        history.tokenize(tokenizer=Tokenizer())
+
+
 def test_responses_empty_chat_source_requires_outputless_generation() -> None:
     from art.trajectories._tokenize import _responses_source_generation
 
@@ -3152,6 +3256,155 @@ def test_chat_prefix_retokenization_splits_unless_reconciled(
     )
     assert direct.tokens == tokenized.tokens
     assert grouped.trajectories[0].tokens == tokenized.tokens
+
+
+def test_reconciled_reasoning_preserves_complete_outputs_after_prefix_retokenization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Tokenizer:
+        chat_template = "{{ preserve_thinking }}"
+
+        @staticmethod
+        def _render(
+            messages: list[dict[str, Any]], *, add_generation_prompt: bool
+        ) -> str:
+            rendered = ""
+            for message in messages:
+                rendered += f"<{message['role']}>"
+                if reasoning := message.get("reasoning") or message.get(
+                    "reasoning_content"
+                ):
+                    rendered += f"<think>{reasoning}</think>"
+                rendered += str(message.get("content") or "") + "<end>"
+            return rendered + ("<assistant>" if add_generation_prompt else "")
+
+        def __call__(self, text: str, **kwargs: object) -> object:
+            token_ids = [ord(character) for character in text]
+            if kwargs.get("return_offsets_mapping"):
+                return {
+                    "input_ids": token_ids,
+                    "offset_mapping": [
+                        (index, index + 1) for index in range(len(text))
+                    ],
+                }
+            return token_ids
+
+        def apply_chat_template(
+            self,
+            messages: list[dict[str, Any]],
+            *,
+            add_generation_prompt: bool,
+            tokenize: bool,
+            **kwargs: object,
+        ) -> object:
+            del kwargs
+            rendered = self._render(
+                messages, add_generation_prompt=add_generation_prompt
+            )
+            return self(rendered) if tokenize else rendered
+
+    tokenizer = Tokenizer()
+    first = _chat_exchange([], [])
+    first_messages = [{"role": "user", "content": "one"}]
+    first.request["messages"] = cast(list[ChatCompletionMessageParam], first_messages)
+    first_prompt = cast(
+        list[int],
+        tokenizer.apply_chat_template(
+            first_messages, add_generation_prompt=True, tokenize=True
+        ),
+    )
+    first_prompt[0] = 900
+    first_message = {
+        "role": "assistant",
+        "reasoning": "thought-one",
+        "content": "first",
+    }
+    first_completed = cast(
+        list[int],
+        tokenizer.apply_chat_template(
+            [*first_messages, first_message],
+            add_generation_prompt=False,
+            tokenize=True,
+        ),
+    )
+    first_output = first_completed[len(first_prompt) :]
+    first_output[5] = 901
+    first_data = first.response.model_dump(mode="python")
+    first_data["choices"][0]["message"] = first_message
+    first_data["choices"][0]["prompt_token_ids"] = first_prompt
+    first_data["choices"][0]["token_ids"] = first_output
+    first_data["choices"][0]["logprobs"]["content"] = [
+        {
+            "token": f"token_id:{token_id}",
+            "logprob": -0.1,
+            "bytes": [],
+            "top_logprobs": [],
+        }
+        for token_id in first_output
+    ]
+    first.response = ChatCompletion.model_validate(first_data)
+
+    second = _chat_exchange([], [], offset=1)
+    second_messages = [
+        *first_messages,
+        first_message,
+        {"role": "user", "content": "two"},
+    ]
+    second.request["messages"] = cast(list[ChatCompletionMessageParam], second_messages)
+    second_prompt = cast(
+        list[int],
+        tokenizer.apply_chat_template(
+            second_messages, add_generation_prompt=True, tokenize=True
+        ),
+    )
+    second_prompt[0] = 900
+    second_message = {
+        "role": "assistant",
+        "reasoning": "thought-two",
+        "content": "second",
+    }
+    second_completed = cast(
+        list[int],
+        tokenizer.apply_chat_template(
+            [*second_messages, second_message],
+            add_generation_prompt=False,
+            tokenize=True,
+        ),
+    )
+    second_output = second_completed[len(second_prompt) :]
+    second_data = second.response.model_dump(mode="python")
+    second_data["choices"][0]["message"] = second_message
+    second_data["choices"][0]["prompt_token_ids"] = second_prompt
+    second_data["choices"][0]["token_ids"] = second_output
+    second_data["choices"][0]["logprobs"]["content"] = [
+        {
+            "token": f"token_id:{token_id}",
+            "logprob": -0.2,
+            "bytes": [],
+            "top_logprobs": [],
+        }
+        for token_id in second_output
+    ]
+    second.response = ChatCompletion.model_validate(second_data)
+
+    trajectory = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second])
+    )
+    assert len(trajectory.chat_completions_histories()) == 2
+    history = trajectory.chat_completions_history(
+        reconcile_text_equivalent_tokenizations=True
+    )
+    monkeypatch.setattr(
+        "art.trajectories._tokenize._WARNED_PREFIX_RETOKENIZATION", False
+    )
+    with pytest.warns(UserWarning, match="preserved the original sampled token IDs"):
+        tokenized = history.tokenize(tokenizer=tokenizer)
+
+    assert tokenized.tokens[0] == 900
+    assert 901 in tokenized.tokens
+    assert sum(bool(flag & tr.TokenFlag.SAMPLED) for flag in tokenized.flags) == len(
+        first_output
+    ) + len(second_output)
 
 
 def test_template_change_rerenders_scaffold_but_preserves_sampled_output() -> None:


### PR DESCRIPTION
## Context

Companion to OpenPipe/caladan#109. A long-running tau2-bench/Qwen3.5-4B campaign exposed multi-turn reasoning re-render failures, trainer Dynamo recompiles, and checkpoint restore edge cases. This PR contains the ART-side repairs.

> [!IMPORTANT]
> The original soak was not a clean-clone validation: the driver imported ART through a stale editable checkout, while the trainer used the older ART revision pinned by Caladan. That run was useful for diagnosis but is not treated as verification of this final branch. Clean-environment driver/trainer SHA validation is part of the companion Caladan PR's merge gate.

## Changes

### Preserve prior thinking end to end

- ART-managed trainable and internally configured models default to `preserve_thinking=true`; explicit caller overrides, including `false`, still win. Unmanaged external endpoints are unchanged.
- Legacy Qwen3/Qwen3.5 templates are upgraded only when needed, including hub namespaces and local paths whose final component is a Qwen3/Qwen3.5 model name.
- Explicit server chat templates take precedence and avoid tokenizer/hub access. Expected offline or invalid-tokenizer loads warn and fall back instead of failing startup.
- SFT and trajectory re-rendering share the preservation behavior. The intentional SFT behavior is documented, with multi-turn Qwen regression coverage.

### Tool-call argument normalization

- Shared normalization converts JSON-string tool arguments to mappings only for templates that iterate the tool-call arguments: `arguments | items`, direct `arguments.items()`, or a recognized tool-call argument alias subsequently iterated with `.items()`.
- GLM/MiniMax-style positives and gpt-oss/schema-object negatives prevent the earlier broad `.items()` heuristic from changing unrelated templates.
- Empty no-argument strings normalize to `{}`; invalid non-empty or non-object JSON raises a clear error.

### History reconciliation and alternate rendering

- Speculative chat-template probes are non-fatal; errors from the authoritative render still propagate.
- Marked message bounds are recomputed where possible and invalidated after alternate-render mismatches or failed probes, preventing stale offsets from being reused.
- Canonical marker/probe spans are translated across both same-length and length-changing exact prompt splices, including a canonical-empty prompt.
- Reconciliation keys include hidden reasoning and canonicalize the `reasoning_content` alias, so visibly identical histories with different reasoning cannot borrow one another's sampled-source metadata.
- Dict-valued tokenizer template registries are not forwarded as a concrete chat template.

### Checkpointing and compilation

- Weights-only checkpoints remain valid and lazily recreate optimizer state; LoRA slot refs are preserved across restore failures.
- Dynamic Dynamo parameter shapes are enabled only with transformer compilation. This is intentionally process-wide because PyTorch exposes the setting globally; regression coverage locks down the conditional application.

### Rollout observability

- Tau-bench trajectories record policy, environment, startup, active latency, and prompt/completion token metrics.

## Testing

- Final tokenization/SFT regression set: **181 passed**; two additional end-to-end tests require the optional `tinker` dependency absent from the local environment.
- Fresh Codex and Claude Fable 5 findings were addressed with focused regressions and clean follow-up reviews.
- Ruff formatting/lint and `ty` checks pass for all touched files.
- Megatron compilation regressions: **4 passed**.
- Checkpoint/tau regressions: **106 passed**.
- GitHub Actions is the authoritative clean-environment check for the final head.
