### PR TITLE
fix: profile backward memory in TrainerRank microbatch planning

### DIFF
--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -1581,12 +1581,11 @@ class TrainerRank:
                 candidate = self._select_next_micro_batch(
                     items, start, checkpoint=checkpoint
                 )
-            flat_outputs = iter(
-                self._run_flat_plan_with_memory_tracking(
-                    candidate.plan,
-                    context="forward_micro_batches",
-                )
+            tracked_outputs, memory_baseline = self._run_flat_plan_with_memory_tracking(
+                candidate.plan,
+                context="forward_micro_batches",
             )
+            flat_outputs = iter(tracked_outputs)
             outputs = [_unflatten(item, flat_outputs) for item in candidate.inputs]
             stop = start + candidate.stats_global_count
             if stop < len(items):
@@ -1618,6 +1617,11 @@ class TrainerRank:
                         cold_start=candidate.cold_start,
                     ),
                 )
+            # The caller normally runs backward while the micro-batch is yielded.
+            # Include that peak in future planning; forward-only profiling can
+            # otherwise admit a later micro-batch that leaves no collective or
+            # optimizer headroom.
+            self._update_peak_memory_profile(candidate.plan, memory_baseline)
             start = stop
 
     @overload
@@ -1695,12 +1699,13 @@ class TrainerRank:
                     context="dp_rank_forward",
                     message="forward is predicted to exceed available memory",
                 )
-            outputs = iter(
+            tracked_outputs, _memory_baseline = (
                 self._run_flat_plan_with_memory_tracking(
                     plan,
                     context="dp_rank_forward",
                 )
             )
+            outputs = iter(tracked_outputs)
             return _unflatten(materialized, outputs)
 
     def dp_reduce(
@@ -2608,13 +2613,13 @@ class TrainerRank:
         plan: _FlatForwardPlan,
         *,
         context: str,
-    ) -> list[AnyForwardOutput]:
+    ) -> tuple[list[AnyForwardOutput], int | None]:
         if torch.cuda.is_available() and self.device.type == "cuda":
             torch.cuda.synchronize(self.device)
             baseline = int(torch.cuda.memory_allocated(self.device))
             torch.cuda.reset_peak_memory_stats(self.device)
         else:
-            baseline = 0
+            baseline = None
         try:
             with _telemetry_phase(
                 "forward",
@@ -2634,10 +2639,16 @@ class TrainerRank:
                 message="CUDA OOM occurred despite the planner estimate",
             )
             raise AssertionError("unreachable") from exc
-        if torch.cuda.is_available() and self.device.type == "cuda":
-            peak = int(torch.cuda.max_memory_allocated(self.device))
-            self._update_memory_profile(plan, max(0, peak - baseline))
-        return outputs
+        self._update_peak_memory_profile(plan, baseline)
+        return outputs, baseline
+
+    def _update_peak_memory_profile(
+        self, plan: _FlatForwardPlan, baseline: int | None
+    ) -> None:
+        if baseline is None:
+            return
+        peak = int(torch.cuda.max_memory_allocated(self.device))
+        self._update_memory_profile(plan, max(0, peak - baseline))
 
     @staticmethod
     def _telemetry_plan_signature(plan: _FlatForwardPlan) -> dict[str, object]:

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -180,7 +180,11 @@ def _empty_outputs(plan: object, **_kwargs: object) -> list[ForwardOutput]:
 
 def _stub_forward(mp, rank, out=_empty_outputs, dp=(0, 1), profiled=False) -> None:
     mp.setattr(rank, "_dp_rank_and_size", lambda: dp)
-    mp.setattr(rank, "_run_flat_plan_with_memory_tracking", out)
+
+    def run(*args, **kwargs):
+        return out(*args, **kwargs), None
+
+    mp.setattr(rank, "_run_flat_plan_with_memory_tracking", run)
     if profiled:
         mp.setattr(rank, "_all_ranks_have_memory_profile", lambda **_: True)
 
@@ -2688,6 +2692,35 @@ def test_forward_micro_batches_ramps_after_first_success(
     assert batches[0].stats.cold_start
     assert batches[1].stats.global_count > 1
     assert not batches[1].stats.cold_start
+
+
+def test_forward_micro_batches_profiles_caller_peak_after_yield(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    _stub_forward(monkeypatch, trainer, profiled=True)
+    plan = trainer._plan_flat_forward([_target_request(1)])
+    monkeypatch.setattr(
+        trainer,
+        "_run_flat_plan_with_memory_tracking",
+        lambda *_args, **_kwargs: (_empty_outputs(plan), 123),
+    )
+    profiles: list[tuple[int, int | None]] = []
+    monkeypatch.setattr(
+        trainer,
+        "_update_peak_memory_profile",
+        lambda candidate, baseline: profiles.append(
+            (candidate.packed_tokens, baseline)
+        ),
+    )
+
+    batches = trainer.forward_micro_batches([_target_request(1)])
+    next(batches)
+
+    assert profiles == []
+    with pytest.raises(StopIteration):
+        next(batches)
+    assert profiles == [(plan.packed_tokens, 123)]
 
 
 def test_memory_profiles_distinguish_grad_mode() -> None:

--- a/tests/unit/test_trainer_rank_weird_shapes.py
+++ b/tests/unit/test_trainer_rank_weird_shapes.py
@@ -251,9 +251,10 @@ def test_forward_micro_batches_preserves_nested_vineppo_groups(
     monkeypatch.setattr(
         rank,
         "_run_flat_plan_with_memory_tracking",
-        lambda plan, **_kwargs: [
-            ForwardOutput(None, None, None, None) for _ in range(plan.request_count)
-        ],
+        lambda plan, **_kwargs: (
+            [ForwardOutput(None, None, None, None) for _ in range(plan.request_count)],
+            None,
+        ),
     )
     groups = _vineppo_like_inputs()
 
@@ -279,9 +280,10 @@ def test_forward_preserves_caller_owned_nested_input_tensors(
     monkeypatch.setattr(
         rank,
         "_run_flat_plan_with_memory_tracking",
-        lambda plan, **_kwargs: [
-            ForwardOutput(None, None, None, None) for _ in range(plan.request_count)
-        ],
+        lambda plan, **_kwargs: (
+            [ForwardOutput(None, None, None, None) for _ in range(plan.request_count)],
+            None,
+        ),
     )
     groups = _vineppo_like_inputs()
     tensors = [
@@ -457,9 +459,10 @@ def test_forward_micro_batches_shrinks_when_memory_budget_drops(
     def run(plan, **_kwargs):
         if available["packed_tokens"] == first_limit_packed_tokens:
             available["packed_tokens"] = tail_limit_packed_tokens
-        return [
-            ForwardOutput(None, None, None, None) for _ in range(plan.request_count)
-        ]
+        return (
+            [ForwardOutput(None, None, None, None) for _ in range(plan.request_count)],
+            None,
+        )
 
     monkeypatch.setattr(rank, "_plan_flat_forward", plan)
     _set_packed_token_budget(monkeypatch, rank, lambda: available["packed_tokens"])


### PR DESCRIPTION
## Summary

- include caller-side loss/backward peak memory in `TrainerRank.forward_micro_batches()` planning
- keep the existing immediate forward-only profile update, then conservatively update the same profile after the yielded microbatch resumes
- leave `dp_rank_forward()` semantics and ART `PipelineTrainer` unchanged

## Root cause

The planner reset and sampled CUDA peak memory only around forward. Callers normally construct loss and run backward while each microbatch is yielded, so that peak was invisible. A later microbatch could therefore consume nearly all H200 memory and leave NCCL unable to allocate its reduction buffer.

## Verification

- 183 TrainerRank unit tests passed
- Ruff lint/format passed
- targeted `ty` checks passed
- live Qwen3.5-4B experiment has completed 17+ optimizer updates without the prior OOM (the original run failed on update 4)
- matched driver/trainer ART SHA verified as `94c09b13d5a821970567a95a709ed33ce6452490`

Live evidence: https://wandb.ai/wandb/tau2-bench-overfit-val/runs/046-tau2-bench-overfit-val-new-bmQwen-Qwen3.5-4B-jmopenai-gpt-5.4-ls0.125-asymptotic-replay2-g16-c256-callerpeak-r2