### PR TITLE
Bound tau-bench policy completions by default

### DIFF
--- a/src/art/tau_bench/rollout.py
+++ b/src/art/tau_bench/rollout.py
@@ -106,7 +106,11 @@ async def rollout(
         ),
     ) as env:
         environment_startup = time.perf_counter() - started
-        chat_completion_kwargs = chat_completion_kwargs or {}
+        chat_completion_kwargs = dict(chat_completion_kwargs or {})
+        if not {"max_tokens", "max_completion_tokens"} & chat_completion_kwargs.keys():
+            chat_completion_kwargs["max_completion_tokens"] = (
+                DEFAULT_MAX_COMPLETION_TOKENS
+            )
         openai_client, model_name, cost_model = _completion_client_and_model(
             base_url_or_model,
             api_key=api_key,

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -429,6 +429,10 @@ async def test_rollout_supports_string_model_args(
         ("http://model.test/v1", "model-key")
     ]
     assert policy_client.chat.completions.kwargs["stream"] is False
+    assert (
+        policy_client.chat.completions.kwargs["max_completion_tokens"]
+        == rollout_module.DEFAULT_MAX_COMPLETION_TOKENS
+    )
     assert policy_client.kwargs["max_retries"] == 1
     http_client = policy_client.kwargs["http_client"]
     assert http_client.timeout == httpx.Timeout(
@@ -470,6 +474,35 @@ async def test_rollout_supports_art_model_like_args() -> None:
     assert trajectory.metadata["scenario_id"] == "task_001"
     assert trajectory.metrics["num_turns"] == 1
     assert client.create_kwargs["idle_timeout_seconds"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("argument", ["max_tokens", "max_completion_tokens"])
+async def test_rollout_preserves_explicit_completion_limit(
+    argument: str,
+) -> None:
+    rollout_module = importlib.import_module("art.tau_bench.rollout")
+    model = art.Model(
+        name="registered-model",
+        project="test",
+        inference_api_key="test-key",
+        inference_base_url="http://model.test/v1",
+    )
+    client = FakeTauBenchClient()
+    completion_client = FakeAsyncOpenAI()
+    object.__setattr__(model, "_openai_client", completion_client)
+
+    await rollout_module.rollout(
+        Scenario(domain="banking_knowledge", task=Task(id="task_001")),
+        model,
+        client=client,
+        max_turns=1,
+        chat_completion_kwargs={argument: 123},
+    )
+
+    assert completion_client.chat.completions.kwargs[argument] == 123
+    other = {"max_tokens", "max_completion_tokens"} - {argument}
+    assert other.isdisjoint(completion_client.chat.completions.kwargs)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- send tau-bench's existing 4,096-token default to the policy inference API
- preserve explicit `max_tokens` and `max_completion_tokens` values
- avoid mutating caller-supplied completion kwargs

## Root cause
Tau-bench used `DEFAULT_MAX_COMPLETION_TOKENS` only for its next-turn context check. It did not put that value in the current inference request, so vLLM could decode a malformed turn toward the full model context and occupy a worker for many minutes.

## Verification
- `uv run --frozen pytest -q tests/unit/test_tau_bench_client.py` (16 passed)
- `uv run --frozen ruff check ...`
- `uv run --frozen ruff format --check ...`
- `uv run --frozen ty check src/art/tau_bench/rollout.py`

An additional broad tokenization test invocation had six collection/runtime failures because this CPU-only environment does not install optional Torch/Transformers dependencies; 171 tests in that invocation passed. CI installs the project's intended matrix.