### PR TITLE
Bound tau-bench environment requests

### DIFF
--- a/src/art/tau_bench/client.py
+++ b/src/art/tau_bench/client.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+import logging
+import math
 import os
 from typing import Any, AsyncGenerator, Literal, cast
 import uuid
@@ -14,7 +16,18 @@ TRANSIENT_STATUS_CODES = {429, 502, 503, 504}
 DEFAULT_STATUS_RETRIES = 12
 DEFAULT_RETRY_BASE_DELAY = 0.5
 DEFAULT_RETRY_MAX_DELAY = 5.0
+DEFAULT_REQUEST_ATTEMPT_TIMEOUT = 300.0
+DEFAULT_CLEANUP_TIMEOUT = 30.0
+DEFAULT_HTTP_TIMEOUT = httpx.Timeout(connect=10.0, pool=30.0, write=30.0, read=300.0)
 _HTTP_POOL_SHARDS = 64
+_SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
+_PRE_SEND_TRANSPORT_ERRORS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.PoolTimeout,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def _default_limits() -> httpx.Limits:
@@ -216,9 +229,10 @@ class TauBenchClient:
         *,
         base_url: str | None = None,
         api_key: str | None = None,
-        timeout: float | httpx.Timeout | None = 300.0,
+        timeout: float | httpx.Timeout | None = DEFAULT_HTTP_TIMEOUT,
         limits: httpx.Limits | None = None,
         http_client: httpx.AsyncClient | None = None,
+        request_attempt_timeout: float | None = DEFAULT_REQUEST_ATTEMPT_TIMEOUT,
         status_retries: int | None = None,
         retry_base_delay: float | None = None,
         retry_max_delay: float | None = None,
@@ -240,6 +254,13 @@ class TauBenchClient:
             else _default_retry_max_delay()
         )
         self._owns_client = http_client is None
+        if request_attempt_timeout is not None and (
+            not math.isfinite(request_attempt_timeout) or request_attempt_timeout <= 0
+        ):
+            raise ValueError("request_attempt_timeout must be finite and positive")
+        self._request_attempt_timeout = (
+            request_attempt_timeout if self._owns_client else None
+        )
         self._client = http_client or httpx.AsyncClient(
             base_url=(
                 base_url or os.getenv("TAU_BENCH_BASE_URL") or "http://localhost:8000"
@@ -355,8 +376,31 @@ class TauBenchClient:
         )
         try:
             yield env
-        finally:
+        except BaseException as error:
+            await self._delete_after_error(env.id, error)
+            raise
+        else:
             await self.delete_environment(env.id)
+
+    async def _delete_after_error(
+        self, env_id: str, primary_error: BaseException
+    ) -> None:
+        cleanup = asyncio.create_task(self.delete_environment(env_id))
+        try:
+            async with asyncio.timeout(DEFAULT_CLEANUP_TIMEOUT):
+                await asyncio.shield(cleanup)
+        except BaseException as cleanup_error:
+            if not cleanup.done():
+                cleanup.cancel()
+                cleanup.add_done_callback(_discard_task_result)
+            primary_error.add_note(
+                f"Failed to delete tau-bench environment {env_id}: {cleanup_error!r}"
+            )
+            logger.warning(
+                "Failed to delete tau-bench environment %s while handling another error",
+                env_id,
+                exc_info=True,
+            )
 
     def _auth_headers(self) -> dict[str, str]:
         if self.api_key is None:
@@ -364,25 +408,38 @@ class TauBenchClient:
         return {"Authorization": f"Bearer {self.api_key}"}
 
     async def _request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        method = method.upper()
         headers = dict(kwargs.pop("headers", {}))
         headers.setdefault("X-Request-ID", str(uuid.uuid4()))
         attempts = self.status_retries + 1
         last_transport_error: httpx.TransportError | None = None
         for attempt in range(attempts):
             try:
-                response = await self._client.request(
-                    method,
-                    url,
-                    headers=headers,
-                    **kwargs,
-                )
+                try:
+                    async with asyncio.timeout(self._request_attempt_timeout):
+                        response = await self._client.request(
+                            method,
+                            url,
+                            headers=headers,
+                            **kwargs,
+                        )
+                except TimeoutError as exc:
+                    raise httpx.TimeoutException(
+                        f"tau-bench {method} {url} exceeded the "
+                        f"{self._request_attempt_timeout:g}s attempt deadline"
+                    ) from exc
             except httpx.TransportError as exc:
                 last_transport_error = exc
-                if attempt == attempts - 1:
+                if attempt == attempts - 1 or not _transport_retry_is_safe(
+                    method,
+                    exc,
+                    trusted_transport=self._owns_client,
+                ):
                     raise
             else:
                 if (
                     response.status_code not in TRANSIENT_STATUS_CODES
+                    or method not in _SAFE_METHODS
                     or attempt == attempts - 1
                 ):
                     return response
@@ -392,6 +449,26 @@ class TauBenchClient:
             )
         assert last_transport_error is not None
         raise last_transport_error
+
+
+def _transport_retry_is_safe(
+    method: str,
+    error: httpx.TransportError,
+    *,
+    trusted_transport: bool,
+) -> bool:
+    return method in _SAFE_METHODS or (
+        trusted_transport and isinstance(error, _PRE_SEND_TRANSPORT_ERRORS)
+    )
+
+
+def _discard_task_result(task: asyncio.Task[Any]) -> None:
+    if task.cancelled():
+        return
+    try:
+        task.exception()
+    except BaseException:
+        pass
 
 
 default_client: TauBenchClient | None = None

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -49,7 +49,12 @@ def test_client_reuses_connections_by_default(
     assert {limit.max_connections for limit in limits} == {100_000}
     assert sum(limit.max_keepalive_connections or 0 for limit in limits) == 100_000
     assert {kwargs["retries"] for kwargs in transport_kwargs} == {2}
-    assert isinstance(seen["timeout"], httpx.Timeout)
+    assert seen["timeout"] == httpx.Timeout(
+        connect=10.0,
+        pool=30.0,
+        write=30.0,
+        read=300.0,
+    )
 
 
 @pytest.mark.asyncio
@@ -246,6 +251,178 @@ async def test_client_retries_transport_errors() -> None:
 
 
 @pytest.mark.asyncio
+async def test_owned_client_retries_pre_send_error_for_stateful_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    async def request(*args: Any, **kwargs: Any) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise httpx.ConnectError("temporary connect failure")
+        return httpx.Response(
+            200,
+            request=httpx.Request("POST", "http://tau.test/environments"),
+            json={"id": "env-1", "observation": "user: hello", "info": {}},
+        )
+
+    client = TauBenchClient(
+        base_url="http://tau.test",
+        api_key="secret",
+        status_retries=3,
+        retry_base_delay=0,
+    )
+    monkeypatch.setattr(client._client, "request", request)
+
+    environment = await client.create_environment(domain="telecom", task_id="task_001")
+    await client.close()
+
+    assert environment.id == "env-1"
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_caller_owned_client_does_not_retry_stateful_connect_error() -> None:
+    attempts = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        raise httpx.ConnectError("custom transport failure", request=request)
+
+    http_client = httpx.AsyncClient(
+        base_url="http://tau.test",
+        transport=httpx.MockTransport(handler),
+    )
+    client = TauBenchClient(
+        api_key="secret",
+        http_client=http_client,
+        status_retries=3,
+        retry_base_delay=0,
+    )
+
+    with pytest.raises(httpx.ConnectError):
+        await client.create_environment(domain="telecom", task_id="task_001")
+    await http_client.aclose()
+
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [
+        httpx.ReadError("response connection failed"),
+        httpx.ReadTimeout("response timed out"),
+        httpx.WriteError("request write failed"),
+        httpx.RemoteProtocolError("response was incomplete"),
+    ],
+)
+async def test_client_does_not_retry_ambiguous_stateful_transport_error(
+    failure: httpx.TransportError,
+) -> None:
+    attempts = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        failure.request = request
+        raise failure
+
+    http_client = httpx.AsyncClient(
+        base_url="http://tau.test",
+        transport=httpx.MockTransport(handler),
+    )
+    client = TauBenchClient(
+        api_key="secret",
+        http_client=http_client,
+        status_retries=3,
+        retry_base_delay=0,
+    )
+
+    with pytest.raises(type(failure)):
+        await client.create_environment(domain="telecom", task_id="task_001")
+    await http_client.aclose()
+
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_client_does_not_retry_transient_status_for_stateful_request() -> None:
+    attempts = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(503, text="Unavailable")
+
+    http_client = httpx.AsyncClient(
+        base_url="http://tau.test",
+        transport=httpx.MockTransport(handler),
+    )
+    client = TauBenchClient(
+        api_key="secret",
+        http_client=http_client,
+        status_retries=3,
+        retry_base_delay=0,
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.create_environment(domain="telecom", task_id="task_001")
+    await http_client.aclose()
+
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_owned_client_has_outer_request_attempt_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = TauBenchClient(
+        base_url="http://tau.test",
+        api_key="secret",
+        request_attempt_timeout=0.01,
+        status_retries=0,
+    )
+
+    async def request(*args: Any, **kwargs: Any) -> httpx.Response:
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(client._client, "request", request)
+    with pytest.raises(httpx.TimeoutException, match="attempt deadline"):
+        await client.get_scenarios()
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_caller_owned_client_is_not_wrapped_in_attempt_deadline() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0.02)
+        return httpx.Response(200, json={"scenarios": []})
+
+    http_client = httpx.AsyncClient(
+        base_url="http://tau.test",
+        transport=httpx.MockTransport(handler),
+    )
+    client = TauBenchClient(
+        api_key="secret",
+        http_client=http_client,
+        request_attempt_timeout=0.001,
+    )
+
+    assert await client.get_scenarios() == []
+    await http_client.aclose()
+
+
+@pytest.mark.parametrize("value", [0, -1, float("inf"), float("nan")])
+def test_client_rejects_invalid_request_attempt_timeout(value: float) -> None:
+    with pytest.raises(ValueError, match="finite and positive"):
+        TauBenchClient(request_attempt_timeout=value)
+
+
+@pytest.mark.asyncio
 async def test_client_sends_create_environment_idle_timeout() -> None:
     seen: dict[str, Any] = {}
 
@@ -350,6 +527,93 @@ class FakeTauBenchClient(TauBenchClient):
     async def delete_environment(self, env_id: str) -> DeleteEnvironmentResponse:
         self.deleted.append(env_id)
         return DeleteEnvironmentResponse(id=env_id, deleted=True)
+
+
+class FailingDeleteTauBenchClient(FakeTauBenchClient):
+    async def delete_environment(self, env_id: str) -> DeleteEnvironmentResponse:
+        raise RuntimeError(f"could not delete {env_id}")
+
+
+class HangingDeleteTauBenchClient(FakeTauBenchClient):
+    async def delete_environment(self, env_id: str) -> DeleteEnvironmentResponse:
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+class CancellationResistantDeleteTauBenchClient(FakeTauBenchClient):
+    def __init__(self) -> None:
+        self.cancelled = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def delete_environment(self, env_id: str) -> DeleteEnvironmentResponse:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            await self.release.wait()
+        return DeleteEnvironmentResponse(id=env_id, deleted=True)
+
+
+@pytest.mark.asyncio
+async def test_environment_preserves_primary_error_when_cleanup_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = FailingDeleteTauBenchClient()
+
+    with pytest.raises(ValueError, match="rollout failed") as exc_info:
+        async with client.environment(domain="telecom", task_id="task_001"):
+            raise ValueError("rollout failed")
+
+    assert exc_info.value.__notes__ == [
+        "Failed to delete tau-bench environment env-1: RuntimeError('could not delete env-1')"
+    ]
+    assert "Failed to delete tau-bench environment env-1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_environment_preserves_cancellation_when_cleanup_fails() -> None:
+    client = FailingDeleteTauBenchClient()
+
+    with pytest.raises(asyncio.CancelledError):
+        async with client.environment(domain="telecom", task_id="task_001"):
+            raise asyncio.CancelledError
+
+
+@pytest.mark.asyncio
+async def test_environment_bounds_cleanup_while_preserving_primary_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_module, "DEFAULT_CLEANUP_TIMEOUT", 0.01)
+    client = HangingDeleteTauBenchClient()
+
+    with pytest.raises(ValueError, match="rollout failed"):
+        async with client.environment(domain="telecom", task_id="task_001"):
+            raise ValueError("rollout failed")
+
+
+@pytest.mark.asyncio
+async def test_environment_does_not_await_cancellation_resistant_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_module, "DEFAULT_CLEANUP_TIMEOUT", 0.01)
+    client = CancellationResistantDeleteTauBenchClient()
+
+    with pytest.raises(ValueError, match="rollout failed"):
+        async with client.environment(domain="telecom", task_id="task_001"):
+            raise ValueError("rollout failed")
+
+    await asyncio.wait_for(client.cancelled.wait(), timeout=0.1)
+    client.release.set()
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_environment_propagates_cleanup_error_after_success() -> None:
+    client = FailingDeleteTauBenchClient()
+
+    with pytest.raises(RuntimeError, match="could not delete env-1"):
+        async with client.environment(domain="telecom", task_id="task_001"):
+            pass
 
 
 class FakeCompletions:


### PR DESCRIPTION
## Summary

- preserve tau-bench's existing 300-second response budget while tightening connect, pool, and write phase bounds
- add a 300-second wall-clock deadline around each ART-owned request attempt, covering waits that HTTPX phase timeouts do not
- retry stateful operations only for known pre-send failures on ART-owned transports; retain safe-method retries
- preserve the primary rollout exception or cancellation when cleanup fails
- bound best-effort cleanup even when DELETE resists cancellation
- leave caller-managed HTTP clients unchanged

This is the ART client-side half of the remediation paired with OpenPipe/tau-bench#13. The 300-second compatibility bound avoids shortening legitimate tau-bench user-LLM retries; the server can later advertise a tighter authoritative end-to-end operation deadline.

## Verification

- `uv run pytest tests/unit/test_tau_bench_client.py -q` — 34 passed
- `uv run ty check src/art/tau_bench/client.py tests/unit/test_tau_bench_client.py`
- `uv run ruff check src/art/tau_bench/client.py tests/unit/test_tau_bench_client.py`
- `uv run ruff format --check src/art/tau_bench/client.py tests/unit/test_tau_bench_client.py`
- independent probes confirmed a cancellation-resistant cleanup returns at its bound and a stateful outer timeout is not retried
