### PR TITLE
Include the Megatron runtime in ART GPU image builds

### DIFF
--- a/scripts/build-gpu-image.sh
+++ b/scripts/build-gpu-image.sh
@@ -297,9 +297,14 @@ cleanup() {
 trap cleanup EXIT
 printf '0' > "${build_log_offset_path}"
 
-mkdir -p "${context_dir}/docker" "${context_dir}/vllm_runtime"
+mkdir -p "${context_dir}/docker" "${context_dir}/megatron_runtime" \
+  "${context_dir}/vllm_runtime"
 cp "${repo_root}/pyproject.toml" "${context_dir}/pyproject.toml"
 cp "${repo_root}/uv.lock" "${context_dir}/uv.lock"
+cp "${repo_root}/megatron_runtime/pyproject.toml" \
+  "${context_dir}/megatron_runtime/pyproject.toml"
+cp "${repo_root}/megatron_runtime/uv.lock" \
+  "${context_dir}/megatron_runtime/uv.lock"
 cp "${repo_root}/vllm_runtime/pyproject.toml" "${context_dir}/vllm_runtime/pyproject.toml"
 cp "${repo_root}/vllm_runtime/uv.lock" "${context_dir}/vllm_runtime/uv.lock"
 cp "${repo_root}/.dockerignore" "${context_dir}/.dockerignore"

--- a/tests/unit/test_gpu_image_build_context.py
+++ b/tests/unit/test_gpu_image_build_context.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import shlex
+
+ROOT = Path(__file__).parents[2]
+
+
+def test_gpu_image_build_context_copies_every_local_docker_source() -> None:
+    dockerfile = (ROOT / "docker/art-gpu.Dockerfile").read_text()
+    build_script = (ROOT / "scripts/build-gpu-image.sh").read_text()
+
+    for line in dockerfile.splitlines():
+        if not line.startswith("COPY ") or "--from=" in line:
+            continue
+        for source in shlex.split(line)[1:-1]:
+            assert f"${{repo_root}}/{source}" in build_script


### PR DESCRIPTION
## Summary

- copy the Megatron runtime project and lock into the BuildKit context
- regression-test that every local Dockerfile COPY source is staged by the build script

## Why

ART GPU image builds have failed since #808 because the Dockerfile references megatron_runtime files that the build context omitted. That left art-gpu:latest stale and forced every cold Caladan trainer to rebuild Apex and Transformer Engine for about 6.5 minutes.

## Verification

- bash -n scripts/build-gpu-image.sh
- focused pytest
- Ruff check/format
- git diff --check