### PR TITLE
Fix Qwen 3.6 MoE identity LoRA layout

### DIFF
--- a/src/art/megatron/model_support/handlers/qwen3_5.py
+++ b/src/art/megatron/model_support/handlers/qwen3_5.py
@@ -651,6 +651,83 @@ def _vllm_moe_config(
     return config
 
 
+def _canonicalize_qwen35_peft_moe_target_parameter_layout(
+    tensors: dict[str, torch.Tensor],
+    *,
+    adapter_config: dict[str, Any],
+) -> dict[str, torch.Tensor]:
+    """Transpose PEFT's parameter-LoRA factors into vLLM's 3D MoE layout.
+
+    Qwen3.5 and Qwen3.6 store expert parameters as ``[expert, out, in]``
+    tensors, while PEFT's generic 3D target-parameter wrapper interprets them
+    as ``[expert, in, out]``. The resulting factors already use vLLM's fused
+    expert key names, but every expert delta is transposed. Shape-detect that
+    layout and transpose the factors back before Megatron import or vLLM
+    normalization.
+    """
+    grouped: dict[str, dict[str, str]] = {}
+    for key in tensors:
+        match = _VLLM_MOE_KEY_RE.match(key)
+        if match is None:
+            continue
+        slot = (
+            f"{'base_layer.' if match.group('base_layer') else ''}{match.group('lora')}"
+        )
+        grouped.setdefault(match.group("prefix"), {})[slot] = key
+    if not grouped:
+        return tensors
+
+    base_model = adapter_config.get("base_model_name_or_path")
+    if not isinstance(base_model, str) or not base_model:
+        return tensors
+    num_experts = int(adapter_config.get("num_experts", 0) or 0)
+    hidden = int(adapter_config.get("hidden_size", 0) or 0)
+    intermediate = int(adapter_config.get("moe_intermediate_size", 0) or 0)
+    if num_experts <= 0 or hidden <= 0 or intermediate <= 0:
+        config = _qwen35_text_config(base_model)
+        num_experts = int(getattr(config, "num_experts", 0) or 0)
+        hidden = int(getattr(config, "hidden_size", 0) or 0)
+        intermediate = int(getattr(config, "moe_intermediate_size", 0) or 0)
+    if num_experts <= 0 or hidden <= 0 or intermediate <= 0:
+        return tensors
+
+    transformed = dict(tensors)
+    for slots in grouped.values():
+        required = {
+            "base_layer.lora_A",
+            "base_layer.lora_B",
+            "lora_A",
+            "lora_B",
+        }
+        if set(slots) != required:
+            continue
+        gate_up_a_key = slots["base_layer.lora_A"]
+        gate_up_b_key = slots["base_layer.lora_B"]
+        down_a_key = slots["lora_A"]
+        down_b_key = slots["lora_B"]
+        gate_up_a = tensors[gate_up_a_key]
+        gate_up_b = tensors[gate_up_b_key]
+        down_a = tensors[down_a_key]
+        down_b = tensors[down_b_key]
+        packed_rank = int(gate_up_a.shape[0])
+        peft_shapes = (
+            (packed_rank, 2 * intermediate),
+            (hidden, packed_rank),
+            (packed_rank, hidden),
+            (intermediate, packed_rank),
+        )
+        actual_shapes = tuple(
+            tuple(tensor.shape) for tensor in (gate_up_a, gate_up_b, down_a, down_b)
+        )
+        if actual_shapes != peft_shapes:
+            continue
+        transformed[gate_up_a_key] = gate_up_b.transpose(0, 1).contiguous()
+        transformed[gate_up_b_key] = gate_up_a.transpose(0, 1).contiguous()
+        transformed[down_a_key] = down_b.transpose(0, 1).contiguous()
+        transformed[down_b_key] = down_a.transpose(0, 1).contiguous()
+    return transformed
+
+
 type _ExpertLoraGroups = dict[str, dict[int, dict[str, dict[str, torch.Tensor]]]]
 
 
@@ -705,6 +782,10 @@ def _to_vllm_lora_tensors(
     *,
     adapter_config: dict[str, Any],
 ) -> tuple[dict[str, torch.Tensor], dict[str, Any]]:
+    tensors = _canonicalize_qwen35_peft_moe_target_parameter_layout(
+        tensors,
+        adapter_config=adapter_config,
+    )
     grouped = _group_expert_lora_tensors(tensors, _ART_MOE_EXPERT_KEY_RE)
     has_shared_experts = _has_shared_expert_lora_tensors(tensors)
     transformed: dict[str, torch.Tensor] = {}
@@ -790,6 +871,10 @@ def _from_vllm_lora_tensors(
     *,
     adapter_config: dict[str, Any],
 ) -> dict[str, torch.Tensor]:
+    tensors = _canonicalize_qwen35_peft_moe_target_parameter_layout(
+        tensors,
+        adapter_config=adapter_config,
+    )
     convert = lambda key, tensor: _from_vllm_lora_tensor(
         key,
         tensor,

--- a/tests/integration/megatron/lora/test_lora_disk_codecs.py
+++ b/tests/integration/megatron/lora/test_lora_disk_codecs.py
@@ -131,6 +131,9 @@ def _qwen35_config(base_model: str, rank: int = 2, alpha: int = 4) -> dict:
     config = _config(base_model, rank=rank, alpha=alpha)
     config.update(
         {
+            "hidden_size": 3,
+            "moe_intermediate_size": 4,
+            "num_experts": 2,
             "num_attention_heads": 2,
             "num_key_value_heads": 1,
             "head_dim": 3,
@@ -775,6 +778,55 @@ def test_qwen35_and_qwen36_vllm_canonical_roundtrip_and_stock_loader(tmp_path: P
         )
         assert "language_model.model.layers.0.mlp.experts" in loaded_modules
         assert "language_model.model.layers.0.mlp.experts.base_layer" in loaded_modules
+
+
+def test_qwen36_peft_target_parameter_moe_layout_is_transposed():
+    prefix = "base_model.model.model.language_model.layers.0.mlp.experts"
+    peft_gate_up_a = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    peft_gate_up_b = torch.arange(12, dtype=torch.float32).reshape(6, 2)
+    peft_down_a = torch.arange(12, 24, dtype=torch.float32).reshape(2, 6)
+    peft_down_b = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+    peft_tensors = {
+        f"{prefix}.base_layer.lora_A.weight": peft_gate_up_a,
+        f"{prefix}.base_layer.lora_B.weight": peft_gate_up_b,
+        f"{prefix}.lora_A.weight": peft_down_a,
+        f"{prefix}.lora_B.weight": peft_down_b,
+    }
+    adapter_config = _qwen35_config(
+        "Qwen/Qwen3.6-35B-A3B",
+        rank=1,
+        alpha=1,
+    )
+    adapter_config.update({"hidden_size": 6, "moe_intermediate_size": 2})
+
+    normalized, _ = QWEN3_5_MOE_HANDLER.to_vllm_lora_tensors(
+        peft_tensors,
+        adapter_config=adapter_config,
+    )
+
+    assert torch.equal(
+        normalized[f"{prefix}.base_layer.lora_A.weight"], peft_gate_up_b.T
+    )
+    assert torch.equal(
+        normalized[f"{prefix}.base_layer.lora_B.weight"], peft_gate_up_a.T
+    )
+    assert torch.equal(normalized[f"{prefix}.lora_A.weight"], peft_down_b.T)
+    assert torch.equal(normalized[f"{prefix}.lora_B.weight"], peft_down_a.T)
+
+    internal = QWEN3_5_MOE_HANDLER.from_vllm_lora_tensors(
+        peft_tensors,
+        adapter_config=adapter_config,
+    )
+    art_prefix = "base_model.model.model.layers.0.mlp.experts"
+    for expert in range(2):
+        gate_up_a = internal[f"{art_prefix}.{expert}.gate_up_proj.lora_A.weight"]
+        gate_up_b = internal[f"{art_prefix}.{expert}.gate_up_proj.lora_B.weight"]
+        down_a = internal[f"{art_prefix}.{expert}.down_proj.lora_A.weight"]
+        down_b = internal[f"{art_prefix}.{expert}.down_proj.lora_B.weight"]
+        assert torch.equal(gate_up_a, peft_gate_up_b[:, expert].unsqueeze(0))
+        assert torch.equal(gate_up_b, peft_gate_up_a[expert].unsqueeze(1))
+        assert torch.equal(down_a, peft_down_b[:, expert].unsqueeze(0))
+        assert torch.equal(down_b, peft_down_a[expert].unsqueeze(1))
 
 
 def test_qwen35_vllm_config_preserves_shared_expert_targets_when_present():


### PR DESCRIPTION
## Summary

Fix Qwen 3.5/3.6 MoE LoRA conversion so identity adapters created through PEFT can be loaded by Megatron and normalized for vLLM.

## What failed

Qwen/Qwen3.6-35B-A3B training failed before the first optimization step while Megatron loaded the rank-1 identity LoRA:

    gate_up_proj: sharded load shape mismatch, got (256, 1024, 1), expected (256, 2048, 1)

The saved expert factors were transposed and assigned to the wrong side of each LoRA pair. For example, gate/up A was `(256, 1024)` instead of `(256, 2048)`, and the down-projection factors had the analogous mismatch.

## What we tried and why it did not work

We first checked whether serverless training was loading an old or partially generated identity adapter. The failing adapter had just been generated by the identity-LoRA workflow, so it was not stale.

Generating it again with the same ART/PEFT conversion path produced the same layout. A cache refresh alone therefore could not fix the problem; it would only store another malformed adapter.

We then compared the Qwen parameter shapes, PEFT factors, vLLM representation, and Megatron loader expectations. PEFT interprets a 3D target parameter as `[experts, in, out]`, while Qwen stores these expert weights as `[experts, out, in]`. That reverses the A/B dimensions for gate/up and down expert projections.

## What this fixes

- Detect the PEFT expert layout using Qwen's hidden size, MoE intermediate size, and expert count.
- Swap and transpose the affected gate/up and down A/B factors into the canonical layout.
- Apply the normalization before both vLLM conversion and Megatron import so the two paths agree.
- Add a regression test covering the PEFT-style Qwen 3.6 expert layout.

## Validation

- [x] Ruff check and format check.
- [x] Local tensor-layout regression smoke test.
- [x] Generated a fresh Qwen 3.6 35B rank-1 identity LoRA on an H200.
- [x] Loaded that adapter in Megatron without the original shape mismatch.
- [x] Completed a one-batch Qwen 3.6 35B SFT job on the H200.
