### PR TITLE
Add Qwen 3.8 27B Megatron support

### DIFF
--- a/src/art/megatron/model_support/registry.py
+++ b/src/art/megatron/model_support/registry.py
@@ -151,6 +151,7 @@ QWEN3_5_DENSE_SPEC = ModelSupportSpec(
         "Qwen/Qwen3.5-9B",
         "Qwen/Qwen3.5-27B",
         "Qwen/Qwen3.6-27B",
+        "Qwen/Qwen3.8-27B",
     ),
     default_target_modules=_QWEN3_5_DENSE_TARGET_MODULES,
     native_vllm_lora_status=_VALIDATED_NATIVE_VLLM_LORA_STATUS,

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -1377,7 +1377,7 @@ class TrainerRank:
             raise TypeError(
                 "adapter_config['base_model_name_or_path'] must be a string"
             )
-        if base_model.startswith(("Qwen/Qwen3.5-", "Qwen/Qwen3.6-")):
+        if base_model.startswith(("Qwen/Qwen3.5-", "Qwen/Qwen3.6-", "Qwen/Qwen3.8-")):
             dimensions = {
                 "num_attention_heads": getattr(
                     self.runtime.provider, "num_attention_heads", None

--- a/tests/integration/megatron/model_support/test_provider_support.py
+++ b/tests/integration/megatron/model_support/test_provider_support.py
@@ -146,6 +146,16 @@ def test_qwen35_9b_uses_qwen35_dense_support() -> None:
     assert handler.key == "qwen3_5_dense"
 
 
+def test_qwen38_27b_uses_qwen35_dense_support() -> None:
+    spec = get_model_support_spec("Qwen/Qwen3.8-27B")
+    handler = get_model_support_handler("Qwen/Qwen3.8-27B")
+
+    assert spec.key == "qwen3_5_dense"
+    assert spec.is_moe is False
+    assert spec.native_vllm_lora_status == "validated"
+    assert handler.key == "qwen3_5_dense"
+
+
 def test_meta_llama_32_1b_instruct_uses_llama3_dense_support() -> None:
     model = "meta-llama/Llama-3.2-1B-Instruct"
     spec = get_model_support_spec(model)

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -968,7 +968,13 @@ def test_checkpoint_slot_adapter_config_is_validated_and_copied() -> None:
         trainer._validate_checkpoint_adapter_config("student", {"r": 8}, alpha=None)
 
 
-def test_qwen35_checkpoint_adapter_config_captures_attention_dimensions() -> None:
+@pytest.mark.parametrize(
+    "base_model",
+    ("Qwen/Qwen3.5-4B", "Qwen/Qwen3.6-27B", "Qwen/Qwen3.8-27B"),
+)
+def test_qwen35_checkpoint_adapter_config_captures_attention_dimensions(
+    base_model: str,
+) -> None:
     runtime = _runtime()
     runtime.provider.num_attention_heads = 16
     runtime.provider.num_query_groups = 4
@@ -978,7 +984,7 @@ def test_qwen35_checkpoint_adapter_config_captures_attention_dimensions() -> Non
     retained = trainer._validate_checkpoint_adapter_config(
         "student",
         {
-            "base_model_name_or_path": "Qwen/Qwen3.5-4B",
+            "base_model_name_or_path": base_model,
             "r": 8,
             "lora_alpha": 16,
             "target_modules": ["q_proj"],


### PR DESCRIPTION
## Summary

- register `Qwen/Qwen3.8-27B` as a validated Qwen 3.5-family dense Megatron model
- preserve Qwen attention dimensions in checkpoint adapter metadata
- cover model-family routing and checkpoint metadata for the new identifier

## Why

Qwen 3.8 27B has the same model architecture and checkpoint schema as Qwen 3.6 27B, but ART currently rejects it because validated model support is keyed by exact Hugging Face model identifier.

## Validation

- `uv run --extra tensors pytest tests/unit/test_trainer_rank_validation.py -k qwen35_checkpoint_adapter_config_captures_attention_dimensions`
- `uv run prek run --all-files`