### PR TITLE
Stream base URL tau-bench completions safely

### DIFF
--- a/src/art/openai.py
+++ b/src/art/openai.py
@@ -2,7 +2,12 @@ from typing import Any, Callable, cast
 
 from openai import AsyncStream, Stream
 from openai.types.chat.chat_completion import ChatCompletion, Choice, ChoiceLogprobs
-from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
+from openai.types.chat.chat_completion_chunk import (
+    ChatCompletionChunk,
+)
+from openai.types.chat.chat_completion_chunk import (
+    Choice as ChatCompletionChunkChoice,
+)
 from openai.types.chat.chat_completion_message import (
     ChatCompletionMessage,
     FunctionCall,
@@ -17,9 +22,15 @@ from .preprocessing.policy_spans import POLICY_TOKEN_SPANS_KEY
 ART_MOE_ROUTING_METADATA_KEY = "art_moe_routing"
 
 
+class IncompleteChatCompletionStreamError(ValueError):
+    pass
+
+
 async def consume_chat_completion_stream(
     stream: AsyncStream[ChatCompletionChunk],
     on_chunk: Callable[[ChatCompletionChunk, ChatCompletion], Any] | None = None,
+    *,
+    require_usage: bool = False,
 ) -> ChatCompletion:
     """Consume a chat completion stream and build a complete ChatCompletion object.
 
@@ -31,56 +42,137 @@ async def consume_chat_completion_stream(
         stream: An AsyncStream of ChatCompletionChunk objects.
         on_chunk: Optional callback that receives each chunk and the current state of the
             ChatCompletion. If the callback raises StopIteration, the stream will close early.
+        require_usage: Reject a completed stream without a usage trailer.
 
     Returns:
         A complete ChatCompletion object built from the streamed chunks.
 
     Raises:
-        AssertionError: If no chat completion object could be created.
+        ValueError: If the stream has no choices or ends before a choice is terminal.
     """
     chat_completion: ChatCompletion | None = None
-    async for chunk in stream:
-        if chat_completion is None:
-            chat_completion = init_chat_completion(chunk)
-        update_chat_completion(chat_completion, chunk)
-        if on_chunk:
-            try:
-                on_chunk(chunk, chat_completion)
-            except StopIteration:
-                await stream.close()
-                break
-    assert chat_completion is not None
-    return chat_completion
+    terminal_choices: set[int] = set()
+    stopped_early = False
+    try:
+        async for chunk in stream:
+            if _is_empty_stream_prologue(chunk):
+                continue
+            if chat_completion is None:
+                chat_completion = init_chat_completion(chunk)
+            update_chat_completion(chat_completion, chunk)
+            terminal_choices.update(
+                choice.index
+                for choice in chunk.choices
+                if choice.finish_reason is not None
+            )
+            if on_chunk:
+                try:
+                    on_chunk(chunk, chat_completion)
+                except StopIteration:
+                    await stream.close()
+                    stopped_early = True
+                    break
+        return _validate_and_finalize_chat_completion(
+            chat_completion,
+            terminal_choices,
+            allow_incomplete=stopped_early,
+            require_usage=require_usage,
+        )
+    except BaseException:
+        await stream.close()
+        raise
+
+
+def _is_empty_stream_prologue(chunk: ChatCompletionChunk) -> bool:
+    return (
+        not chunk.choices
+        and chunk.id == ""
+        and chunk.object == ""
+        and chunk.model == ""
+        and chunk.usage is None
+    )
 
 
 def consume_sync_chat_completion_stream(
     stream: Stream[ChatCompletionChunk],
 ) -> ChatCompletion:
     chat_completion: ChatCompletion | None = None
-    for chunk in stream:
-        if chat_completion is None:
-            chat_completion = init_chat_completion(chunk)
-        update_chat_completion(chat_completion, chunk)
-    assert chat_completion is not None
-    return chat_completion
+    terminal_choices: set[int] = set()
+    try:
+        for chunk in stream:
+            if _is_empty_stream_prologue(chunk):
+                continue
+            if chat_completion is None:
+                chat_completion = init_chat_completion(chunk)
+            update_chat_completion(chat_completion, chunk)
+            terminal_choices.update(
+                choice.index
+                for choice in chunk.choices
+                if choice.finish_reason is not None
+            )
+        return _validate_and_finalize_chat_completion(
+            chat_completion,
+            terminal_choices,
+        )
+    except BaseException:
+        stream.close()
+        raise
+
+
+def _validate_and_finalize_chat_completion(
+    chat_completion: ChatCompletion | None,
+    terminal_choices: set[int],
+    *,
+    allow_incomplete: bool = False,
+    require_usage: bool = False,
+) -> ChatCompletion:
+    if chat_completion is None or not chat_completion.choices:
+        raise IncompleteChatCompletionStreamError(
+            "Chat Completions stream returned no choices"
+        )
+    if not allow_incomplete:
+        missing = {
+            choice.index for choice in chat_completion.choices
+        } - terminal_choices
+        if missing:
+            raise IncompleteChatCompletionStreamError(
+                "Chat Completions stream ended before choices "
+                f"{sorted(missing)} became terminal"
+            )
+    if require_usage and chat_completion.usage is None:
+        raise IncompleteChatCompletionStreamError(
+            "Chat Completions stream ended before its usage trailer"
+        )
+    return finalize_chat_completion(chat_completion)
 
 
 def init_chat_completion(chunk: ChatCompletionChunk) -> ChatCompletion:
     return ChatCompletion(
         id=chunk.id,
-        choices=[
-            Choice(
-                finish_reason="stop",
-                index=choice.index,
-                logprobs=(ChoiceLogprobs() if choice.logprobs else None),
-                message=ChatCompletionMessage(role="assistant"),
-            )
-            for choice in chunk.choices
-        ],
+        choices=[_init_choice(choice) for choice in chunk.choices],
         created=chunk.created,
         model=chunk.model,
         object="chat.completion",
     )
+
+
+def _init_choice(chunk_choice: ChatCompletionChunkChoice) -> Choice:
+    return Choice(
+        finish_reason=chunk_choice.finish_reason or "stop",
+        index=chunk_choice.index,
+        logprobs=(ChoiceLogprobs() if chunk_choice.logprobs else None),
+        message=ChatCompletionMessage(role="assistant"),
+    )
+
+
+def finalize_chat_completion(chat_completion: ChatCompletion) -> ChatCompletion:
+    prompt_token_ids = (chat_completion.model_extra or {}).get("prompt_token_ids")
+    if prompt_token_ids is not None:
+        for choice in chat_completion.choices:
+            cast(dict[str, Any], choice.model_extra)["prompt_token_ids"] = (
+                prompt_token_ids
+            )
+    return chat_completion
 
 
 def update_chat_completion(
@@ -91,7 +183,18 @@ def update_chat_completion(
     if prompt_token_ids is not None:
         chat_completion_extra["prompt_token_ids"] = prompt_token_ids
     completion_prompt_token_ids = chat_completion_extra.get("prompt_token_ids")
-    for choice, chunk_choice in zip(chat_completion.choices, chunk.choices):
+    choices = {choice.index: choice for choice in chat_completion.choices}
+    if completion_prompt_token_ids is not None:
+        for choice in choices.values():
+            cast(dict[str, Any], choice.model_extra)["prompt_token_ids"] = (
+                completion_prompt_token_ids
+            )
+    for chunk_choice in chunk.choices:
+        choice = choices.get(chunk_choice.index)
+        if choice is None:
+            choice = _init_choice(chunk_choice)
+            choices[choice.index] = choice
+            chat_completion.choices.append(choice)
         choice_extra = cast(dict[str, Any], choice.model_extra)
         if completion_prompt_token_ids is not None:
             choice_extra["prompt_token_ids"] = completion_prompt_token_ids
@@ -107,7 +210,8 @@ def update_chat_completion(
                 *choice_extra.get(POLICY_TOKEN_SPANS_KEY, []),
                 *policy_token_spans,
             ]
-        choice.finish_reason = chunk_choice.finish_reason or "stop"
+        if chunk_choice.finish_reason is not None:
+            choice.finish_reason = chunk_choice.finish_reason
         if chunk_choice.logprobs:
             if choice.logprobs is None:
                 choice.logprobs = ChoiceLogprobs()
@@ -119,11 +223,11 @@ def update_chat_completion(
                 if choice.logprobs.refusal is None:
                     choice.logprobs.refusal = []
                 choice.logprobs.refusal.extend(chunk_choice.logprobs.refusal)
-        if chunk_choice.delta.content:
+        if chunk_choice.delta.content is not None:
             if choice.message.content is None:
                 choice.message.content = ""
             choice.message.content += chunk_choice.delta.content
-        if chunk_choice.delta.refusal:
+        if chunk_choice.delta.refusal is not None:
             if choice.message.refusal is None:
                 choice.message.refusal = ""
             choice.message.refusal += chunk_choice.delta.refusal
@@ -140,6 +244,11 @@ def update_chat_completion(
             if choice.message.tool_calls is None:
                 choice.message.tool_calls = []
             for tool_call_delta in chunk_choice.delta.tool_calls:
+                if tool_call_delta.index < 0:
+                    raise ValueError(
+                        "Tool call stream index must be non-negative, got "
+                        f"{tool_call_delta.index}"
+                    )
                 while tool_call_delta.index not in range(
                     len(choice.message.tool_calls)
                 ):
@@ -151,27 +260,31 @@ def update_chat_completion(
                         )
                     )
                 if tool_call_delta.id:
-                    choice.message.tool_calls[
-                        tool_call_delta.index
-                    ].id = tool_call_delta.id
+                    choice.message.tool_calls[tool_call_delta.index].id += (
+                        tool_call_delta.id
+                    )
                 if tool_call_delta.function:
                     tool_call = choice.message.tool_calls[tool_call_delta.index]
                     assert isinstance(tool_call, ChatCompletionMessageFunctionToolCall)
                     if tool_call_delta.function.name:
-                        tool_call.function.name = tool_call_delta.function.name
+                        tool_call.function.name += tool_call_delta.function.name
                     if tool_call_delta.function.arguments:
                         tool_call.function.arguments += (
                             tool_call_delta.function.arguments
                         )
         for field in ("reasoning", "reasoning_content"):
             value = getattr(chunk_choice.delta, field, None)
-            if not value:
+            if value is None:
                 continue
             setattr(
                 choice.message,
                 field,
                 (getattr(choice.message, field, None) or "") + value,
             )
-    chat_completion.service_tier = chunk.service_tier
-    chat_completion.system_fingerprint = chunk.system_fingerprint
-    chat_completion.usage = chunk.usage
+    chat_completion.choices.sort(key=lambda choice: choice.index)
+    if chunk.service_tier is not None:
+        chat_completion.service_tier = chunk.service_tier
+    if chunk.system_fingerprint is not None:
+        chat_completion.system_fingerprint = chunk.system_fingerprint
+    if chunk.usage is not None:
+        chat_completion.usage = chunk.usage

--- a/src/art/tau_bench/rollout.py
+++ b/src/art/tau_bench/rollout.py
@@ -1,17 +1,34 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 import json
+import logging
 import os
 import time
 from typing import Any, cast, overload
 
-from openai import AsyncOpenAI, BadRequestError
+import httpx
+from openai import (
+    APIConnectionError,
+    APIError,
+    APITimeoutError,
+    AsyncOpenAI,
+    AsyncStream,
+    BadRequestError,
+    DefaultAsyncHttpxClient,
+)
 from openai.types.chat import ChatCompletionMessageParam
+from openai.types.chat.chat_completion import ChatCompletion
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from openai.types.completion_usage import CompletionUsage
 
 from art.costs import get_model_pricing, tokens_to_cost
 from art.model import Model
+from art.openai import (
+    IncompleteChatCompletionStreamError,
+    consume_chat_completion_stream,
+)
 from art.trajectories import Trajectory
 
 from .client import Scenario, TauBenchClient, _get_default_client
@@ -19,6 +36,8 @@ from .client import Scenario, TauBenchClient, _get_default_client
 openai_clients: dict[tuple[str, str], AsyncOpenAI] = {}
 CONTEXT_TOKEN_LIMIT = 32_768
 DEFAULT_MAX_COMPLETION_TOKENS = 4096
+_POLICY_CONNECTION_LIMIT = 2048
+_STREAM_RETRY_STATUS_CODES = {408, 409, 429, 500, 502, 503, 504}
 
 
 @overload
@@ -98,6 +117,29 @@ async def rollout(
             model=model,
             base_model=base_model,
         )
+        policy_completion_kwargs = dict(chat_completion_kwargs)
+        stream_policy = bool(
+            policy_completion_kwargs.setdefault(
+                "stream", isinstance(base_url_or_model, str)
+            )
+        )
+        if stream_policy:
+            stream_options = dict(
+                cast(
+                    Mapping[str, Any],
+                    policy_completion_kwargs.get("stream_options") or {},
+                )
+            )
+            stream_options["include_usage"] = True
+            policy_completion_kwargs["stream_options"] = stream_options
+            extra_headers = dict(
+                cast(
+                    Mapping[str, str],
+                    policy_completion_kwargs.get("extra_headers") or {},
+                )
+            )
+            extra_headers.setdefault("X-ART-Stream-Progress", "sse-comments-v1")
+            policy_completion_kwargs["extra_headers"] = extra_headers
         messages: list[ChatCompletionMessageParam] = [
             {"role": "system", "content": env.info["policy"]},
             {"role": "user", "content": env.observation.removeprefix("user: ")},
@@ -120,13 +162,14 @@ async def rollout(
                     break
                 try:
                     policy_started = time.perf_counter()
-                    chat_completion = await openai_client.chat.completions.create(
+                    chat_completion = await _create_policy_completion(
+                        openai_client,
                         messages=messages,
                         model=model_name,
-                        stream=False,
+                        stream_policy=stream_policy,
                         tool_choice="auto",
                         tools=tools,
-                        **chat_completion_kwargs,
+                        **policy_completion_kwargs,
                     )
                     policy_latency = time.perf_counter() - policy_started
                     trajectory.metrics["latency/policy"] = (
@@ -136,7 +179,7 @@ async def rollout(
                         trajectory.metrics.get("latency/policy_max", 0.0),
                         policy_latency,
                     )
-                except BadRequestError as exc:
+                except (BadRequestError, APIError) as exc:
                     if _is_max_tokens_error(exc):
                         break
                     raise
@@ -220,6 +263,58 @@ async def rollout(
         return trajectory
 
 
+async def _create_policy_completion(
+    openai_client: AsyncOpenAI,
+    *,
+    stream_policy: bool,
+    **kwargs: Any,
+) -> ChatCompletion:
+    attempts = max(1, int(getattr(openai_client, "max_retries", 2)) + 1)
+    for attempt in range(attempts):
+        completion = await openai_client.chat.completions.create(**kwargs)
+        if not stream_policy:
+            return cast(ChatCompletion, completion)
+        try:
+            return await consume_chat_completion_stream(
+                cast(AsyncStream[ChatCompletionChunk], completion),
+                require_usage=True,
+            )
+        except Exception as error:
+            if attempt == attempts - 1 or not _retryable_stream_error(error):
+                raise
+            delay = 0.25 * (2**attempt)
+            logging.warning(
+                "Retrying streamed policy completion after %s",
+                type(error).__name__,
+            )
+            await asyncio.sleep(delay)
+    raise AssertionError("unreachable")
+
+
+def _retryable_stream_error(error: Exception) -> bool:
+    if isinstance(
+        error,
+        (
+            IncompleteChatCompletionStreamError,
+            APIConnectionError,
+            APITimeoutError,
+            httpx.TransportError,
+            json.JSONDecodeError,
+        ),
+    ):
+        return True
+    if not isinstance(error, APIError):
+        return False
+    body = getattr(error, "body", None)
+    code = body.get("code") if isinstance(body, Mapping) else None
+    if not isinstance(code, (int, str)):
+        return False
+    try:
+        return int(code) in _STREAM_RETRY_STATUS_CODES
+    except (TypeError, ValueError):
+        return False
+
+
 def _completion_client_and_model(
     base_url_or_model: str | Model,
     *,
@@ -238,7 +333,16 @@ def _completion_client_and_model(
         raise TypeError("base_url, api_key, and model are required for string rollouts")
     key = (base_url_or_model, api_key)
     if key not in openai_clients:
-        openai_clients[key] = AsyncOpenAI(api_key=api_key, base_url=base_url_or_model)
+        openai_clients[key] = AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url_or_model,
+            http_client=DefaultAsyncHttpxClient(
+                limits=httpx.Limits(
+                    max_connections=_POLICY_CONNECTION_LIMIT,
+                    max_keepalive_connections=_POLICY_CONNECTION_LIMIT,
+                )
+            ),
+        )
     return openai_clients[key], model, base_model
 
 
@@ -274,7 +378,7 @@ def _record_tinker_costs(
     )
 
 
-def _is_max_tokens_error(exc: BadRequestError) -> bool:
+def _is_max_tokens_error(exc: APIError) -> bool:
     message = getattr(exc, "message", str(exc))
     return "max_tokens" in message or "max_completion_tokens" in message
 

--- a/src/art/trajectories/_protocols.py
+++ b/src/art/trajectories/_protocols.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
 import json
 import math
@@ -15,7 +16,11 @@ from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from openai.types.responses import Response
 from pydantic import TypeAdapter, ValidationError
 
-from ..openai import init_chat_completion, update_chat_completion
+from ..openai import (
+    finalize_chat_completion,
+    init_chat_completion,
+    update_chat_completion,
+)
 from ..preprocessing.moe_routing import attach_moe_routing_metadata_to_choice
 from ..vllm_route_transport import (
     decode_routed_experts_response,
@@ -99,6 +104,7 @@ def _chat_response(body: bytes, *, stream: bool) -> ChatCompletion:
         return ChatCompletion.model_validate_json(body)
     response: ChatCompletion | None = None
     choices: dict[int, ChatCompletion] = {}
+    terminal_choices: set[int] = set()
     done = False
     for _, payload in _sse_events(body):
         if payload == "[DONE]":
@@ -129,16 +135,23 @@ def _chat_response(body: bytes, *, stream: bool) -> ChatCompletion:
             response = init_chat_completion(chunk.model_copy(update={"choices": []}))
         update_chat_completion(response, chunk.model_copy(update={"choices": []}))
         for choice in chunk.choices:
+            if choice.finish_reason is not None:
+                terminal_choices.add(choice.index)
             choice_chunk = chunk.model_copy(update={"choices": [choice]})
             choice_response = choices.get(choice.index)
             if choice_response is None:
                 choice_response = init_chat_completion(choice_chunk)
                 choices[choice.index] = choice_response
             update_chat_completion(choice_response, choice_chunk)
-    if response is None or not done:
+    if response is None or not done or not choices:
         raise ValueError("Incomplete Chat Completions stream")
+    missing = set(choices) - terminal_choices
+    if missing:
+        raise ValueError(
+            f"Chat Completions stream choices {sorted(missing)} were not terminal"
+        )
     response.choices = [choices[index].choices[0] for index in sorted(choices)]
-    return response
+    return finalize_chat_completion(response)
 
 
 def _completion_response(body: bytes, *, stream: bool) -> Completion:
@@ -361,6 +374,14 @@ def build_exchange(
     stream = request.get("stream") is True
     if endpoint == "chat_completions":
         response = _chat_response(body, stream=stream)
+        stream_options = request.get("stream_options")
+        if (
+            stream
+            and isinstance(stream_options, Mapping)
+            and stream_options.get("include_usage") is True
+            and response.usage is None
+        ):
+            raise ValueError("Chat Completions stream is missing requested usage")
         return ChatCompletionsExchange(
             request=ChatCompletionsRequest(**request),
             response=response,

--- a/tests/unit/test_auto_trajectory.py
+++ b/tests/unit/test_auto_trajectory.py
@@ -120,13 +120,15 @@ mock_stream_response = b"""data: {"id":"chatcmpl-aa0d1e3261414f53acafc2f8e53bf9d
 
 data: {"id":"chatcmpl-aa0d1e3261414f53acafc2f8e53bf9d6","object":"chat.completion.chunk","created":1755831263,"model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
 
-data: {"id":"chatcmpl-aa0d1e3261414f53acafc2f8e53bf9d6","object":"chat.completion.chunk","created":1755831263,"model":"test","choices":[{"index":0,"delta":{"tool_calls":[{"id":"chatcmpl-tool-29e663261e524fcfa2162f4f3d76a7f0","type":"function","index":0,"function":{"name":"get_current_weather","arguments":"{"}}]},"logprobs":{"content":[{"token":"token_id:314","logprob":-0.00015293381875380874,"bytes":[32,123],"top_logprobs":[]}]},"finish_reason":null}]}
+data: {"id":"chatcmpl-aa0d1e3261414f53acafc2f8e53bf9d6","object":"chat.completion.chunk","created":1755831263,"model":"test","choices":[{"index":0,"delta":{"tool_calls":[{"type":"function","index":0,"function":{"arguments":"{"}}]},"logprobs":{"content":[{"token":"token_id:314","logprob":-0.00015293381875380874,"bytes":[32,123],"top_logprobs":[]}]},"finish_reason":null}]}
 
 data: {"id":"chatcmpl-aa0d1e3261414f53acafc2f8e53bf9d6","object":"chat.completion.chunk","created":1755831263,"model":"test","choices":[{"index":0,"delta":{"tool_calls":[{"id":"chatcmpl-tool-29e663261e524fcfa2162f4f3d76a7f0","type":"function","index":0,"function":{"name":"get_current_weather","arguments":"{"}}]},"logprobs":{"content":[{"token":"token_id:314","logprob":-0.00015293381875380874,"bytes":[32,123],"top_logprobs":[]}]},"finish_reason":null}]}
 
 data: {"id":"chatcmpl-aa0d1e3261414f53acafc2f8e53bf9d6","object":"chat.completion.chunk","created":1755831263,"model":"test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":null,"arguments":"}"}}]},"logprobs":{"content":[{"token":"token_id:3417","logprob":-3.576278118089249e-7,"bytes":[125,125],"top_logprobs":[]}]},"finish_reason":null}]}
 
 data: {"id":"chatcmpl-aa0d1e3261414f53acafc2f8e53bf9d6","object":"chat.completion.chunk","created":1755831263,"model":"test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":null,"arguments":"}"}}]},"logprobs":{"content":[{"token":"token_id:3417","logprob":-3.576278118089249e-7,"bytes":[125,125],"top_logprobs":[]}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-aa0d1e3261414f53acafc2f8e53bf9d6","object":"chat.completion.chunk","created":1755831263,"model":"test","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
 
 data: [DONE]
 
@@ -167,7 +169,7 @@ mock_stream_choice = Choice(
             "refusal": None,
         },
         "message": {
-            "content": None,
+            "content": "",
             "refusal": None,
             "role": "assistant",
             "annotations": None,

--- a/tests/unit/test_openai_stream.py
+++ b/tests/unit/test_openai_stream.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterator
+from typing import cast
+
+import httpx
+from openai import AsyncOpenAI, AsyncStream, Stream
+from openai.types.chat import ChatCompletionChunk
+from openai.types.chat.chat_completion_message_function_tool_call import (
+    ChatCompletionMessageFunctionToolCall,
+)
+import pytest
+
+from art.openai import (
+    consume_chat_completion_stream,
+    consume_sync_chat_completion_stream,
+)
+from art.trajectories._protocols import _chat_response
+
+
+class _Stream:
+    def __init__(self, chunks: list[ChatCompletionChunk]) -> None:
+        self._chunks = iter(chunks)
+        self.closed = False
+
+    def __aiter__(self) -> AsyncIterator[ChatCompletionChunk]:
+        return self
+
+    async def __anext__(self) -> ChatCompletionChunk:
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _SyncStream:
+    def __init__(self, chunks: list[ChatCompletionChunk]) -> None:
+        self._chunks = chunks
+        self.closed = False
+
+    def __iter__(self) -> Iterator[ChatCompletionChunk]:
+        return iter(self._chunks)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _HangingStream(_Stream):
+    def __init__(self, chunks: list[ChatCompletionChunk]) -> None:
+        super().__init__(chunks)
+        self.waiting = asyncio.Event()
+
+    async def __anext__(self) -> ChatCompletionChunk:
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            self.waiting.set()
+            await asyncio.Future()
+            raise AssertionError("unreachable")
+
+
+def _chunk(**values: object) -> ChatCompletionChunk:
+    return ChatCompletionChunk.model_validate(
+        {
+            "id": "completion",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "test-model",
+            "choices": [],
+            **values,
+        }
+    )
+
+
+def _chunks() -> list[ChatCompletionChunk]:
+    first_span = {
+        "start_token": 0,
+        "end_token": 1,
+        "policy_version": 1,
+        "lora_slot": "slot",
+        "update_seq": 2,
+    }
+    second_span = {**first_span, "start_token": 1, "end_token": 2}
+    return [
+        ChatCompletionChunk.model_construct(
+            id="", object="", created=0, model="", choices=[]
+        ),
+        _chunk(
+            service_tier="default",
+            system_fingerprint="fingerprint",
+            choices=[
+                {
+                    "index": 1,
+                    "delta": {
+                        "role": "assistant",
+                        "reasoning_content": "think-b ",
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call-",
+                                "type": "function",
+                                "function": {
+                                    "name": "look",
+                                    "arguments": '{"x":',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": None,
+                    "token_ids": [21],
+                    "policy_token_spans": [first_span],
+                    "logprobs": {
+                        "content": [
+                            {
+                                "token": "token_id:21",
+                                "logprob": -0.21,
+                                "bytes": [98],
+                                "top_logprobs": [],
+                            }
+                        ]
+                    },
+                }
+            ],
+        ),
+        _chunk(
+            choices=[
+                {
+                    "index": 1,
+                    "delta": {
+                        "reasoning_content": "more",
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "b",
+                                "function": {"name": "up", "arguments": "1}"},
+                            }
+                        ],
+                    },
+                    "finish_reason": None,
+                    "token_ids": [22],
+                    "policy_token_spans": [second_span],
+                    "logprobs": {
+                        "content": [
+                            {
+                                "token": "token_id:22",
+                                "logprob": -0.22,
+                                "bytes": [99],
+                                "top_logprobs": [],
+                            }
+                        ]
+                    },
+                },
+                {
+                    "index": 0,
+                    "delta": {
+                        "role": "assistant",
+                        "reasoning": "think-a",
+                        "content": "answer-a",
+                    },
+                    "finish_reason": None,
+                    "token_ids": [11],
+                    "policy_token_spans": [first_span],
+                    "logprobs": {
+                        "content": [
+                            {
+                                "token": "token_id:11",
+                                "logprob": -0.11,
+                                "bytes": [97],
+                                "top_logprobs": [],
+                            }
+                        ]
+                    },
+                },
+            ]
+        ),
+        _chunk(
+            choices=[
+                {
+                    "index": 0,
+                    "delta": {"content": "!"},
+                    "finish_reason": "stop",
+                    "token_ids": [12],
+                    "policy_token_spans": [second_span],
+                    "logprobs": {
+                        "content": [
+                            {
+                                "token": "token_id:12",
+                                "logprob": -0.12,
+                                "bytes": [33],
+                                "top_logprobs": [],
+                            }
+                        ]
+                    },
+                },
+                {
+                    "index": 1,
+                    "delta": {},
+                    "finish_reason": "tool_calls",
+                },
+            ]
+        ),
+        _chunk(
+            prompt_token_ids=[1, 2],
+            usage={
+                "prompt_tokens": 2,
+                "completion_tokens": 4,
+                "total_tokens": 6,
+            }
+        ),
+    ]
+
+
+def _sse(chunks: list[ChatCompletionChunk]) -> bytes:
+    frames = [b": caladan-progress\n\n"]
+    for chunk in chunks:
+        if chunk.object == "":
+            frames.append(
+                b'data: {"id":"","object":"","created":0,"model":"",'
+                b'"choices":[]}\n\n'
+            )
+            continue
+        frames.extend(
+            (
+                b"data: " + chunk.model_dump_json(exclude_none=True).encode() + b"\n\n",
+                b": caladan-progress\n\n",
+            )
+        )
+    frames.append(b"data: [DONE]\n\n")
+    return b"".join(frames)
+
+
+def _consume(chunks: list[ChatCompletionChunk], *, require_usage: bool = False):
+    return asyncio.run(
+        consume_chat_completion_stream(
+            cast(AsyncStream[ChatCompletionChunk], _Stream(chunks)),
+            require_usage=require_usage,
+        )
+    )
+
+
+def test_stream_consumer_matches_auto_capture_reconstruction() -> None:
+    chunks = _chunks()
+
+    consumed = _consume(chunks)
+    captured = _chat_response(_sse(chunks), stream=True)
+
+    assert consumed.model_dump(mode="json") == captured.model_dump(mode="json")
+    assert [choice.index for choice in consumed.choices] == [0, 1]
+    first, second = consumed.choices
+    assert first.message.content == "answer-a!"
+    assert first.message.model_extra == {"reasoning": "think-a"}
+    assert second.message.model_extra == {"reasoning_content": "think-b more"}
+    assert second.message.tool_calls is not None
+    tool_call = second.message.tool_calls[0]
+    assert isinstance(tool_call, ChatCompletionMessageFunctionToolCall)
+    assert tool_call.function.arguments == '{"x":1}'
+    assert first.model_extra == {
+        "prompt_token_ids": [1, 2],
+        "token_ids": [11, 12],
+        "policy_token_spans": [
+            {
+                "start_token": 0,
+                "end_token": 1,
+                "policy_version": 1,
+                "lora_slot": "slot",
+                "update_seq": 2,
+            },
+            {
+                "start_token": 1,
+                "end_token": 2,
+                "policy_version": 1,
+                "lora_slot": "slot",
+                "update_seq": 2,
+            },
+        ],
+    }
+    assert second.model_extra is not None
+    assert second.model_extra["token_ids"] == [21, 22]
+    assert first.logprobs is not None
+    assert second.logprobs is not None
+    assert len(first.logprobs.content or []) == 2
+    assert len(second.logprobs.content or []) == 2
+    assert consumed.usage is not None
+    assert consumed.usage.total_tokens == 6
+    assert consumed.service_tier == "default"
+    assert consumed.system_fingerprint == "fingerprint"
+
+
+def test_sync_stream_consumer_matches_async_consumer() -> None:
+    chunks = _chunks()
+
+    asynchronous = _consume(chunks)
+    synchronous = consume_sync_chat_completion_stream(
+        cast(Stream[ChatCompletionChunk], _SyncStream(chunks))
+    )
+
+    assert synchronous.model_dump(mode="json") == asynchronous.model_dump(mode="json")
+
+
+@pytest.mark.asyncio
+async def test_openai_sdk_ignores_sse_comments_and_empty_prologue() -> None:
+    chunks = _chunks()
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=_sse(chunks),
+            headers={"Content-Type": "text/event-stream"},
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = AsyncOpenAI(
+        api_key="test",
+        base_url="http://model.test/v1",
+        http_client=http_client,
+    )
+    try:
+        stream = await client.chat.completions.create(
+            model="test-model",
+            messages=[{"role": "user", "content": "test"}],
+            stream=True,
+        )
+        consumed = await consume_chat_completion_stream(stream)
+    finally:
+        await client.close()
+        await http_client.aclose()
+
+    captured = _chat_response(_sse(chunks), stream=True)
+    assert consumed.model_dump(mode="json") == captured.model_dump(mode="json")
+
+
+def test_stream_consumer_preserves_explicit_empty_text_fields() -> None:
+    chunks = [
+        _chunk(
+            choices=[
+                {
+                    "index": 0,
+                    "delta": {"content": "", "refusal": ""},
+                    "finish_reason": "stop",
+                }
+            ]
+        )
+    ]
+
+    consumed = _consume(chunks)
+
+    assert consumed.choices[0].message.content == ""
+    assert consumed.choices[0].message.refusal == ""
+
+
+def test_stream_consumer_rejects_premature_choice_termination() -> None:
+    chunks = _chunks()[:2]
+
+    with pytest.raises(ValueError, match="ended before choices"):
+        _consume(chunks)
+
+
+def test_stream_consumer_can_require_usage_trailer() -> None:
+    chunks = _chunks()[:-1]
+
+    assert _consume(chunks).usage is None
+    with pytest.raises(ValueError, match="usage trailer"):
+        _consume(chunks, require_usage=True)
+
+
+def test_auto_capture_rejects_done_with_nonterminal_choice() -> None:
+    with pytest.raises(ValueError, match="were not terminal"):
+        _chat_response(_sse(_chunks()[:2]), stream=True)
+
+
+def _negative_tool_call_chunk() -> ChatCompletionChunk:
+    return _chunk(
+        choices=[
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": -1,
+                            "id": "call",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls",
+            }
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_closes_on_reconstruction_error() -> None:
+    stream = _Stream([_negative_tool_call_chunk()])
+
+    with pytest.raises(ValueError, match="must be non-negative"):
+        await consume_chat_completion_stream(
+            cast(AsyncStream[ChatCompletionChunk], stream)
+        )
+
+    assert stream.closed
+
+
+def test_sync_stream_consumer_closes_on_reconstruction_error() -> None:
+    stream = _SyncStream([_negative_tool_call_chunk()])
+
+    with pytest.raises(ValueError, match="must be non-negative"):
+        consume_sync_chat_completion_stream(cast(Stream[ChatCompletionChunk], stream))
+
+    assert stream.closed
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_closes_on_cancellation() -> None:
+    stream = _HangingStream(
+        [_chunk(choices=[{"index": 0, "delta": {"content": "partial"}}])]
+    )
+    task = asyncio.create_task(
+        consume_chat_completion_stream(cast(AsyncStream[ChatCompletionChunk], stream))
+    )
+    await stream.waiting.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert stream.closed

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 import importlib
 import json
 from types import SimpleNamespace
 from typing import Any
 
 import httpx
-from openai import AsyncOpenAI
-from openai.types.chat import ChatCompletion
+from openai import APIError, AsyncOpenAI
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
 import pytest
 
 import art
@@ -250,9 +251,92 @@ class FakeTauBenchClient(TauBenchClient):
         return DeleteEnvironmentResponse(id=env_id, deleted=True)
 
 
+class FakeStream:
+    def __init__(self, chunks: list[ChatCompletionChunk]) -> None:
+        self._chunks = iter(chunks)
+
+    def __aiter__(self) -> AsyncIterator[ChatCompletionChunk]:
+        return self
+
+    async def __anext__(self) -> ChatCompletionChunk:
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+    async def close(self) -> None:
+        pass
+
+
+class FailedStream:
+    def __aiter__(self) -> AsyncIterator[ChatCompletionChunk]:
+        return self
+
+    async def __anext__(self) -> ChatCompletionChunk:
+        raise httpx.ReadError(
+            "connection reset",
+            request=httpx.Request("POST", "http://model.test/v1/chat/completions"),
+        )
+
+    async def close(self) -> None:
+        pass
+
+
+class MaxTokensErrorStream:
+    def __aiter__(self) -> AsyncIterator[ChatCompletionChunk]:
+        return self
+
+    async def __anext__(self) -> ChatCompletionChunk:
+        raise APIError(
+            message="max_tokens is too large for this model",
+            request=httpx.Request("POST", "http://model.test/v1/chat/completions"),
+            body={"code": 400},
+        )
+
+    async def close(self) -> None:
+        pass
+
+
 class FakeCompletions:
     async def create(self, **kwargs: Any) -> Any:
         self.kwargs = kwargs
+        if kwargs.get("stream"):
+            return FakeStream(
+                [
+                    ChatCompletionChunk.model_validate(
+                        {
+                            "id": "chat-1",
+                            "object": "chat.completion.chunk",
+                            "created": 0,
+                            "model": "default",
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "finish_reason": "stop",
+                                    "delta": {
+                                        "role": "assistant",
+                                        "content": "hello",
+                                    },
+                                }
+                            ],
+                        }
+                    ),
+                    ChatCompletionChunk.model_validate(
+                        {
+                            "id": "chat-1",
+                            "object": "chat.completion.chunk",
+                            "created": 0,
+                            "model": "default",
+                            "choices": [],
+                            "usage": {
+                                "prompt_tokens": 10,
+                                "completion_tokens": 5,
+                                "total_tokens": 15,
+                            },
+                        }
+                    ),
+                ]
+            )
         return ChatCompletion.model_validate(
             {
                 "id": "chat-1",
@@ -281,6 +365,36 @@ class FakeAsyncOpenAI:
         self.chat = SimpleNamespace(completions=FakeCompletions())
 
 
+class RetryStreamCompletions(FakeCompletions):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.calls += 1
+        if self.calls == 1:
+            return FailedStream()
+        return await super().create(**kwargs)
+
+
+class RetryStreamAsyncOpenAI:
+    max_retries = 1
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.chat = SimpleNamespace(completions=RetryStreamCompletions())
+
+
+class MaxTokensStreamCompletions:
+    async def create(self, **kwargs: Any) -> Any:
+        return MaxTokensErrorStream()
+
+
+class MaxTokensStreamAsyncOpenAI:
+    max_retries = 0
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.chat = SimpleNamespace(completions=MaxTokensStreamCompletions())
+
+
 @pytest.mark.asyncio
 async def test_rollout_supports_string_model_args(
     monkeypatch: pytest.MonkeyPatch,
@@ -288,6 +402,11 @@ async def test_rollout_supports_string_model_args(
     rollout_module = importlib.import_module("art.tau_bench.rollout")
     rollout_module.openai_clients.clear()
     monkeypatch.setattr(rollout_module, "AsyncOpenAI", FakeAsyncOpenAI)
+    monkeypatch.setattr(
+        rollout_module,
+        "DefaultAsyncHttpxClient",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
     client = FakeTauBenchClient()
     scenario = Scenario(domain="banking_knowledge", task=Task(id="task_001"))
 
@@ -312,6 +431,136 @@ async def test_rollout_supports_string_model_args(
     assert trajectory.metrics["tokens/completion"] == 5
     assert client.deleted == ["env-1"]
     assert client.create_kwargs["user_llm"] == "gpt-4.1-2025-04-14"
+    policy_client: Any = rollout_module.openai_clients[
+        ("http://model.test/v1", "model-key")
+    ]
+    completions = policy_client.chat.completions
+    assert completions.kwargs["stream"] is True
+    assert completions.kwargs["stream_options"] == {"include_usage": True}
+    assert completions.kwargs["extra_headers"] == {
+        "X-ART-Stream-Progress": "sse-comments-v1"
+    }
+    limits = policy_client.kwargs["http_client"].limits
+    assert limits.max_connections == 2048
+    assert limits.max_keepalive_connections == 2048
+
+
+@pytest.mark.asyncio
+async def test_rollout_retries_stream_body_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rollout_module = importlib.import_module("art.tau_bench.rollout")
+    rollout_module.openai_clients.clear()
+    monkeypatch.setattr(rollout_module, "AsyncOpenAI", RetryStreamAsyncOpenAI)
+
+    trajectory = await rollout_module.rollout(
+        Scenario(domain="banking_knowledge", task=Task(id="task_001")),
+        "http://model.test/v1",
+        "model-key",
+        "default",
+        client=FakeTauBenchClient(),
+        max_turns=1,
+    )
+
+    completions: Any = rollout_module.openai_clients[
+        ("http://model.test/v1", "model-key")
+    ].chat.completions
+    assert completions.calls == 2
+    assert trajectory.reward == 1.0
+
+
+@pytest.mark.asyncio
+async def test_rollout_does_not_capture_stream_attempt_missing_requested_usage() -> None:
+    rollout_module = importlib.import_module("art.tau_bench.rollout")
+    rollout_module.openai_clients.clear()
+    requests = 0
+
+    def stream_body(content: str, *, include_usage: bool) -> bytes:
+        chunks = [
+            {
+                "id": "completion",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "default",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": content},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "completion",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "default",
+                "choices": [
+                    {"index": 0, "delta": {}, "finish_reason": "stop"}
+                ],
+            },
+        ]
+        if include_usage:
+            chunks.append(
+                {
+                    "id": "completion",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "default",
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 2,
+                        "completion_tokens": 1,
+                        "total_tokens": 3,
+                    },
+                }
+            )
+        return b"".join(
+            [
+                *(f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks),
+                b"data: [DONE]\n\n",
+            ]
+        )
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal requests
+        requests += 1
+        return httpx.Response(
+            200,
+            content=stream_body(
+                "bad" if requests == 1 else "good",
+                include_usage=requests > 1,
+            ),
+            headers={"Content-Type": "text/event-stream"},
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    openai_client = AsyncOpenAI(
+        api_key="model-key",
+        base_url="http://model.test/v1",
+        http_client=http_client,
+        max_retries=1,
+    )
+    rollout_module.openai_clients[("http://model.test/v1", "model-key")] = openai_client
+    try:
+        trajectory = await rollout_module.rollout(
+            Scenario(domain="banking_knowledge", task=Task(id="task_001")),
+            "http://model.test/v1",
+            "model-key",
+            "default",
+            client=FakeTauBenchClient(),
+            max_turns=1,
+        )
+    finally:
+        await openai_client.close()
+        await http_client.aclose()
+        rollout_module.openai_clients.clear()
+
+    assert requests == 2
+    assert len(trajectory.exchanges.chat_completions) == 1
+    assert trajectory.exchanges.chat_completions[0].response.choices[0].message.content == (
+        "good"
+    )
 
 
 @pytest.mark.asyncio
@@ -465,6 +714,7 @@ async def test_rollout_captures_two_turn_tool_exchange_with_exact_tokens() -> No
             "default",
             client=ToolTauBenchClient(),
             max_turns=2,
+            chat_completion_kwargs={"stream": False},
         )
     finally:
         await openai_client.close()
@@ -552,6 +802,35 @@ async def test_rollout_stops_on_max_tokens_bad_request(
         "default",
         client=client,
         max_turns=10,
+        chat_completion_kwargs={"stream": False},
+    )
+
+    assert trajectory.metrics["num_turns"] == 0
+    assert client.steps == 0
+    assert client.deleted == ["env-1"]
+
+
+@pytest.mark.asyncio
+async def test_rollout_stops_on_in_band_max_tokens_stream_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rollout_module = importlib.import_module("art.tau_bench.rollout")
+    rollout_module.openai_clients.clear()
+    monkeypatch.setattr(rollout_module, "AsyncOpenAI", MaxTokensStreamAsyncOpenAI)
+    monkeypatch.setattr(
+        rollout_module,
+        "DefaultAsyncHttpxClient",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    client = CountingTauBenchClient()
+
+    trajectory = await rollout_module.rollout(
+        Scenario(domain="banking_knowledge", task=Task(id="task_001")),
+        "http://model.test/v1",
+        "model-key",
+        "default",
+        client=client,
+        max_turns=10,
     )
 
     assert trajectory.metrics["num_turns"] == 0
@@ -605,6 +884,7 @@ async def test_rollout_stops_before_next_turn_exceeds_context(
         "default",
         client=client,
         max_turns=10,
+        chat_completion_kwargs={"stream": False},
     )
 
     assert trajectory.metrics["num_turns"] == 1


### PR DESCRIPTION
## What changed

- reconstruct streamed Chat Completions by choice index, including reasoning, tool-call deltas, logprobs, token IDs, usage, and prompt IDs
- close async and sync SDK streams on reconstruction, callback, validation, or cancellation failures
- make direct stream consumption and automatic trajectory capture share the same reconstruction and finalization behavior
- stream tau-bench policy calls on the string/base-URL path by default, require usage trailers, retry bounded transient stream-body failures, and opt into comment-based progress signaling
- retain ART-managed model calls as non-streaming by default and retain an explicit `stream=False` escape hatch
- size the base-URL HTTP pool for the existing 1024-rollout experiment concurrency without extending request timeouts

## Why

Long non-streaming policy calls can look dead to intermediate transports even while inference is healthy. Streaming supplies real token progress without inflating client timeouts. The previous accumulator matched choices positionally and did not preserve enough streamed fields to use safely for training trajectories.

## Validation

- `pytest -q tests/unit/test_openai_stream.py tests/unit/test_auto_trajectory.py tests/unit/test_tau_bench_client.py` — 26 passed
- focused Ruff and ty checks passed after rebasing on current `main`
- live Caladan/vLLM audit: direct consumption exactly matched independently auto-captured raw SSE, including reasoning, tool call, usage, and prompt/output token IDs
- live OpenAI audit: direct consumption exactly matched auto-capture; a seeded temperature-zero non-stream request matched streamed semantic fields and token counts
- fresh Codex review: no remaining findings
- persistent Claude Fable 5 review requested on the final head

## Earlier soak limitation

The earlier experiment soak was diagnostic rather than clean-head validation: its driver imported a stale editable ART checkout and its trainer used the prior ART pin. It is not counted as validation of this PR. Final experiment validation is being run with `ART_REF` and `ART_ROOT` unset and will record the driver import path plus driver/trainer ART SHAs.
