### PR TITLE
Defer trajectory string interning to pickle

### DIFF
--- a/src/art/trajectories/__init__.py
+++ b/src/art/trajectories/__init__.py
@@ -74,6 +74,7 @@ from ..types import Messages, MessagesAndChoices, Tools
 from ._serialization import (
     _CompactModel,
     _rebind_history_sources,
+    _StringInterningModel,
     _StringPool,
     serialize_chat_completion,
     serialize_history,
@@ -297,7 +298,7 @@ class PydanticException(pydantic.BaseModel):
     traceback: str
 
 
-class LegacyHistory(pydantic.BaseModel):
+class LegacyHistory(_StringInterningModel):
     messages_and_choices: MessagesAndChoices
     tools: Tools | None = None
 
@@ -354,7 +355,7 @@ class LegacyHistory(pydantic.BaseModel):
         ).tensorize(device=device)
 
 
-class History(pydantic.BaseModel):
+class History(_StringInterningModel):
     """Mutable, protocol-native view of one tokenizable sequence."""
 
     model_config = pydantic.ConfigDict(extra="forbid")
@@ -552,7 +553,6 @@ class Trajectory(_CompactModel):
             raise ValueError(
                 "A trajectory cannot contain both exchanges and legacy histories"
             )
-        self._intern_strings()
         return self
 
     def _intern_strings(self, pool: _StringPool | None = None) -> None:
@@ -585,7 +585,6 @@ class Trajectory(_CompactModel):
 
     def finish(self) -> Trajectory:
         self.metrics["duration"] = (datetime.now() - self.start_time).total_seconds()
-        self._intern_strings()
         return self
 
     @asynccontextmanager
@@ -774,7 +773,6 @@ class Trajectory(_CompactModel):
     ) -> TokenizedTrajectory | TokenizedMultiHistoryTrajectory:
         from ._tokenize import tokenize_trajectory
 
-        self._intern_strings()
         return tokenize_trajectory(
             self,
             multi_history=multi_history,
@@ -855,11 +853,6 @@ class TrajectoryGroup(_CompactModel):
     logs: list[str] = pydantic.Field(default_factory=list)
     _collect_packing_shape: bool = pydantic.PrivateAttr(default=False)
     _packed_group_shape: Any = pydantic.PrivateAttr(default=None)
-
-    @pydantic.model_validator(mode="after")
-    def _intern_string_graph(self) -> TrajectoryGroup:
-        self._intern_strings()
-        return self
 
     def _intern_strings(self, pool: _StringPool | None = None) -> None:
         _intern_string_graph(self, pool)
@@ -998,7 +991,6 @@ class TrajectoryGroup(_CompactModel):
     ):
         from ._tokenize import tokenize_group
 
-        self._intern_strings()
         return tokenize_group(
             self,
             multi_history=multi_history,
@@ -1064,7 +1056,7 @@ class TrajectoryGroup(_CompactModel):
         ).tensorize(device=device)
 
 
-class TokenizedHistory(pydantic.BaseModel):
+class TokenizedHistory(_StringInterningModel):
     model_config = pydantic.ConfigDict(ser_json_inf_nan="strings")
 
     history: TrajectoryHistory
@@ -1088,7 +1080,6 @@ class TokenizedHistory(pydantic.BaseModel):
     def validate_tokenwise_lengths(self) -> TokenizedHistory:
         if not (len(self.tokens) == len(self.logprobs) == len(self.flags)):
             raise ValueError("Tokenized history fields differ in length")
-        _intern_string_graph(self)
         return self
 
     def tensorize(
@@ -1149,7 +1140,7 @@ class TokenizedTrajectory(TokenizedHistory):
         return _load_tensors().tensorize_trajectory(self, device=device)
 
 
-class TokenizedMultiHistoryTrajectory(pydantic.BaseModel):
+class TokenizedMultiHistoryTrajectory(_StringInterningModel):
     model_config = pydantic.ConfigDict(ser_json_inf_nan="strings")
 
     trajectory: Trajectory
@@ -1183,7 +1174,6 @@ class TokenizedMultiHistoryTrajectory(pydantic.BaseModel):
     def _intern_source_graph(self) -> TokenizedMultiHistoryTrajectory:
         for history in self.histories:
             _rebind_history_sources(history.history, self.trajectory)
-        _intern_string_graph(self)
         return self
 
     def compact_dump(self) -> CompactTrajectoryPayload:
@@ -1204,7 +1194,7 @@ TokenizedTrajectoryT = TypeVar(
 )
 
 
-class TokenizedTrajectoryGroup(pydantic.BaseModel, Generic[TokenizedTrajectoryT]):
+class TokenizedTrajectoryGroup(_StringInterningModel, Generic[TokenizedTrajectoryT]):
     model_config = pydantic.ConfigDict(ser_json_inf_nan="strings")
 
     trajectory_group: TrajectoryGroup
@@ -1241,7 +1231,6 @@ class TokenizedTrajectoryGroup(pydantic.BaseModel, Generic[TokenizedTrajectoryT]
             else:
                 for history in tokenized.histories:
                     _rebind_history_sources(history.history, trajectory)
-        _intern_string_graph(self)
         return self
 
     def compact_dump(self) -> CompactTrajectoryPayload:

--- a/src/art/trajectories/_capture/core.py
+++ b/src/art/trajectories/_capture/core.py
@@ -17,7 +17,6 @@ from .. import (
 )
 from .._protocols import Endpoint, Exchange, build_exchange, endpoint_for_url
 from .._scope import _get_current_scope
-from .._serialization import _intern_strings, _StringPool
 
 logger = logging.getLogger(__name__)
 _adapter_active: contextvars.ContextVar[bool] = contextvars.ContextVar(
@@ -65,7 +64,6 @@ def _terminal_sse_event(endpoint: Endpoint, block: bytes) -> bool:
 @dataclass
 class CaptureState:
     trajectory: Trajectory
-    strings: _StringPool
     endpoint: Endpoint
     request: dict[str, Any]
     start_time: datetime = field(default_factory=datetime.now)
@@ -119,7 +117,6 @@ class CaptureState:
         except Exception as exc:
             logger.debug("Ignoring incomplete trajectory exchange: %s", exc)
             return
-        _intern_strings(exchange, self.strings)
         _append_exchange(self.trajectory, exchange)
 
 
@@ -183,7 +180,6 @@ def begin(
     return (
         CaptureState(
             trajectory=scope.trajectory,
-            strings=scope.strings,
             endpoint=endpoint,
             request=request,
         ),

--- a/src/art/trajectories/_compact.py
+++ b/src/art/trajectories/_compact.py
@@ -20,8 +20,7 @@ from . import (
     TrajectoryGroup,
     _load_tensors,
 )
-from ._serialization import _intern_strings as _intern_string_graph
-from ._serialization import _rebind_history_sources, _StringPool
+from ._serialization import _rebind_history_sources
 
 _FORMAT = "art.trajectories"
 _VERSION = 1
@@ -64,7 +63,6 @@ def dump(
 
     if _is_dumpable(value):
         kind = _kind(value)
-        _intern(value)
         return _encode(kind, _dump_value(value, kind))
     values = list(cast(Iterable[CompactDumpable], value))
     if not values:
@@ -74,9 +72,6 @@ def dump(
     kinds = [_kind(item) for item in values]
     if len(set(kinds)) != 1:
         raise TypeError("compact_dump() requires a homogeneous iterable")
-    pool: _StringPool = {}
-    for item in values:
-        _intern(item, pool)
     return _encode(
         _plural_kind(kinds[0]),
         [_dump_value(item, kind) for item, kind in zip(values, kinds, strict=True)],
@@ -137,9 +132,8 @@ def validate(
             _validate_value(item, singular, target_model, device=device)
             for item in data
         ]
-        pool: _StringPool = {}
         for value in values:
-            _finish(value, pool)
+            _finish(value)
         return cast(_CompactValidated, values)
     return _finish(_validate_value(data, kind, target_model, device=device))
 
@@ -551,12 +545,11 @@ def _replace_source_exchanges(
             _replace_source_exchanges(item, registry, encode=encode)
 
 
-def _finish[ValueT](value: ValueT, pool: _StringPool | None = None) -> ValueT:
+def _finish[ValueT](value: ValueT) -> ValueT:
     if isinstance(value, TokenizedHistory):
         _rebind_history_sources(value.history)
     elif _is_tensorized(value) and hasattr(value, "history"):
         _rebind_history_sources(value.history)
-    _intern(value, pool)
     return value
 
 
@@ -581,15 +574,6 @@ def _list(value: object, label: str) -> list[object]:
 
 def _json_key(value: object) -> str:
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
-
-
-def _intern(value: object, pool: _StringPool | None = None) -> None:
-    if isinstance(value, Trajectory):
-        value._intern_strings(pool)
-    elif isinstance(value, TrajectoryGroup):
-        value._intern_strings(pool)
-    else:
-        _intern_string_graph(value, pool)
 
 
 def _encode(

--- a/src/art/trajectories/_scope.py
+++ b/src/art/trajectories/_scope.py
@@ -10,13 +10,11 @@ from typing import Any
 
 from . import PydanticException, Trajectory, TrajectoryGroup
 from ._compat import exception_model
-from ._serialization import _StringPool
 
 
 @dataclass(frozen=True, slots=True)
 class _TrajectoryScope:
     trajectory: Trajectory
-    strings: _StringPool
 
 
 _scopes: contextvars.ContextVar[tuple[_TrajectoryScope, ...]] = contextvars.ContextVar(
@@ -42,9 +40,7 @@ def enter_trajectory(trajectory: Trajectory) -> Trajectory:
     from ._capture import install
 
     install()
-    strings: _StringPool = {}
-    trajectory._intern_strings(strings)
-    _scopes.set((*_scopes.get(), _TrajectoryScope(trajectory, strings)))
+    _scopes.set((*_scopes.get(), _TrajectoryScope(trajectory)))
     return trajectory
 
 

--- a/src/art/trajectories/_serialization.py
+++ b/src/art/trajectories/_serialization.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import fields, is_dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal, SupportsIndex, cast
 
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion import Choice
@@ -13,6 +13,23 @@ from pydantic.main import IncEx
 from ..openai import ART_MOE_ROUTING_METADATA_KEY
 
 type _StringPool = dict[str, str]
+
+
+class _StringInterningModel(BaseModel):
+    """Intern strings once, immediately before this graph is pickled."""
+
+    # Process-local optimization state: omitting it from Pydantic private state keeps
+    # equality and serialization unchanged, and lets a receiving process prepare the
+    # graph again after local mutation.
+    __slots__ = ("_art_pickle_strings_interned",)
+
+    def __reduce_ex__(self, protocol: SupportsIndex, /) -> str | tuple[Any, ...]:
+        if not getattr(self, "_art_pickle_strings_interned", False):
+            _intern_strings(self)
+        return super().__reduce_ex__(protocol)
+
+    def _mark_pickle_strings_interned(self) -> None:
+        object.__setattr__(self, "_art_pickle_strings_interned", True)
 
 
 def _intern_strings(value: object, pool: _StringPool | None = None) -> None:
@@ -39,6 +56,8 @@ def _intern_value(value: object, pool: _StringPool, memo: dict[int, object]) -> 
         if extra is not None and id(extra) not in memo:
             memo[id(extra)] = extra
             _intern_mapping(cast(dict[object, object], extra), pool, memo)
+        if isinstance(value, _StringInterningModel):
+            value._mark_pickle_strings_interned()
         return value
     if is_dataclass(value) and type(value).__module__.startswith("art.trajectories"):
         memo[value_id] = value
@@ -257,7 +276,7 @@ def _rebind_history_sources(history: object, trajectory: object | None = None) -
     visit(history)
 
 
-class _CompactModel(BaseModel):
+class _CompactModel(_StringInterningModel):
     """Pydantic model whose default dump omits fields equal to their defaults."""
 
     def model_dump(

--- a/src/art/trajectories/tensors.py
+++ b/src/art/trajectories/tensors.py
@@ -24,9 +24,9 @@ from . import (
     Trajectory,
     TrajectoryGroup,
     TrajectoryHistory,
+    _StringInterningModel,
 )
 from ._serialization import (
-    _intern_strings,
     _rebind_history_sources,
     serialize_history,
     validate_history,
@@ -60,7 +60,7 @@ def _json_tensor(value: torch.Tensor) -> list[int] | list[float | str]:
     return [int(item) for item in items]
 
 
-class TensorizedHistory(pydantic.BaseModel):
+class TensorizedHistory(_StringInterningModel):
     """One tokenizable history represented by canonical one-dimensional tensors."""
 
     model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
@@ -105,7 +105,6 @@ class TensorizedHistory(pydantic.BaseModel):
     def validate_tokenwise_lengths(self) -> Self:
         if not (len(self.tokens) == len(self.logprobs) == len(self.flags)):
             raise ValueError("Tensorized history fields differ in length")
-        _intern_strings(self)
         return self
 
     def to(self, device: torch.device | str) -> Self:
@@ -155,7 +154,7 @@ class TensorizedTrajectory(TensorizedHistory):
         return self
 
 
-class TensorizedMultiHistoryTrajectory(pydantic.BaseModel):
+class TensorizedMultiHistoryTrajectory(_StringInterningModel):
     model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
 
     trajectory: Trajectory
@@ -189,7 +188,6 @@ class TensorizedMultiHistoryTrajectory(pydantic.BaseModel):
     def bind_source_trajectory(self) -> Self:
         for history in self.histories:
             _rebind_history_sources(history.history, self.trajectory)
-        _intern_strings(self)
         return self
 
     def to(self, device: torch.device | str) -> Self:
@@ -210,7 +208,7 @@ TensorizedTrajectoryT = TypeVar(
 )
 
 
-class TensorizedTrajectoryGroup(pydantic.BaseModel, Generic[TensorizedTrajectoryT]):
+class TensorizedTrajectoryGroup(_StringInterningModel, Generic[TensorizedTrajectoryT]):
     model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
 
     trajectory_group: TrajectoryGroup
@@ -249,7 +247,6 @@ class TensorizedTrajectoryGroup(pydantic.BaseModel, Generic[TensorizedTrajectory
             else:
                 for history in tensorized.histories:
                     _rebind_history_sources(history.history, trajectory)
-        _intern_strings(self)
         return self
 
     def to(self, device: torch.device | str) -> Self:

--- a/tests/unit/trajectories/test_compact_serialization.py
+++ b/tests/unit/trajectories/test_compact_serialization.py
@@ -33,7 +33,7 @@ def _json_size(value: object) -> int:
     return len(json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode())
 
 
-def test_trajectory_construction_interns_nested_models_keys_and_cycles() -> None:
+def test_explicit_interning_handles_nested_models_keys_and_cycles() -> None:
     class ProviderExtra(pydantic.BaseModel, extra="allow"):
         content: str
 
@@ -66,6 +66,10 @@ def test_trajectory_construction_interns_nested_models_keys_and_cycles() -> None
     )
 
     canonical = next(key for key in trajectory.metadata if key == repeated)
+    assert cycle[0] is not canonical
+
+    trajectory._intern_strings()
+
     assert cycle[0] is canonical
     assert cycle[1] is canonical
     assert cycle[2] is cycle
@@ -79,21 +83,21 @@ def test_trajectory_construction_interns_nested_models_keys_and_cycles() -> None
     assert next(iter(trajectory.metadata["frozenset"])) is canonical
 
 
-def test_validation_finish_grouping_copy_and_pickle_preserve_sharing() -> None:
+def test_only_pickle_boundary_interns_validated_finished_and_grouped_values() -> None:
     repeated = _long()
     trajectory = art.Trajectory.model_validate(
         {"metadata": {"first": _fresh(repeated), "second": _fresh(repeated)}}
     )
-    assert trajectory.metadata["first"] is trajectory.metadata["second"]
+    assert trajectory.metadata["first"] is not trajectory.metadata["second"]
     from_json = art.Trajectory.model_validate_json(
         json.dumps({"metadata": {"first": repeated, "second": repeated}})
     )
-    assert from_json.metadata["first"] is from_json.metadata["second"]
+    assert from_json.metadata["first"] is not from_json.metadata["second"]
 
     trajectory.metadata["third"] = _fresh(repeated)
     assert trajectory.metadata["third"] is not trajectory.metadata["first"]
     trajectory.finish()
-    assert trajectory.metadata["third"] is trajectory.metadata["first"]
+    assert trajectory.metadata["third"] is not trajectory.metadata["first"]
 
     other = art.Trajectory(metadata={"value": _fresh(repeated)})
     group = art.TrajectoryGroup(
@@ -101,17 +105,24 @@ def test_validation_finish_grouping_copy_and_pickle_preserve_sharing() -> None:
         exceptions=[ValueError(_fresh(repeated))],
         metadata={"value": _fresh(repeated)},
     )
+    assert other.metadata["value"] is not trajectory.metadata["first"]
+    assert group.metadata["value"] is not trajectory.metadata["first"]
+    assert group.exceptions[0].message is not trajectory.metadata["first"]
+
+    assert (
+        copy.copy(group).trajectories[0].metadata["first"]
+        is trajectory.metadata["first"]
+    )
+    deep = copy.deepcopy(group)
+    assert (
+        deep.trajectories[0].metadata["first"]
+        is not deep.trajectories[1].metadata["value"]
+    )
+    restored = pickle.loads(pickle.dumps(group))
     canonical = trajectory.metadata["first"]
     assert other.metadata["value"] is canonical
     assert group.metadata["value"] is canonical
     assert group.exceptions[0].message is canonical
-
-    assert copy.copy(group).trajectories[0].metadata["first"] is canonical
-    deep = copy.deepcopy(group)
-    assert (
-        deep.trajectories[0].metadata["first"] is deep.trajectories[1].metadata["value"]
-    )
-    restored = pickle.loads(pickle.dumps(group))
     assert (
         restored.trajectories[0].metadata["first"]
         is restored.trajectories[1].metadata["value"]
@@ -128,7 +139,7 @@ def test_interning_does_not_change_model_equality() -> None:
     assert trajectory == before
 
 
-def test_capture_uses_a_scope_pool_and_no_capture_hides_it() -> None:
+def test_capture_defers_interning_and_no_capture_hides_scope() -> None:
     body = {
         "id": "chatcmpl-1",
         "object": "chat.completion",
@@ -155,7 +166,7 @@ def test_capture_uses_a_scope_pool_and_no_capture_hides_it() -> None:
         state.finish()
         reset(token)
         exchange = trajectory.exchanges.chat_completions[0]
-        assert exchange.request["model"] is exchange.response.model
+        assert exchange.request["model"] is not exchange.response.model
 
         with art.no_capture():
             hidden, hidden_token = begin(
@@ -164,8 +175,11 @@ def test_capture_uses_a_scope_pool_and_no_capture_hides_it() -> None:
             assert hidden is None
             assert hidden_token is None
 
+    pickle.dumps(trajectory)
+    assert exchange.request["model"] is exchange.response.model
 
-def test_nested_scopes_do_not_share_string_pools() -> None:
+
+def test_nested_scopes_do_not_intern_strings() -> None:
     repeated = _long()
     outer = art.Trajectory(metadata={"value": _fresh(repeated)})
     inner = art.Trajectory(metadata={"value": _fresh(repeated)})
@@ -177,7 +191,7 @@ def test_nested_scopes_do_not_share_string_pools() -> None:
         assert outer.metadata["value"] is not inner.metadata["value"]
 
 
-async def test_concurrent_capture_scopes_keep_independent_pools() -> None:
+async def test_concurrent_capture_scopes_do_not_intern_strings() -> None:
     repeated = _long()
     ready = 0
     both_ready = asyncio.Event()
@@ -210,7 +224,7 @@ def test_normal_pydantic_dumps_are_unchanged() -> None:
     assert json.loads(trajectory.model_dump_json()) == expected
 
 
-def test_tokenization_boundaries_intern_manual_mutations(
+def test_tokenization_boundaries_do_not_intern_manual_mutations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repeated = _long()
@@ -219,7 +233,7 @@ def test_tokenization_boundaries_intern_manual_mutations(
 
     def tokenize_trajectory(value: art.Trajectory, **_: object) -> object:
         first, second = value.metadata["items"]
-        assert first is second
+        assert first is not second
         return object()
 
     monkeypatch.setattr(_tokenize, "tokenize_trajectory", tokenize_trajectory)
@@ -230,7 +244,7 @@ def test_tokenization_boundaries_intern_manual_mutations(
 
     def tokenize_group(value: art.TrajectoryGroup, **_: object) -> object:
         first, second = value.metadata["items"]
-        assert first is second
+        assert first is not second
         return object()
 
     monkeypatch.setattr(_tokenize, "tokenize_group", tokenize_group)
@@ -259,7 +273,7 @@ def test_compact_trajectory_round_trip_and_literal_reference_collision() -> None
 
     trajectory.metadata["third"] = _fresh(repeated)
     trajectory.compact_dump()
-    assert trajectory.metadata["third"] is trajectory.metadata["first"]
+    assert trajectory.metadata["third"] is not trajectory.metadata["first"]
 
 
 def test_compact_decode_is_one_level_and_unmatched_references_are_literal() -> None:
@@ -677,18 +691,51 @@ def test_interning_reduces_pickle_and_compact_json_sizes() -> None:
     trajectory.metadata["items"] = [_fresh(repeated) for _ in range(200)]
     items = trajectory.metadata["items"]
     before_memory = sum(sys.getsizeof(item) for item in items)
-    before_pickle = len(pickle.dumps(trajectory))
-    trajectory.finish()
+    before_pickle = len(pickle.dumps(trajectory.model_dump()))
+    pickled = pickle.dumps(trajectory)
     after_memory = sum(
         sys.getsizeof(item) for item in {id(item): item for item in items}.values()
     )
-    after_pickle = len(pickle.dumps(trajectory))
     compact = trajectory.compact_dump()
     plain = {**compact, "strings": {}, "data": trajectory.model_dump(mode="json")}
 
     assert after_memory < before_memory / 100
-    assert after_pickle < before_pickle / 4
+    assert len(pickled) < before_pickle / 4
     assert _json_size(compact) < _json_size(plain) / 4
+
+
+def test_pickle_prepares_nested_graph_once_and_receiver_can_prepare_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from art.trajectories import _serialization
+
+    repeated = _long()
+    trajectory = art.Trajectory(
+        metadata={"first": _fresh(repeated), "second": _fresh(repeated)}
+    )
+    group = art.TrajectoryGroup([trajectory])
+    calls: list[object] = []
+    intern_strings = _serialization._intern_strings
+
+    def counted(value: object, pool: dict[str, str] | None = None) -> None:
+        calls.append(value)
+        intern_strings(value, pool)
+
+    monkeypatch.setattr(_serialization, "_intern_strings", counted)
+
+    payload = pickle.dumps(group)
+    assert calls == [group]
+    pickle.dumps(group)
+    assert calls == [group]
+
+    restored = pickle.loads(payload)
+    restored.trajectories[0].metadata["third"] = _fresh(repeated)
+    pickle.dumps(restored)
+    assert calls == [group, restored]
+    assert (
+        restored.trajectories[0].metadata["third"]
+        is restored.trajectories[0].metadata["first"]
+    )
 
 
 def test_cloudpickle_preserves_shared_references() -> None:


### PR DESCRIPTION
## Summary

- remove implicit string-interning traversals from trajectory construction, capture, finish, grouping, tokenization, and compact serialization
- lazily intern trajectory/history/tokenized/tensorized object graphs at their first pickle or cloudpickle boundary
- mark every eligible nested model during the root traversal so nested reducers and repeated sends in the same process do not rescan
- keep the marker process-local, preserving Pydantic equality and letting a receiving process prepare after local mutation

## Why

Automatic lifecycle scans made common trajectory-group construction hundreds of milliseconds slower at larger rollout sizes even when the values never crossed a process boundary. Pickle/cloudpickle transfer is where shared string identity materially reduces payload size, so this moves the work to that boundary.

Representative local timings for group construction before → after:

- 8 × 500 records: ~20 ms → ~0.1 ms
- 32 × 1,000 records: ~160 ms → ~0.1 ms
- 64 × 2,000 records: ~653 ms → ~0.2 ms

The corresponding first-boundary scans remain approximately 10 ms, 82 ms, and 346 ms, then are skipped on repeated serialization in that process.

## Validation

- trajectory suite: 335 passed
- focused compact/tokenized/tensorized suite: 43 passed
- full non-Megatron unit suite: 724 passed, 11 skipped; two unrelated OpenAI stream-close tests failed in the combined run and both passed immediately when rerun in isolation
- Ruff, Ruff format, ty, and uv-lock checks passed
- verified Python pickle, cloudpickle, nested one-scan behavior, receiver-side preparation, and unchanged normal/compact serialization