### PR TITLE
Retry tau-bench policy connects promptly

### DIFF
--- a/src/art/tau_bench/rollout.py
+++ b/src/art/tau_bench/rollout.py
@@ -21,8 +21,9 @@ openai_clients: dict[tuple[str, str], AsyncOpenAI] = {}
 CONTEXT_TOKEN_LIMIT = 32_768
 DEFAULT_MAX_COMPLETION_TOKENS = 4096
 _POLICY_CONNECTION_LIMIT = 100_000
+_POLICY_CONNECT_RETRIES = 2
 _POLICY_MAX_RETRIES = 1
-_POLICY_HTTP_TIMEOUT = httpx.Timeout(connect=30, read=10 * 60, write=30, pool=30)
+_POLICY_HTTP_TIMEOUT = httpx.Timeout(connect=10, read=10 * 60, write=30, pool=30)
 
 
 @overload
@@ -248,9 +249,12 @@ def _completion_client_and_model(
             max_retries=_POLICY_MAX_RETRIES,
             http_client=DefaultAsyncHttpxClient(
                 timeout=_POLICY_HTTP_TIMEOUT,
-                limits=httpx.Limits(
-                    max_connections=_POLICY_CONNECTION_LIMIT,
-                    max_keepalive_connections=_POLICY_CONNECTION_LIMIT,
+                transport=httpx.AsyncHTTPTransport(
+                    retries=_POLICY_CONNECT_RETRIES,
+                    limits=httpx.Limits(
+                        max_connections=_POLICY_CONNECTION_LIMIT,
+                        max_keepalive_connections=_POLICY_CONNECTION_LIMIT,
+                    ),
                 ),
             ),
         )

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -293,6 +293,11 @@ async def test_rollout_supports_string_model_args(
         "DefaultAsyncHttpxClient",
         lambda **kwargs: SimpleNamespace(**kwargs),
     )
+    monkeypatch.setattr(
+        rollout_module.httpx,
+        "AsyncHTTPTransport",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
     client = FakeTauBenchClient()
     scenario = Scenario(domain="banking_knowledge", task=Task(id="task_001"))
 
@@ -324,13 +329,14 @@ async def test_rollout_supports_string_model_args(
     assert policy_client.kwargs["max_retries"] == 1
     http_client = policy_client.kwargs["http_client"]
     assert http_client.timeout == httpx.Timeout(
-        connect=30,
+        connect=10,
         read=10 * 60,
         write=30,
         pool=30,
     )
-    assert http_client.limits.max_connections == 100_000
-    assert http_client.limits.max_keepalive_connections == 100_000
+    assert http_client.transport.retries == 2
+    assert http_client.transport.limits.max_connections == 100_000
+    assert http_client.transport.limits.max_keepalive_connections == 100_000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- retry policy TCP connection failures in the HTTP transport, which limits retries to `ConnectError`/`ConnectTimeout` rather than replaying long read timeouts
- use three 10-second connection attempts per SDK request instead of one 30-second attempt
- retain the existing one OpenAI SDK retry and 10-minute inference read timeout

This keeps the failure-time bound approximately unchanged while giving transient Modal ingress/routing failures more chances to recover. It addresses the observed validation failure below ART, without exception handling in experiment 046.

## Verification
- `tests/unit/test_tau_bench_client.py`: 11 passed
- Ruff check/format
