### PR TITLE
Fix Gemma 4 SFT template compatibility

### DIFF
--- a/src/art/preprocessing/tokenize.py
+++ b/src/art/preprocessing/tokenize.py
@@ -490,13 +490,43 @@ def _last_assistant_input_ids_and_labels(
         add_generation_prompt=False,
         **template_kwargs,
     )
-    if not completed_text.startswith(prompt_text):
-        raise ValueError(
-            "Cannot isolate the final assistant response because the completed chat "
-            "does not extend its generation prompt"
+    if completed_text.startswith(prompt_text):
+        target_text = completed_text[len(prompt_text) :]
+    else:
+        history_text = _apply_chat_template_text(
+            tokenizer,
+            messages[:-1],
+            tools=tools,
+            add_generation_prompt=False,
+            **template_kwargs,
         )
+        marker = "__ART_FINAL_ASSISTANT_TARGET__"
+        final_message = messages[-1]
+        has_final_output = any(
+            final_message.get(key)
+            for key in ("content", "reasoning", "reasoning_content", "tool_calls")
+        )
+        marked_text = _apply_chat_template_text(
+            tokenizer,
+            [*messages[:-1], {"role": "assistant", "content": marker}],
+            tools=tools,
+            add_generation_prompt=False,
+            **template_kwargs,
+        )
+        marker_start = marked_text.find(marker)
+        if (
+            not prompt_text.startswith(history_text)
+            or not has_final_output
+            or marker in completed_text
+            or marker_start < 0
+            or completed_text[:marker_start] != marked_text[:marker_start]
+        ):
+            raise ValueError(
+                "Cannot isolate the final assistant response because the completed "
+                "chat does not extend its generation prompt"
+            )
+        target_text = completed_text[marker_start:]
 
-    target_text = completed_text[len(prompt_text) :]
     prompt_ids = token_ids_for_template_part(tokenizer, prompt_text)
     target_ids = token_ids_for_template_part(tokenizer, target_text)
     input_ids = [*prompt_ids, *target_ids]

--- a/src/art/utils/model_config.py
+++ b/src/art/utils/model_config.py
@@ -54,6 +54,10 @@ def detect_chat_template_parts(
             "<|start_header_id|>assistant<|end_header_id|>\n\n",
         )
 
+    # Gemma 4 format
+    if "<|turn>" in template:
+        return "<|turn>user\n", "<|turn>model\n"
+
     # Gemma format
     if "<start_of_turn>" in template:
         return "<start_of_turn>user\n", "<start_of_turn>model\n"

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -1,0 +1,14 @@
+from types import SimpleNamespace
+
+from art.utils.model_config import detect_chat_template_parts
+
+
+def test_detects_gemma_4_template_parts() -> None:
+    tokenizer = SimpleNamespace(
+        chat_template="{{ '<|turn>' + role + '\\n' }}",
+    )
+
+    assert detect_chat_template_parts(tokenizer) == (
+        "<|turn>user\n",
+        "<|turn>model\n",
+    )

--- a/tests/unit/test_preprocessing_tokenize.py
+++ b/tests/unit/test_preprocessing_tokenize.py
@@ -264,6 +264,48 @@ class _BoundaryMergingTokenizer(_LastAssistantTokenizer):
         return token_ids
 
 
+class _DisabledThinkingTokenizer(_LastAssistantTokenizer):
+    disabled_thinking_prefix = "<assistant><|channel>thought\n<channel|>"
+
+    def _render_chat(self, messages, *, add_generation_prompt: bool) -> str:
+        rendered_parts: list[str] = []
+        for message in messages:
+            role = message["role"]
+            content = message.get("content") or ""
+            if role == "assistant":
+                rendered_parts.append(f"<assistant>{content}{self.eos_token}\n")
+            else:
+                rendered_parts.append(f"<{role}>{content}{self.eos_token}\n")
+        if add_generation_prompt:
+            rendered_parts.append(self.disabled_thinking_prefix)
+        return "".join(rendered_parts)
+
+
+class _ToolContinuationTokenizer(_LastAssistantTokenizer):
+    def _render_chat(self, messages, *, add_generation_prompt: bool) -> str:
+        rendered_parts: list[str] = []
+        previous_role = None
+        for message in messages:
+            role = message["role"]
+            content = message.get("content") or ""
+            if role == "assistant":
+                content += "".join(
+                    f"<call:{tool_call['function']['name']}>"
+                    for tool_call in message.get("tool_calls", [])
+                )
+            if role == "assistant" and previous_role == "tool":
+                rendered_parts[-1] = rendered_parts[-1].removesuffix(
+                    f"{self.eos_token}\n"
+                )
+                rendered_parts.append(f"{content}{self.eos_token}\n")
+            else:
+                rendered_parts.append(f"<{role}>{content}{self.eos_token}\n")
+            previous_role = role
+        if add_generation_prompt and previous_role != "tool":
+            rendered_parts.append("<assistant>")
+        return "".join(rendered_parts)
+
+
 class _NonPrefixStableTokenizer(_LastAssistantTokenizer):
     def apply_chat_template(self, *args, **kwargs):
         rendered = super().apply_chat_template(*args, **kwargs)
@@ -450,6 +492,100 @@ def test_tokenize_sft_batch_trains_only_final_assistant_turn() -> None:
     assert input_ids[target_start:] == target_ids
     assert tokenizer.decode(target_ids) == "final answer<eos>\n"
     assert batch.num_trainable_tokens == len(target_ids)
+
+
+def test_tokenize_sft_batch_handles_disabled_thinking_generation_prefix() -> None:
+    tokenizer = _DisabledThinkingTokenizer()
+    messages = cast(
+        MessagesAndChoices,
+        [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "earlier answer"},
+            {"role": "user", "content": "second question"},
+            {"role": "assistant", "content": "final answer"},
+        ],
+    )
+
+    batch = tokenize_sft_batch(
+        trajectory_batch=[Trajectory(messages_and_choices=messages)],
+        learning_rate=1e-5,
+        tokenizer=tokenizer,
+        instruction_part="<user>",
+        response_part="<assistant>",
+        assistant_turns="last",
+    )
+
+    input_ids = batch.trajectory_tensors[0]["input_ids"][0].tolist()
+    labels = batch.trajectory_tensors[0]["labels"][0].tolist()
+    target_ids = [token_id for token_id in labels if token_id != -100]
+    target_start = next(index for index, label in enumerate(labels) if label != -100)
+
+    assert tokenizer.decode(target_ids) == "final answer<eos>\n"
+    assert tokenizer.decode(input_ids[:target_start]).endswith(
+        tokenizer.disabled_thinking_prefix
+    )
+
+
+def test_tokenize_sft_batch_handles_assistant_continuation_after_tool() -> None:
+    tokenizer = _ToolContinuationTokenizer()
+    messages = cast(
+        MessagesAndChoices,
+        [
+            {"role": "user", "content": "look it up"},
+            {"role": "assistant", "content": "calling tool"},
+            {"role": "tool", "content": "tool result"},
+            {"role": "assistant", "content": "final answer"},
+        ],
+    )
+
+    batch = tokenize_sft_batch(
+        trajectory_batch=[Trajectory(messages_and_choices=messages)],
+        learning_rate=1e-5,
+        tokenizer=tokenizer,
+        instruction_part="<user>",
+        response_part="<assistant>",
+        assistant_turns="last",
+    )
+
+    labels = batch.trajectory_tensors[0]["labels"][0].tolist()
+    target_ids = [token_id for token_id in labels if token_id != -100]
+    assert tokenizer.decode(target_ids) == "final answer<eos>\n"
+
+
+def test_tokenize_sft_batch_handles_tool_call_continuation_after_tool() -> None:
+    tokenizer = _ToolContinuationTokenizer()
+    messages = cast(
+        MessagesAndChoices,
+        [
+            {"role": "user", "content": "look it up"},
+            {"role": "assistant", "content": "calling tool"},
+            {"role": "tool", "content": "tool result"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "next_tool", "arguments": "{}"},
+                    }
+                ],
+            },
+        ],
+    )
+
+    batch = tokenize_sft_batch(
+        trajectory_batch=[Trajectory(messages_and_choices=messages)],
+        learning_rate=1e-5,
+        tokenizer=tokenizer,
+        instruction_part="<user>",
+        response_part="<assistant>",
+        assistant_turns="last",
+    )
+
+    labels = batch.trajectory_tensors[0]["labels"][0].tolist()
+    target_ids = [token_id for token_id in labels if token_id != -100]
+    assert tokenizer.decode(target_ids) == "<call:next_tool><eos>\n"
 
 
 def test_tokenize_sft_batch_trains_final_tool_call_and_turn_end() -> None:


### PR DESCRIPTION
## What

Add the remaining Gemma 4 SFT compatibility needed by Serverless Training:

- Detect Gemma 4 model families and select the Gemma SFT chat-template format.
- Support final-assistant masking when a completed chat is not a literal extension of its generation prompt. The existing prefix-stable path remains unchanged; a sentinel fallback isolates the final assistant target only when required.
- Recognize Gemma templates that require tool-call arguments as mappings and normalize JSON-string arguments before rendering.

The earlier final-assistant file-SFT and general tool-argument normalization work is already present on current ART main; this PR extends that normalization for Gemma bracket access rather than duplicating it.

## Why

Gemma templates with thinking disabled insert a thought-channel scaffold into the generation prompt while omitting it from the completed render. Assistant continuations after tool responses can have the same non-prefix-stable shape. Gemma also validates that function[arguments] is a mapping before rendering tool calls. These differences caused valid SFT examples to fail before the first training batch.

## Impact

- Selects the correct SFT template family for Gemma 4 models.
- Supports disabled-thinking Gemma answers.
- Supports text and tool-call continuations after tool responses.
- Normalizes tool arguments only for templates that explicitly require structured mappings.
- Preserves behavior for prefix-stable and raw-JSON templates.

## Validation

- 27 targeted tokenizer unit tests passed.
- Targeted ty check passed.
- Targeted Ruff lint and format checks passed.
- The actual google/gemma-4-31B-it tokenizer rendered a string-argument tool call after normalization.
- Dry-rendered the production Gemma training artifact for final-assistant isolation: 20,985 rows, including 17,918 fallback-path rows, with zero isolation failures.