### PR TITLE
Harden TrainerRank device and live-graph handling

### DIFF
--- a/src/art/trainer_rank/__init__.py
+++ b/src/art/trainer_rank/__init__.py
@@ -235,6 +235,9 @@ class TrainerRank(_impl.TrainerRank):
 
         Per-input checkpoints override `checkpoint`. `no_grad=None` inherits the
         ambient PyTorch grad mode; `True` disables grads and `False` enables them.
+        Input and target tensors may be on a different device from the trainer;
+        ART moves its packed model inputs and labels internally without mutating
+        the caller-owned `ForwardInput` objects.
         """
         forward = cast(
             Callable[..., Iterator[MicroBatch[ForwardInputs, ForwardOutputs]]],
@@ -307,6 +310,9 @@ class TrainerRank(_impl.TrainerRank):
 
         Per-input checkpoints override `checkpoint`. `no_grad=None` inherits the
         ambient PyTorch grad mode; `True` disables grads and `False` enables them.
+        Input and target tensors may be on a different device from the trainer;
+        ART moves its packed model inputs and labels internally without mutating
+        the caller-owned `ForwardInput` objects.
         """
         forward = cast(
             Callable[..., ForwardOutputs],
@@ -328,11 +334,21 @@ class TrainerRank(_impl.TrainerRank):
         params: AdamParams,
         scale_grads: float = 1.0,
         checkpoints: Sequence[str] | None = None,
+        on_live_graphs: Literal["allow", "error"] = "allow",
     ) -> dict[str, float]:
+        """Step checkpoint slots that have accumulated gradients.
+
+        By default, caller-retained forward graphs do not block the step. ART does
+        not detach or free those graphs, and backward through one after the step is
+        unsafe: it may fail PyTorch's version checks or recompute against updated
+        checkpoint-slot weights. Pass `on_live_graphs="error"` to raise before
+        mutating any selected slot when a live graph remains on any rank.
+        """
         return super().optim_step(
             params=params,
             scale_grads=scale_grads,
             checkpoints=checkpoints,
+            on_live_graphs=on_live_graphs,
         )
 
 

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -1679,8 +1679,16 @@ class TrainerRank:
         params: AdamParams,
         scale_grads: float = 1.0,
         checkpoints: Sequence[str] | None = None,
+        on_live_graphs: Literal["allow", "error"] = "allow",
     ) -> dict[str, float]:
+        if on_live_graphs not in ("allow", "error"):
+            raise ValueError(
+                "on_live_graphs must be either 'allow' or 'error', got "
+                f"{on_live_graphs!r}"
+            )
         selected_checkpoints = self._selected_dynamic_checkpoints(checkpoints)
+        if on_live_graphs == "error":
+            self._guard_checkpoints_can_step(selected_checkpoints)
         return self._dynamic_optim_step(
             selected_checkpoints,
             params=params,
@@ -1946,7 +1954,6 @@ class TrainerRank:
         )
         selected = []
         for name in checkpoint_names:
-            self._guard_checkpoint_can_step(name)
             slot_params = self._checkpoint_slots[name].params
             step_flags = self._dynamic_param_step_flags(slot_params)
             slot_grads = self._reduce_dynamic_grads(
@@ -2713,14 +2720,39 @@ class TrainerRank:
         )
 
     def _guard_checkpoint_can_step(self, name: str) -> None:
-        ref = self._slot_ref(name)
-        if not self._has_live_slot_graph(ref):
+        if not self._has_live_slot_graph(self._slot_ref(name)):
             return
         raise TrainerRankSlotStateError(
             f"Cannot optim_step checkpoint slot {name!r} while outputs from an "
             "earlier forward using that slot have not been backpropagated. Call "
             "loss.backward() without retaining the graph before optim_step(); if "
             "the forward was abandoned, release all references to its outputs."
+        )
+
+    def _guard_checkpoints_can_step(self, names: Sequence[str]) -> None:
+        local_live = [self._has_live_slot_graph(self._slot_ref(name)) for name in names]
+        if dist.is_available() and dist.is_initialized():
+            live = torch.tensor(
+                local_live,
+                device=self.device,
+                dtype=torch.int32,
+            )
+            dist.all_reduce(live, op=dist.ReduceOp.MAX)
+            live_flags = live.tolist()
+        else:
+            live_flags = local_live
+        blocked = [
+            name for name, is_live in zip(names, live_flags, strict=True) if is_live
+        ]
+        if not blocked:
+            return
+        raise TrainerRankSlotStateError(
+            f"Cannot optim_step checkpoint slots {blocked!r} while outputs from an "
+            "earlier forward using those slots have a live backward graph on at "
+            "least one rank. Call loss.backward() without retaining the graph "
+            "before optim_step(); if the forward was abandoned, release all "
+            "references to its outputs; or pass on_live_graphs='allow' to accept "
+            "responsibility for any retained graphs."
         )
 
     def _estimate_group_request_output_bytes(

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -422,6 +422,7 @@ def test_cp1_packed_forward_uses_model_attention_metadata(
 
     runtime = _runtime()
     trainer = TrainerRank(runtime)
+    trainer.device = torch.device("meta")
     batch = prefix_tree_pack(
         (torch.tensor([1, 2, 3]), torch.tensor([1, 2, 4])), max_depth=1
     )
@@ -448,6 +449,11 @@ def test_cp1_packed_forward_uses_model_attention_metadata(
     assert captured["model_support_handler"] is runtime.model_support_handler
     assert captured["sliding_windows"] == (16,)
     assert captured["gdn_planner_config"] == "planner-config"
+    assert captured["target_device"] == torch.device("meta")
+    assert prepared.tokens.device == torch.device("meta")
+    assert prepared.position_ids.device == torch.device("meta")
+    assert batch.tokens.device == torch.device("cpu")
+    assert batch.position_ids.device == torch.device("cpu")
     torch.testing.assert_close(
         cast(torch.Tensor, captured["input_pos"]), batch.position_ids
     )
@@ -2389,6 +2395,124 @@ def test_trainer_rank_releases_abandoned_output_graph() -> None:
     gc.collect()
 
     trainer._guard_slot_can_load(ref)
+
+
+def _tracked_param_target(
+    trainer: TrainerRank,
+    ref: "LoRASlotRef",
+    value: torch.Tensor,
+) -> torch.Tensor:
+    [tracked] = trainer._track_slot_graph_outputs(
+        ref,
+        [ForwardOutput(value, None, None, None)],
+    )
+    assert tracked.target_logprobs is not None
+    return tracked.target_logprobs
+
+
+def test_optim_step_allows_unused_live_graph_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer, param = _trainer_with_checkpoint(monkeypatch, torch.tensor([2.0]))
+    ref = trainer._slot_ref("student")
+    # This models a trajectory with no sampled tokens: its differentiable forward
+    # output is retained but intentionally contributes no loss or gradients.
+    unused = _tracked_param_target(trainer, ref, param.square())
+    used = _tracked_param_target(trainer, ref, param * 3.0)
+    used.sum().backward()
+    before = param.detach().clone()
+
+    result = trainer.optim_step(params=AdamParams(learning_rate=1e-2, weight_decay=0.0))
+
+    assert result["update_successful"] == 1.0
+    assert not torch.equal(param, before)
+    with pytest.raises(RuntimeError, match="modified by an inplace operation|version"):
+        unused.sum().backward()
+
+
+def test_optim_step_can_error_on_unused_live_graph(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer, param = _trainer_with_checkpoint(monkeypatch, torch.tensor([2.0]))
+    ref = trainer._slot_ref("student")
+    unused = _tracked_param_target(trainer, ref, param.square())
+    used = _tracked_param_target(trainer, ref, param * 3.0)
+    used.sum().backward()
+    before = param.detach().clone()
+
+    with pytest.raises(TrainerRankSlotStateError, match="live backward graph"):
+        trainer.optim_step(
+            params=AdamParams(learning_rate=1e-2, weight_decay=0.0),
+            on_live_graphs="error",
+        )
+
+    assert unused.grad_fn is not None
+    torch.testing.assert_close(param, before)
+    assert param.grad is not None
+
+
+def test_optim_step_rejects_invalid_live_graph_policy() -> None:
+    trainer = TrainerRank(_runtime())
+
+    with pytest.raises(ValueError, match="on_live_graphs"):
+        cast(Any, trainer).optim_step(
+            params=AdamParams(learning_rate=1e-3),
+            on_live_graphs="warn",
+        )
+
+
+def _live_graph_error_worker(rank: int, world_size: int, init_method: str) -> None:
+    dist.init_process_group(
+        "gloo",
+        rank=rank,
+        world_size=world_size,
+        init_method=init_method,
+        timeout=timedelta(seconds=30),
+    )
+    retained: torch.Tensor | None = None
+    try:
+        trainer = TrainerRank(_runtime())
+        cast(Any, trainer)._slot_ref = _slot_ref
+        param = torch.nn.Parameter(torch.tensor([2.0]))
+        trainer._checkpoint_slots.setdefault("student", _CheckpointSlot()).params = (
+            param,
+        )
+        param.grad = torch.ones_like(param)
+        if rank == 0:
+            retained = _tracked_param_target(
+                trainer,
+                trainer._slot_ref("student"),
+                param.square(),
+            )
+
+        with pytest.raises(TrainerRankSlotStateError, match="live backward graph"):
+            trainer.optim_step(
+                params=AdamParams(learning_rate=1e-3),
+                on_live_graphs="error",
+            )
+
+        completed = torch.tensor(1)
+        dist.all_reduce(completed)
+        assert completed.item() == world_size
+        assert retained is None or retained.grad_fn is not None
+    finally:
+        dist.destroy_process_group()
+
+
+def test_optim_step_live_graph_error_is_collective(tmp_path: Path) -> None:
+    context = mp.spawn(
+        _live_graph_error_worker,
+        args=(2, f"file://{tmp_path / 'live-graph'}"),
+        nprocs=2,
+        join=False,
+    )
+    deadline = time.monotonic() + 45
+    while time.monotonic() < deadline:
+        if context.join(timeout=1):
+            return
+    for process in context.processes:
+        process.terminate()
+    pytest.fail("collective live-graph policy test hung")
 
 
 def test_dp_rank_forward_preserves_nested_shape_for_inactive_requests() -> None:

--- a/tests/unit/test_trainer_rank_weird_shapes.py
+++ b/tests/unit/test_trainer_rank_weird_shapes.py
@@ -268,6 +268,49 @@ def test_forward_micro_batches_preserves_nested_vineppo_groups(
     )
 
 
+@pytest.mark.parametrize("api", ("dp_rank_forward", "forward_micro_batches"))
+def test_forward_preserves_caller_owned_nested_input_tensors(
+    api: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rank = TrainerRank(_runtime())
+    monkeypatch.setattr(rank, "_dp_rank_and_size", lambda: (0, 1))
+    monkeypatch.setattr(rank, "_all_ranks_have_memory_profile", lambda **_: True)
+    monkeypatch.setattr(
+        rank,
+        "_run_flat_plan_with_memory_tracking",
+        lambda plan, **_kwargs: [
+            ForwardOutput(None, None, None, None) for _ in range(plan.request_count)
+        ],
+    )
+    groups = _vineppo_like_inputs()
+    tensors = [
+        (request, request.input_tokens, request.target_tokens)
+        for group in groups
+        for request in group
+    ]
+    snapshots = [
+        (inputs.clone(), None if targets is None else targets.clone())
+        for _request, inputs, targets in tensors
+    ]
+
+    if api == "dp_rank_forward":
+        rank.dp_rank_forward(groups)
+    else:
+        list(rank.forward_micro_batches(groups))
+
+    for (request, inputs, targets), (expected_inputs, expected_targets) in zip(
+        tensors, snapshots, strict=True
+    ):
+        assert request.input_tokens is inputs
+        assert request.target_tokens is targets
+        assert inputs.device.type == "cpu"
+        torch.testing.assert_close(inputs, expected_inputs)
+        if targets is not None and expected_targets is not None:
+            assert targets.device.type == "cpu"
+            torch.testing.assert_close(targets, expected_targets)
+
+
 def test_adaptive_planner_materializes_only_final_large_candidate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- document and regression-lock `dp_rank_forward()` and `forward_micro_batches()` support for off-device token/target tensors while preserving caller-owned inputs
- make `optim_step()` allow caller-retained live graphs by default without detaching or freeing them
- add opt-in collective enforcement with `on_live_graphs="error"`, including cross-rank propagation and invalid-value validation
- keep checkpoint replacement and HybridEP buffer-growth guards unchanged

## Why

Experiment 046 had defensive caller-side device placement even though the shared TrainerRank packing and label boundaries can co-locate tensors internally. The runtime contract was not documented or covered end to end.

TrainerRank also rejected optimizer steps whenever caller-retained outputs kept a slot graph live, including unused forwards with no sampled-token loss. ART cannot free graphs still owned by callers, so the default now permits the step. Callers that need the previous safety check can opt into `on_live_graphs="error"`.

Backward through a retained graph after stepping remains unsafe: PyTorch may reject it because parameters changed in place, or recomputation may observe updated slot weights. The API docs and regressions make this explicit.

## Validation

- `uv run pytest -q --disable-warnings tests/unit/test_trainer_rank_validation.py tests/unit/test_trainer_rank_weird_shapes.py` — 129 passed
- `uv run ruff check ...` — passed
- `uv run ruff format --check ...` — passed
- `uv run ty check src/art/trainer_rank/__init__.py src/art/trainer_rank/_impl.py` — passed
- two-H200 `scripts/ci/trainer-rank-gpu-tests.sh` — 52 passed, 1 skipped
- final two-rank `trainer_rank_check.py` CP=2 validation — passed with zero slot/head backward differences
