### PR TITLE
Shard tau-bench HTTP connection pools

### DIFF
--- a/src/art/tau_bench/client.py
+++ b/src/art/tau_bench/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 import os
-from typing import Any, AsyncGenerator, Literal
+from typing import Any, AsyncGenerator, Literal, cast
 import uuid
 
 import httpx
@@ -32,6 +32,31 @@ def _shard_limit(total: int | None, shards: int, index: int) -> int | None:
     return quotient + (index < remainder)
 
 
+class _CapacityReleaseStream(httpx.AsyncByteStream):
+    def __init__(
+        self, stream: httpx.AsyncByteStream, capacity: asyncio.Semaphore
+    ) -> None:
+        self._stream = stream
+        self._capacity = capacity
+        self._closed = False
+
+    async def __aiter__(self) -> AsyncGenerator[bytes, None]:
+        try:
+            async for chunk in self._stream:
+                yield chunk
+        finally:
+            await self.aclose()
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            await self._stream.aclose()
+        finally:
+            self._capacity.release()
+
+
 class _ShardedAsyncHTTPTransport(httpx.AsyncBaseTransport):
     """Round-robin requests across smaller HTTP connection pools."""
 
@@ -46,11 +71,17 @@ class _ShardedAsyncHTTPTransport(httpx.AsyncBaseTransport):
         shard_count = min(shards, max_connections or shards)
         if shard_count < 1:
             raise ValueError("HTTP transport shards must be positive")
+        self._capacity = (
+            asyncio.Semaphore(max_connections) if max_connections is not None else None
+        )
         self.transports = tuple(
             httpx.AsyncHTTPTransport(
                 retries=retries,
                 limits=httpx.Limits(
-                    max_connections=_shard_limit(max_connections, shard_count, index),
+                    # Aggregate active capacity is enforced above the shards. Giving
+                    # every shard the aggregate ceiling prevents uneven request
+                    # durations from stranding capacity in another shard.
+                    max_connections=max_connections,
                     max_keepalive_connections=_shard_limit(
                         limits.max_keepalive_connections, shard_count, index
                     ),
@@ -62,9 +93,30 @@ class _ShardedAsyncHTTPTransport(httpx.AsyncBaseTransport):
         self._next = 0
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        capacity = self._capacity
+        if capacity is not None:
+            pool_timeout = request.extensions.get("timeout", {}).get("pool")
+            try:
+                async with asyncio.timeout(pool_timeout):
+                    await capacity.acquire()
+            except TimeoutError:
+                raise httpx.PoolTimeout(
+                    "Timed out waiting for an available connection slot",
+                    request=request,
+                ) from None
         transport = self.transports[self._next]
         self._next = (self._next + 1) % len(self.transports)
-        return await transport.handle_async_request(request)
+        try:
+            response = await transport.handle_async_request(request)
+        except BaseException:
+            if capacity is not None:
+                capacity.release()
+            raise
+        if capacity is not None:
+            response.stream = _CapacityReleaseStream(
+                cast(httpx.AsyncByteStream, response.stream), capacity
+            )
+        return response
 
     async def aclose(self) -> None:
         await asyncio.gather(*(transport.aclose() for transport in self.transports))

--- a/src/art/tau_bench/client.py
+++ b/src/art/tau_bench/client.py
@@ -14,6 +14,7 @@ TRANSIENT_STATUS_CODES = {429, 502, 503, 504}
 DEFAULT_STATUS_RETRIES = 12
 DEFAULT_RETRY_BASE_DELAY = 0.5
 DEFAULT_RETRY_MAX_DELAY = 5.0
+_HTTP_POOL_SHARDS = 64
 
 
 def _default_limits() -> httpx.Limits:
@@ -22,6 +23,57 @@ def _default_limits() -> httpx.Limits:
         max_keepalive_connections=100_000,
         keepalive_expiry=60.0,
     )
+
+
+def _shard_limit(total: int | None, shards: int, index: int) -> int | None:
+    if total is None:
+        return None
+    quotient, remainder = divmod(total, shards)
+    return quotient + (index < remainder)
+
+
+class _ShardedAsyncHTTPTransport(httpx.AsyncBaseTransport):
+    """Round-robin requests across smaller HTTP connection pools."""
+
+    def __init__(
+        self,
+        *,
+        limits: httpx.Limits,
+        retries: int,
+        shards: int = _HTTP_POOL_SHARDS,
+    ) -> None:
+        max_connections = limits.max_connections
+        shard_count = min(shards, max_connections or shards)
+        if shard_count < 1:
+            raise ValueError("HTTP transport shards must be positive")
+        self.transports = tuple(
+            httpx.AsyncHTTPTransport(
+                retries=retries,
+                limits=httpx.Limits(
+                    max_connections=_shard_limit(max_connections, shard_count, index),
+                    max_keepalive_connections=_shard_limit(
+                        limits.max_keepalive_connections, shard_count, index
+                    ),
+                    keepalive_expiry=limits.keepalive_expiry,
+                ),
+            )
+            for index in range(shard_count)
+        )
+        self._next = 0
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        transport = self.transports[self._next]
+        self._next = (self._next + 1) % len(self.transports)
+        return await transport.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await asyncio.gather(*(transport.aclose() for transport in self.transports))
+
+
+def _sharded_transport(
+    *, limits: httpx.Limits, retries: int
+) -> _ShardedAsyncHTTPTransport:
+    return _ShardedAsyncHTTPTransport(limits=limits, retries=retries)
 
 
 def _normalize_timeout(timeout: float | httpx.Timeout | None) -> httpx.Timeout | None:
@@ -141,10 +193,7 @@ class TauBenchClient:
                 base_url or os.getenv("TAU_BENCH_BASE_URL") or "http://localhost:8000"
             ),
             timeout=_normalize_timeout(timeout),
-            transport=httpx.AsyncHTTPTransport(
-                limits=limits or _default_limits(),
-                retries=2,
-            ),
+            transport=_sharded_transport(limits=limits or _default_limits(), retries=2),
         )
 
     async def close(self) -> None:

--- a/src/art/tau_bench/rollout.py
+++ b/src/art/tau_bench/rollout.py
@@ -98,6 +98,10 @@ async def rollout(
         idle_timeout_seconds=(
             _STRING_POLICY_ENV_IDLE_TIMEOUT_SECONDS
             if isinstance(base_url_or_model, str)
+            and (
+                chat_completion_kwargs is None
+                or "timeout" not in chat_completion_kwargs
+            )
             else None
         ),
     ) as env:

--- a/src/art/tau_bench/rollout.py
+++ b/src/art/tau_bench/rollout.py
@@ -24,6 +24,7 @@ _POLICY_CONNECTION_LIMIT = 100_000
 _POLICY_CONNECT_RETRIES = 2
 _POLICY_MAX_RETRIES = 1
 _POLICY_HTTP_TIMEOUT = httpx.Timeout(connect=10, read=10 * 60, write=30, pool=30)
+_STRING_POLICY_ENV_IDLE_TIMEOUT_SECONDS = 30 * 60
 
 
 @overload
@@ -94,6 +95,11 @@ async def rollout(
         ),
         retrieval_config=retrieval_config,
         retrieval_config_kwargs=retrieval_config_kwargs,
+        idle_timeout_seconds=(
+            _STRING_POLICY_ENV_IDLE_TIMEOUT_SECONDS
+            if isinstance(base_url_or_model, str)
+            else None
+        ),
     ) as env:
         environment_startup = time.perf_counter() - started
         chat_completion_kwargs = chat_completion_kwargs or {}

--- a/src/art/tau_bench/rollout.py
+++ b/src/art/tau_bench/rollout.py
@@ -15,7 +15,7 @@ from art.costs import get_model_pricing, tokens_to_cost
 from art.model import Model
 from art.trajectories import Trajectory
 
-from .client import Scenario, TauBenchClient, _get_default_client
+from .client import Scenario, TauBenchClient, _get_default_client, _sharded_transport
 
 openai_clients: dict[tuple[str, str], AsyncOpenAI] = {}
 CONTEXT_TOKEN_LIMIT = 32_768
@@ -249,7 +249,7 @@ def _completion_client_and_model(
             max_retries=_POLICY_MAX_RETRIES,
             http_client=DefaultAsyncHttpxClient(
                 timeout=_POLICY_HTTP_TIMEOUT,
-                transport=httpx.AsyncHTTPTransport(
+                transport=_sharded_transport(
                     retries=_POLICY_CONNECT_RETRIES,
                     limits=httpx.Limits(
                         max_connections=_POLICY_CONNECTION_LIMIT,

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -140,6 +140,8 @@ async def test_sharded_transport_does_not_strand_aggregate_capacity(
 
     slow = await transport.handle_async_request(request)
     completed = await transport.handle_async_request(request)
+    with pytest.raises(httpx.PoolTimeout):
+        await transport.handle_async_request(request)
     await completed.aclose()
     replacement = await transport.handle_async_request(request)
 

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -473,6 +473,38 @@ async def test_rollout_supports_art_model_like_args() -> None:
 
 
 @pytest.mark.asyncio
+async def test_rollout_preserves_server_lease_for_explicit_policy_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rollout_module = importlib.import_module("art.tau_bench.rollout")
+    rollout_module.openai_clients.clear()
+    monkeypatch.setattr(rollout_module, "AsyncOpenAI", FakeAsyncOpenAI)
+    monkeypatch.setattr(
+        rollout_module,
+        "DefaultAsyncHttpxClient",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    monkeypatch.setattr(
+        rollout_module.httpx,
+        "AsyncHTTPTransport",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    client = FakeTauBenchClient()
+
+    await rollout_module.rollout(
+        Scenario(domain="banking_knowledge", task=Task(id="task_001")),
+        "http://model.test/v1",
+        "model-key",
+        "default",
+        client=client,
+        max_turns=1,
+        chat_completion_kwargs={"timeout": None},
+    )
+
+    assert client.create_kwargs["idle_timeout_seconds"] is None
+
+
+@pytest.mark.asyncio
 async def test_rollout_captures_two_turn_tool_exchange_with_exact_tokens() -> None:
     rollout_module = importlib.import_module("art.tau_bench.rollout")
     rollout_module.openai_clients.clear()

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -27,10 +27,11 @@ def test_client_reuses_connections_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     seen: dict[str, Any] = {}
+    transport_kwargs: list[dict[str, Any]] = []
 
     class FakeTransport:
         def __init__(self, **kwargs: Any) -> None:
-            seen["transport_kwargs"] = kwargs
+            transport_kwargs.append(kwargs)
 
     class FakeAsyncClient:
         def __init__(self, **kwargs: Any) -> None:
@@ -40,12 +41,53 @@ def test_client_reuses_connections_by_default(
     monkeypatch.setattr(client_module.httpx, "AsyncHTTPTransport", FakeTransport)
     TauBenchClient(base_url="http://tau.test", api_key="secret")
 
-    limits = seen["transport_kwargs"]["limits"]
-    assert isinstance(limits, httpx.Limits)
-    assert limits.max_connections == 100_000
-    assert limits.max_keepalive_connections == 100_000
-    assert seen["transport_kwargs"]["retries"] == 2
+    assert len(transport_kwargs) == 64
+    limits = [kwargs["limits"] for kwargs in transport_kwargs]
+    assert all(isinstance(limit, httpx.Limits) for limit in limits)
+    assert sum(limit.max_connections or 0 for limit in limits) == 100_000
+    assert sum(limit.max_keepalive_connections or 0 for limit in limits) == 100_000
+    assert {kwargs["retries"] for kwargs in transport_kwargs} == {2}
     assert isinstance(seen["timeout"], httpx.Timeout)
+
+
+@pytest.mark.asyncio
+async def test_sharded_transport_routes_round_robin_and_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transports: list[Any] = []
+
+    class FakeTransport:
+        def __init__(self, **kwargs: Any) -> None:
+            self.index = len(transports)
+            self.closed = False
+            transports.append(self)
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, request=request, extensions={"shard": self.index}
+            )
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(client_module.httpx, "AsyncHTTPTransport", FakeTransport)
+    transport = client_module._ShardedAsyncHTTPTransport(
+        limits=httpx.Limits(
+            max_connections=100_000,
+            max_keepalive_connections=100_000,
+        ),
+        retries=2,
+    )
+    request = httpx.Request("GET", "http://tau.test")
+
+    shards = [
+        (await transport.handle_async_request(request)).extensions["shard"]
+        for _ in range(65)
+    ]
+    await transport.aclose()
+
+    assert shards == [*range(64), 0]
+    assert all(item.closed for item in transports)
 
 
 @pytest.mark.asyncio
@@ -334,9 +376,14 @@ async def test_rollout_supports_string_model_args(
         write=30,
         pool=30,
     )
-    assert http_client.transport.retries == 2
-    assert http_client.transport.limits.max_connections == 100_000
-    assert http_client.transport.limits.max_keepalive_connections == 100_000
+    transports = http_client.transport.transports
+    assert len(transports) == 64
+    assert {transport.retries for transport in transports} == {2}
+    assert sum(transport.limits.max_connections for transport in transports) == 100_000
+    assert (
+        sum(transport.limits.max_keepalive_connections for transport in transports)
+        == 100_000
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncGenerator
 import importlib
 import json
 from types import SimpleNamespace
@@ -44,7 +46,7 @@ def test_client_reuses_connections_by_default(
     assert len(transport_kwargs) == 64
     limits = [kwargs["limits"] for kwargs in transport_kwargs]
     assert all(isinstance(limit, httpx.Limits) for limit in limits)
-    assert sum(limit.max_connections or 0 for limit in limits) == 100_000
+    assert {limit.max_connections for limit in limits} == {100_000}
     assert sum(limit.max_keepalive_connections or 0 for limit in limits) == 100_000
     assert {kwargs["retries"] for kwargs in transport_kwargs} == {2}
     assert isinstance(seen["timeout"], httpx.Timeout)
@@ -88,6 +90,62 @@ async def test_sharded_transport_routes_round_robin_and_closes(
 
     assert shards == [*range(64), 0]
     assert all(item.closed for item in transports)
+
+
+@pytest.mark.asyncio
+async def test_sharded_transport_does_not_strand_aggregate_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeTransport:
+        def __init__(self, **kwargs: Any) -> None:
+            self.capacity = asyncio.Semaphore(kwargs["limits"].max_connections)
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            await self.capacity.acquire()
+
+            async def release() -> None:
+                self.capacity.release()
+
+            return httpx.Response(
+                200,
+                request=request,
+                stream=ClosingStream(release),
+            )
+
+        async def aclose(self) -> None:
+            pass
+
+    class ClosingStream(httpx.AsyncByteStream):
+        def __init__(self, close: Any) -> None:
+            self.close = close
+
+        async def __aiter__(self) -> AsyncGenerator[bytes, None]:
+            if False:
+                yield b""
+
+        async def aclose(self) -> None:
+            await self.close()
+
+    monkeypatch.setattr(client_module.httpx, "AsyncHTTPTransport", FakeTransport)
+    transport = client_module._ShardedAsyncHTTPTransport(
+        limits=httpx.Limits(max_connections=2, max_keepalive_connections=2),
+        retries=0,
+        shards=2,
+    )
+    request = httpx.Request(
+        "GET",
+        "http://tau.test",
+        extensions={"timeout": {"pool": 0.1}},
+    )
+
+    slow = await transport.handle_async_request(request)
+    completed = await transport.handle_async_request(request)
+    await completed.aclose()
+    replacement = await transport.handle_async_request(request)
+
+    await replacement.aclose()
+    await slow.aclose()
+    await transport.aclose()
 
 
 @pytest.mark.asyncio
@@ -364,6 +422,7 @@ async def test_rollout_supports_string_model_args(
     assert trajectory.metrics["tokens/completion"] == 5
     assert client.deleted == ["env-1"]
     assert client.create_kwargs["user_llm"] == "gpt-4.1-2025-04-14"
+    assert client.create_kwargs["idle_timeout_seconds"] == 30 * 60
     policy_client: Any = rollout_module.openai_clients[
         ("http://model.test/v1", "model-key")
     ]
@@ -379,7 +438,7 @@ async def test_rollout_supports_string_model_args(
     transports = http_client.transport.transports
     assert len(transports) == 64
     assert {transport.retries for transport in transports} == {2}
-    assert sum(transport.limits.max_connections for transport in transports) == 100_000
+    assert {transport.limits.max_connections for transport in transports} == {100_000}
     assert (
         sum(transport.limits.max_keepalive_connections for transport in transports)
         == 100_000
@@ -408,6 +467,7 @@ async def test_rollout_supports_art_model_like_args() -> None:
 
     assert trajectory.metadata["scenario_id"] == "task_001"
     assert trajectory.metrics["num_turns"] == 1
+    assert client.create_kwargs["idle_timeout_seconds"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep tau-bench environment and policy HTTP capacity at 100,000 active connections
- distribute keep-alive scanning across 64 round-robin HTTPcore pools
- enforce active capacity globally so uneven request durations cannot strand available slots in another shard
- request a 30-minute orphan lease only for the string/base-URL rollout path when it retains ART's bounded two-attempt/10-minute timeout configuration
- keep all changes internal to ART; no experiment API or script changes

## Motivation
A representative 10 Hz profile of the 2,048-rollout experiment spent 40.9% of the driver main thread under HTTPcore request assignment and 39.9% checking whether connections had expired. The single pool had roughly 1,400 live sockets, so every request scanned a large connection list.

Abrupt driver teardown can also prevent thousands of environment DELETE requests from completing. A shorter tau-bench server default would be unsafe for generic `art.Model` callers and explicit timeout overrides, so only ART's unchanged, explicitly bounded string-policy path requests the shorter lease.

## Validation
- focused tau/capture/stream suite: 95 passed
- regressions for uneven-duration sharded capacity and aggregate pool timeout/recovery
- string, Model, and explicit-timeout orphan-lease regressions
- `ty` on changed files
- Ruff check and format check
- local keep-alive benchmark after warming 200 concurrent connections (400 measured requests): single pool 10.297 s wall / 10.287 s CPU; 64 shards 0.173 s wall / 0.173 s CPU

Custom active limits retain aggregate semantics through a shared capacity gate; total retained keep-alive capacity remains exactly the configured value.
