### PR TITLE
Handle Gemma structured tool arguments

### DIFF
--- a/src/art/megatron/model_support/handlers/gemma4.py
+++ b/src/art/megatron/model_support/handlers/gemma4.py
@@ -1817,11 +1817,87 @@ def _vllm_moe_config(adapter_config: dict[str, Any]) -> dict[str, Any]:
     return config
 
 
+def _canonicalize_gemma4_peft_moe_target_parameter_layout(
+    tensors: dict[str, torch.Tensor],
+    *,
+    adapter_config: dict[str, Any],
+) -> dict[str, torch.Tensor]:
+    """Transpose PEFT's parameter-LoRA factors into vLLM's 3D MoE layout.
+
+    Gemma4 stores its expert parameters as ``[expert, out, in]`` tensors,
+    while PEFT's generic 3D target-parameter wrapper interprets them as
+    ``[expert, in, out]``.  The resulting factors already use vLLM's fused
+    expert key names, but every expert delta is transposed.  Shape-detect that
+    layout and transpose the factors back before either Megatron import or
+    vLLM normalization.
+    """
+    base_model = adapter_config.get("base_model_name_or_path")
+    if not isinstance(base_model, str) or not base_model:
+        return tensors
+    config = _gemma4_text_config_dict(base_model)
+    if not bool(config.get("enable_moe_block", False)):
+        return tensors
+    hidden = int(config.get("hidden_size", 0) or 0)
+    intermediate = int(config.get("moe_intermediate_size", 0) or 0)
+    if hidden <= 0 or intermediate <= 0:
+        return tensors
+
+    grouped: dict[str, dict[str, str]] = {}
+    for key in tensors:
+        match = _VLLM_MOE_KEY_RE.match(key)
+        if match is None:
+            continue
+        slot = (
+            f"{'base_layer.' if match.group('base_layer') else ''}{match.group('lora')}"
+        )
+        grouped.setdefault(match.group("prefix"), {})[slot] = key
+
+    transformed = dict(tensors)
+    for slots in grouped.values():
+        required = {
+            "base_layer.lora_A",
+            "base_layer.lora_B",
+            "lora_A",
+            "lora_B",
+        }
+        if set(slots) != required:
+            continue
+        gate_up_a_key = slots["base_layer.lora_A"]
+        gate_up_b_key = slots["base_layer.lora_B"]
+        down_a_key = slots["lora_A"]
+        down_b_key = slots["lora_B"]
+        gate_up_a = tensors[gate_up_a_key]
+        gate_up_b = tensors[gate_up_b_key]
+        down_a = tensors[down_a_key]
+        down_b = tensors[down_b_key]
+        packed_rank = int(gate_up_a.shape[0])
+        peft_shapes = (
+            (packed_rank, 2 * intermediate),
+            (hidden, packed_rank),
+            (packed_rank, hidden),
+            (intermediate, packed_rank),
+        )
+        actual_shapes = tuple(
+            tuple(tensor.shape) for tensor in (gate_up_a, gate_up_b, down_a, down_b)
+        )
+        if actual_shapes != peft_shapes:
+            continue
+        transformed[gate_up_a_key] = gate_up_b.transpose(0, 1).contiguous()
+        transformed[gate_up_b_key] = gate_up_a.transpose(0, 1).contiguous()
+        transformed[down_a_key] = down_b.transpose(0, 1).contiguous()
+        transformed[down_b_key] = down_a.transpose(0, 1).contiguous()
+    return transformed
+
+
 def _to_vllm_lora_tensors(
     tensors: dict[str, torch.Tensor],
     *,
     adapter_config: dict[str, Any],
 ) -> tuple[dict[str, torch.Tensor], dict[str, Any]]:
+    tensors = _canonicalize_gemma4_peft_moe_target_parameter_layout(
+        tensors,
+        adapter_config=adapter_config,
+    )
     grouped = group_expert_lora_tensors(tensors, _ART_MOE_EXPERT_KEY_RE)
     if not grouped:
         transformed: dict[str, torch.Tensor] = {}
@@ -1939,6 +2015,10 @@ def _from_vllm_lora_tensors(
     *,
     adapter_config: dict[str, Any],
 ) -> dict[str, torch.Tensor]:
+    tensors = _canonicalize_gemma4_peft_moe_target_parameter_layout(
+        tensors,
+        adapter_config=adapter_config,
+    )
     expert_grouped: dict[str, dict[int, dict[str, dict[str, torch.Tensor]]]] = {}
     for key, tensor in tensors.items():
         match = _VLLM_MOE_EXPERT_KEY_RE.match(key)

--- a/src/art/utils/chat_template.py
+++ b/src/art/utils/chat_template.py
@@ -64,13 +64,15 @@ def _template_requires_structured_tool_arguments(chat_template: object) -> bool:
     if not isinstance(chat_template, str):
         return False
     arguments_access = (
-        r"(?:(?<![.\w])(?:tool_call|tc)\s*\.\s*"
-        r"(?:function\s*\.\s*)?arguments\b"
+        r"(?:(?<![.\w])(?:tool_call|tc|function)\s*(?:\.\s*"
+        r"(?:function\s*\.\s*)?arguments\b|\[\s*['\"]arguments['\"]\s*\])"
         r"|(?<![.\w])arguments\b)"
     )
     if re.search(rf"{arguments_access}\s*\|\s*items\b", chat_template):
         return True
     if re.search(rf"{arguments_access}\s*\.\s*items\s*\(", chat_template):
+        return True
+    if re.search(rf"{arguments_access}\s+is\s+mapping\b", chat_template):
         return True
     aliases = re.findall(
         r"{%[-+]?\s*set\s+([A-Za-z_]\w*)\s*=\s*([^%]*)[-+]?%}",

--- a/tests/integration/megatron/lora/test_lora_disk_codecs.py
+++ b/tests/integration/megatron/lora/test_lora_disk_codecs.py
@@ -970,6 +970,66 @@ def test_gemma4_shared_experts_plural_keys_map_to_vllm_dense_mlp(tmp_path: Path)
     _assert_tensors_equal(roundtrip, original)
 
 
+def test_gemma4_peft_target_parameter_moe_layout_is_transposed(tmp_path: Path):
+    model_dir = tmp_path / "gemma4-moe"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "text_config": {
+                    "enable_moe_block": True,
+                    "hidden_size": 6,
+                    "moe_intermediate_size": 2,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    prefix = "base_model.model.model.layers.0.moe.experts"
+    peft_gate_up_a = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    peft_gate_up_b = torch.arange(12, dtype=torch.float32).reshape(6, 2)
+    peft_down_a = torch.arange(12, 24, dtype=torch.float32).reshape(2, 6)
+    peft_down_b = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+    peft_tensors = {
+        f"{prefix}.base_layer.lora_A.weight": peft_gate_up_a,
+        f"{prefix}.base_layer.lora_B.weight": peft_gate_up_b,
+        f"{prefix}.lora_A.weight": peft_down_a,
+        f"{prefix}.lora_B.weight": peft_down_b,
+    }
+    adapter_config = _config(str(model_dir), rank=1, alpha=1)
+
+    normalized, _ = GEMMA4_MOE_HANDLER.to_vllm_lora_tensors(
+        peft_tensors,
+        adapter_config=adapter_config,
+    )
+
+    assert torch.equal(
+        normalized[f"{prefix}.base_layer.lora_A.weight"], peft_gate_up_b.T
+    )
+    assert torch.equal(
+        normalized[f"{prefix}.base_layer.lora_B.weight"], peft_gate_up_a.T
+    )
+    assert torch.equal(normalized[f"{prefix}.lora_A.weight"], peft_down_b.T)
+    assert torch.equal(normalized[f"{prefix}.lora_B.weight"], peft_down_a.T)
+
+    internal = GEMMA4_MOE_HANDLER.from_vllm_lora_tensors(
+        peft_tensors,
+        adapter_config=adapter_config,
+    )
+    art_prefix = "base_model.model.model.layers.0.mlp.experts"
+    for expert in range(2):
+        gate_up_a = internal[f"{art_prefix}.{expert}.gate_up_proj.lora_A.weight"]
+        gate_up_b = internal[f"{art_prefix}.{expert}.gate_up_proj.lora_B.weight"]
+        down_a = internal[f"{art_prefix}.{expert}.down_proj.lora_A.weight"]
+        down_b = internal[f"{art_prefix}.{expert}.down_proj.lora_B.weight"]
+        assert torch.equal(gate_up_a, peft_gate_up_b[:, expert].unsqueeze(0))
+        assert torch.equal(gate_up_b[:4], peft_gate_up_a[expert].unsqueeze(1))
+        assert torch.count_nonzero(gate_up_b[4:]) == 0
+        assert torch.equal(down_a[:, :2], peft_down_b[:, expert].unsqueeze(0))
+        assert torch.count_nonzero(down_a[:, 2:]) == 0
+        assert torch.equal(down_b, peft_down_a[expert].unsqueeze(1))
+
+
 def test_gpt_oss_vllm_canonical_roundtrip_and_stock_loader(tmp_path: Path):
     art_prefix = "base_model.model.model.layers.0"
     original = _gpt_oss_moe_art_tensors(art_prefix)

--- a/tests/unit/test_preprocessing_tokenize.py
+++ b/tests/unit/test_preprocessing_tokenize.py
@@ -25,6 +25,7 @@ pytest.importorskip("transformers")
         "{% for key, value in tool_call.arguments.items() %}",
         "{{ arguments | items }}",
         "{% for key, value in arguments.items() %}",
+        "{% if function['arguments'] is mapping %}",
         (
             "{% set structured = tool_call.arguments %}"
             "{% for key, value in structured.items() %}"


### PR DESCRIPTION
## What

Extend chat-template argument-shape detection to recognize bracket access through Gemma function aliases, including function[arguments] is mapping. JSON-string tool arguments are then normalized to objects before template rendering.

## Why

The production Gemma 4 template rejects string-encoded tool-call arguments. ART already normalizes arguments for templates that require mappings, but its detector did not recognize Gemma bracket access, so final-assistant SFT failed before the first batch.

## Impact

Gemma tool calls render correctly while templates that consume raw JSON strings retain their existing behavior.

## Validation

- 27 preprocessing tokenizer tests passed.
- Targeted ty, Ruff lint, and Ruff format checks passed.
- The actual google/gemma-4-31B-it tokenizer successfully rendered a representative string-argument tool call after normalization.