### PR TITLE
Fix stream consumer CI

### DIFF
--- a/src/art/openai.py
+++ b/src/art/openai.py
@@ -260,9 +260,9 @@ def update_chat_completion(
                         )
                     )
                 if tool_call_delta.id:
-                    choice.message.tool_calls[tool_call_delta.index].id += (
-                        tool_call_delta.id
-                    )
+                    choice.message.tool_calls[
+                        tool_call_delta.index
+                    ].id += tool_call_delta.id
                 if tool_call_delta.function:
                     tool_call = choice.message.tool_calls[tool_call_delta.index]
                     assert isinstance(tool_call, ChatCompletionMessageFunctionToolCall)

--- a/tests/unit/test_openai_stream.py
+++ b/tests/unit/test_openai_stream.py
@@ -209,7 +209,7 @@ def _chunks() -> list[ChatCompletionChunk]:
                 "prompt_tokens": 2,
                 "completion_tokens": 4,
                 "total_tokens": 6,
-            }
+            },
         ),
     ]
 
@@ -219,8 +219,7 @@ def _sse(chunks: list[ChatCompletionChunk]) -> bytes:
     for chunk in chunks:
         if chunk.object == "":
             frames.append(
-                b'data: {"id":"","object":"","created":0,"model":"",'
-                b'"choices":[]}\n\n'
+                b'data: {"id":"","object":"","created":0,"model":"","choices":[]}\n\n'
             )
             continue
         frames.extend(

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -470,7 +470,9 @@ async def test_rollout_retries_stream_body_transport_failure(
 
 
 @pytest.mark.asyncio
-async def test_rollout_does_not_capture_stream_attempt_missing_requested_usage() -> None:
+async def test_rollout_does_not_capture_stream_attempt_missing_requested_usage() -> (
+    None
+):
     rollout_module = importlib.import_module("art.tau_bench.rollout")
     rollout_module.openai_clients.clear()
     requests = 0
@@ -495,9 +497,7 @@ async def test_rollout_does_not_capture_stream_attempt_missing_requested_usage()
                 "object": "chat.completion.chunk",
                 "created": 0,
                 "model": "default",
-                "choices": [
-                    {"index": 0, "delta": {}, "finish_reason": "stop"}
-                ],
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
             },
         ]
         if include_usage:
@@ -558,9 +558,9 @@ async def test_rollout_does_not_capture_stream_attempt_missing_requested_usage()
 
     assert requests == 2
     assert len(trajectory.exchanges.chat_completions) == 1
-    assert trajectory.exchanges.chat_completions[0].response.choices[0].message.content == (
-        "good"
-    )
+    assert trajectory.exchanges.chat_completions[0].response.choices[
+        0
+    ].message.content == ("good")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/trajectories/test_capture.py
+++ b/tests/unit/trajectories/test_capture.py
@@ -1391,7 +1391,9 @@ def test_streaming_messages_reject_malformed_token_metadata(
 def test_streaming_chat_choices_are_accumulated_by_index() -> None:
     now = datetime.now()
 
-    def chunk(index: int, content: str) -> dict[str, Any]:
+    def chunk(
+        index: int, content: str, finish_reason: str | None = None
+    ) -> dict[str, Any]:
         return {
             "id": "chatcmpl-1",
             "object": "chat.completion.chunk",
@@ -1401,7 +1403,7 @@ def test_streaming_chat_choices_are_accumulated_by_index() -> None:
                 {
                     "index": index,
                     "delta": {"role": "assistant", "content": content},
-                    "finish_reason": None,
+                    "finish_reason": finish_reason,
                     "logprobs": None,
                 }
             ],
@@ -1414,8 +1416,8 @@ def test_streaming_chat_choices_are_accumulated_by_index() -> None:
             [
                 (None, chunk(1, "b")),
                 (None, chunk(0, "a")),
-                (None, chunk(1, "d")),
-                (None, chunk(0, "c")),
+                (None, chunk(1, "d", "stop")),
+                (None, chunk(0, "c", "stop")),
                 (None, "[DONE]"),
             ]
         ),
@@ -1434,7 +1436,7 @@ def test_streaming_chat_choices_are_accumulated_by_index() -> None:
 def test_streaming_chat_preserves_reasoning_fields() -> None:
     now = datetime.now()
 
-    def chunk(**delta: str) -> dict[str, Any]:
+    def chunk(finish_reason: str | None = None, **delta: str) -> dict[str, Any]:
         return {
             "id": "chatcmpl-1",
             "object": "chat.completion.chunk",
@@ -1444,7 +1446,7 @@ def test_streaming_chat_preserves_reasoning_fields() -> None:
                 {
                     "index": 0,
                     "delta": {"role": "assistant", **delta},
-                    "finish_reason": None,
+                    "finish_reason": finish_reason,
                     "logprobs": None,
                 }
             ],
@@ -1456,7 +1458,14 @@ def test_streaming_chat_preserves_reasoning_fields() -> None:
         _sse(
             [
                 (None, chunk(reasoning="r1", reasoning_content="c1")),
-                (None, chunk(reasoning="r2", reasoning_content="c2")),
+                (
+                    None,
+                    chunk(
+                        "stop",
+                        reasoning="r2",
+                        reasoning_content="c2",
+                    ),
+                ),
                 (None, "[DONE]"),
             ]
         ),


### PR DESCRIPTION
## What changed

- apply the repository Ruff formatter to the three files changed by ART #804
- make two pre-existing capture fixtures emit terminal `finish_reason` chunks before `[DONE]`

## Why

ART #804 merged while its non-required quality job was still pending. Full CI then identified the formatting drift and two older fixtures that represented incomplete streams, which the new authoritative terminal-stream validation correctly rejects.

## Validation

- repository Ruff, format, ty, lock, and Megatron stages passed in CI before the fixture failures
- `uv run --frozen pytest -q tests/unit/trajectories/test_capture.py tests/unit/test_openai_stream.py tests/unit/test_auto_trajectory.py tests/unit/test_tau_bench_client.py` — 97 passed
- focused Ruff, full formatting check, and focused ty passed
- fresh Codex review confirmed the formatting changes are AST-identical
