### PR TITLE
Rationalize TrainerRank checkpoint activation

### DIFF
--- a/dev/trainer_rank_checkpoint_acceptance.py
+++ b/dev/trainer_rank_checkpoint_acceptance.py
@@ -9,7 +9,6 @@ weights for cross-topology comparison.
 from __future__ import annotations
 
 import argparse
-import asyncio
 import hashlib
 import json
 import os
@@ -43,10 +42,6 @@ def _digest(path: Path) -> str:
     return digest.hexdigest()
 
 
-async def _load(trainer: TrainerRank, source: str) -> None:
-    await trainer.load_checkpoint(source)
-
-
 def main() -> None:
     args = _args()
     os.environ.setdefault("ART_MEGATRON_TENSOR_MODEL_PARALLEL_SIZE", "1")
@@ -67,7 +62,7 @@ def main() -> None:
             print_env=rank == 0,
         )
         trainer = TrainerRank(runtime)
-        asyncio.run(_load(trainer, args.source))
+        trainer.load_checkpoint(args.source)
         loaded = time.perf_counter()
         if args.operation != "load":
             slot = trainer._checkpoint_slots[args.source]

--- a/src/art/megatron/lora.py
+++ b/src/art/megatron/lora.py
@@ -639,6 +639,36 @@ class LoRA(torch.nn.Module):
         )
         return True
 
+    def _snapshot_lora_slot(
+        self, source: LoRASlotRef, destination: LoRASlotRef
+    ) -> bool:
+        slot = self._slot(source)
+        if slot is None:
+            return False
+        if destination in self._slot_keys:
+            raise RuntimeError(
+                f"LoRA slot {destination.kind}:{destination.name} already exists"
+            )
+        index = len(self._slot_keys)
+        while (key := f"slot_{index}") in self._slot_modules:
+            index += 1
+        self._slot_keys[destination] = key
+        self._slot_modules[key] = LoRASlot(
+            ref=destination,
+            a_t=slot.A_T,
+            b_t=slot.B_T,
+            alpha=slot.alpha,
+            a_template=slot.A_T,
+            b_template=slot.B_T,
+            requires_grad=False,
+        )
+        return True
+
+    def _discard_lora_slot(self, ref: LoRASlotRef) -> None:
+        key = self._slot_keys.pop(ref, None)
+        if key is not None:
+            del self._slot_modules[key]
+
     def lora_slot_params(self, ref: LoRASlotRef) -> list[torch.nn.Parameter]:
         slot = self._slot(ref)
         if slot is None:

--- a/src/art/trainer_rank/__init__.py
+++ b/src/art/trainer_rank/__init__.py
@@ -18,13 +18,13 @@ ForwardInput = _impl.ForwardInput
 ForwardInputs = _impl.ForwardInputs
 ForwardOutput = _impl.ForwardOutput
 ForwardOutputs = _impl.ForwardOutputs
-HiddenStatesT = _impl.HiddenStatesT
-LogitsT = _impl.LogitsT
-LogprobsT = _impl.LogprobsT
 MicroBatch = _impl.MicroBatch
 MicroBatchStats = _impl.MicroBatchStats
 TopK = _impl.TopK
-TopKT = _impl.TopKT
+LogprobsT = TypeVar("LogprobsT", bound=torch.Tensor | None, covariant=True)
+TopKT = TypeVar("TopKT", bound=TopK | None, covariant=True)
+LogitsT = TypeVar("LogitsT", bound=torch.Tensor | None, covariant=True)
+HiddenStatesT = TypeVar("HiddenStatesT", bound=torch.Tensor | None, covariant=True)
 TrainerRankMemoryError = _impl.TrainerRankMemoryError
 TrainerRankSlotStateError = _impl.TrainerRankSlotStateError
 Unset = _impl.Unset
@@ -110,10 +110,12 @@ class TrainerRank(_impl.TrainerRank):
     ) -> asyncio.Task[None]:
         return super().prefetch_checkpoints(*checkpoints)
 
-    def load_checkpoint(
-        self, checkpoint: str | MaterializedCheckpoint | None
-    ) -> asyncio.Task[None]:
-        return super().load_checkpoint(checkpoint)
+    def load_checkpoint(self, checkpoint: str | MaterializedCheckpoint | None) -> None:
+        super().load_checkpoint(checkpoint)
+
+    def snapshot_checkpoint(self, source: str, destination: str) -> bool:
+        """Clone a loaded checkpoint into a forward-only resident snapshot."""
+        return super().snapshot_checkpoint(source, destination)
 
     def push_checkpoint(
         self, checkpoint: str | MaterializedCheckpoint | None
@@ -233,8 +235,9 @@ class TrainerRank(_impl.TrainerRank):
     ) -> Iterator[MicroBatch[ForwardInputs, ForwardOutputs]]:
         """Forward replicated inputs in adaptive data-parallel microbatches.
 
-        Per-input checkpoints override `checkpoint`. `no_grad=None` inherits the
-        ambient PyTorch grad mode; `True` disables grads and `False` enables them.
+        Per-input checkpoints and `no_grad` values override the method defaults.
+        `no_grad=None` inherits the ambient PyTorch grad mode; `True` disables
+        grads and `False` enables them.
         Input and target tensors may be on a different device from the trainer;
         ART moves its packed model inputs and labels internally without mutating
         the caller-owned `ForwardInput` objects.
@@ -308,8 +311,9 @@ class TrainerRank(_impl.TrainerRank):
     ) -> ForwardOutputs:
         """Forward inputs already local to this data-parallel rank.
 
-        Per-input checkpoints override `checkpoint`. `no_grad=None` inherits the
-        ambient PyTorch grad mode; `True` disables grads and `False` enables them.
+        Per-input checkpoints and `no_grad` values override the method defaults.
+        `no_grad=None` inherits the ambient PyTorch grad mode; `True` disables
+        grads and `False` enables them.
         Input and target tensors may be on a different device from the trainer;
         ART moves its packed model inputs and labels internally without mutating
         the caller-owned `ForwardInput` objects.

--- a/src/art/trainer_rank/_checkpoint.py
+++ b/src/art/trainer_rank/_checkpoint.py
@@ -15,6 +15,7 @@ import struct
 import threading
 from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, cast
 import uuid
+import weakref
 
 import torch
 import torch.distributed as dist
@@ -529,6 +530,49 @@ def validate_checkpoint(
     return prepared.manifest
 
 
+def materialize_checkpoint(
+    path: str | Path,
+    output_dir: str | Path,
+    *,
+    require_optimizer: bool = False,
+    expected_digest: str | None = None,
+) -> str:
+    """Copy one validated checkpoint without loading it into a trainer slot."""
+    source = prepare_checkpoint(str(path))
+    if expected_digest is not None and source.digest != expected_digest:
+        raise RuntimeError(
+            f"Checkpoint digest mismatch: {source.digest} != {expected_digest}"
+        )
+    if require_optimizer and (
+        source.manifest is None or source.manifest["optimizer"] is None
+    ):
+        raise RuntimeError("Checkpoint does not contain optimizer state")
+    destination = Path(output_dir)
+    if destination.exists() and any(destination.iterdir()):
+        raise FileExistsError(
+            f"Checkpoint output directory is not empty: {destination}"
+        )
+    destination.mkdir(parents=True, exist_ok=True)
+    files = (
+        {"adapter_config.json", "adapter_model.safetensors"}
+        if source.manifest is None
+        else {*source.manifest["files"], MANIFEST_FILE}
+    )
+    for relative in files:
+        target = destination / _safe_relative(relative)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.link(source.path / relative, target)
+        except OSError:
+            shutil.copy2(source.path / relative, target)
+    actual = prepare_checkpoint(str(destination)).digest
+    if actual != source.digest:
+        raise RuntimeError(
+            f"Materialized checkpoint digest mismatch: {actual} != {source.digest}"
+        )
+    return source.digest
+
+
 def materialize_lora(
     path: str | Path,
     output_dir: str | Path,
@@ -618,6 +662,10 @@ def _validate_save_state(trainer: TrainerRank, name: str) -> _AdapterConfig:
     slot = trainer._checkpoint_slots.get(name)
     if slot is None or slot.config is None:
         raise trainer._slot_state_error(f"Unknown checkpoint: {name!r}")
+    if slot.snapshot:
+        raise trainer._slot_state_error(
+            f"Snapshot checkpoint {name!r} is forward-only and cannot be saved"
+        )
     if trainer._checkpoint_grad_flags((name,))[0]:
         raise trainer._slot_state_error(
             f"Checkpoint {name!r} has accumulated gradients"
@@ -1448,8 +1496,6 @@ def _localized(
 
 
 def _slot_snapshot(trainer: TrainerRank) -> _SlotSnapshot:
-    from art.megatron.lora import LoRA, LoRASlotRef
-
     return tuple(
         (
             module,
@@ -1459,7 +1505,7 @@ def _slot_snapshot(trainer: TrainerRank) -> _SlotSnapshot:
         )
         for chunk in trainer.runtime.model
         for module in chunk.modules()
-        if isinstance(module, LoRA)
+        if hasattr(module, "_slot_keys") and hasattr(module, "_slot_modules")
     )
 
 
@@ -1469,6 +1515,164 @@ def _restore_slots(snapshot: _SlotSnapshot) -> None:
             setattr(slot, "ref", refs[key])
         module._slot_keys = keys
         module._slot_modules = torch.nn.ModuleDict(slots)
+
+
+def _forward_custom_payload(
+    payload: PreparedCustomPayload | None,
+) -> PreparedCustomPayload | None:
+    payload = deepcopy(payload)
+    if payload is None:
+        return None
+    for record in payload.records.values():
+        record["trainable_keys"] = []
+    return PreparedCustomPayload(payload.records, payload.tensors, {})
+
+
+def snapshot_checkpoint(trainer: TrainerRank, source: str, destination: str) -> bool:
+    """Clone one loaded checkpoint into a forward-only resident slot."""
+    from art.trainer_rank._impl import (
+        _CheckpointSlot,
+        _CustomObject,
+        _CustomTensorTracker,
+        _track_custom_object,
+    )
+
+    group = _ensure_group(trainer)
+    error: BaseException | None = None
+    source_slot = trainer._checkpoint_slots.get(source)
+    destination_slot = trainer._checkpoint_slots.get(destination)
+    try:
+        if not source or not destination or source == destination:
+            raise ValueError("Snapshot source and destination must be distinct names")
+        if source_slot is None or source_slot.config is None:
+            raise trainer._slot_state_error(f"Unknown checkpoint: {source!r}")
+        if source_slot.snapshot:
+            raise trainer._slot_state_error(
+                f"Cannot snapshot forward-only checkpoint {source!r}"
+            )
+        if destination_slot is not None and not destination_slot.snapshot:
+            raise trainer._slot_state_error(
+                f"Checkpoint {destination!r} is already loaded"
+            )
+    except BaseException as exc:
+        error = exc
+    raise_distributed(error, "validate checkpoint snapshot", group)
+    assert source_slot is not None and source_slot.config is not None
+    identity = (
+        source,
+        destination,
+        dict(source_slot.config),
+        source_slot.revision,
+        destination_slot is not None,
+    )
+    if any(value != identity for value in _gather(identity, group)):
+        raise trainer._slot_state_error(
+            "Checkpoint snapshot state differs across ranks"
+        )
+    if destination_slot is not None:
+        return False
+
+    model_snapshot = _slot_snapshot(trainer)
+    destination_ref = trainer._slot_ref(destination)
+    custom: dict[str, _CustomObject] = {}
+    trackers: list[_CustomTensorTracker] = []
+    try:
+        for chunk in trainer.runtime.model:
+            for module in chunk.modules():
+                snapshot = getattr(module, "_snapshot_lora_slot", None)
+                if callable(snapshot):
+                    snapshot(trainer._slot_ref(source), destination_ref)
+        for name, item in source_slot.custom.items():
+            value = deepcopy(item.value)
+            if isinstance(value, torch.nn.Module):
+                value.requires_grad_(False)
+            elif isinstance(value, torch.nn.Parameter):
+                value.requires_grad_(False)
+            cloned = _CustomObject(item.kind, value, object())
+            tracker = _CustomTensorTracker(
+                weakref.ref(trainer),
+                destination_ref,
+                name,
+                cloned.generation,
+            )
+            cloned = _track_custom_object(cloned, tracker)
+            custom[name] = cloned
+            trackers.append(tracker)
+        params: list[torch.nn.Parameter] = []
+        seen: set[int] = set()
+        for chunk in trainer.runtime.model:
+            for module in chunk.modules():
+                slot_params = getattr(module, "lora_slot_params", None)
+                if not callable(slot_params):
+                    continue
+                for parameter in slot_params(destination_ref):
+                    if id(parameter) not in seen:
+                        seen.add(id(parameter))
+                        params.append(parameter)
+        trainer._checkpoint_slots[destination] = _CheckpointSlot(
+            params=tuple(params),
+            config=deepcopy(source_slot.config),
+            revision=source_slot.revision,
+            custom=custom,
+            custom_payload=_forward_custom_payload(source_slot.custom_payload),
+            snapshot=True,
+        )
+        for tracker in trackers:
+            tracker.active = True
+    except BaseException as exc:
+        _restore_slots(model_snapshot)
+        trainer._checkpoint_slots.pop(destination, None)
+        error = exc
+    try:
+        raise_distributed(error, "snapshot checkpoint", group)
+    except BaseException:
+        _restore_slots(model_snapshot)
+        trainer._checkpoint_slots.pop(destination, None)
+        raise
+    return True
+
+
+def discard_snapshot_checkpoint(trainer: TrainerRank, checkpoint: str) -> None:
+    """Collectively discard a forward-only resident checkpoint snapshot."""
+    group = _ensure_group(trainer)
+    slot = trainer._checkpoint_slots.get(checkpoint)
+    active = (
+        trainer._default_slot_ref is not None
+        and trainer._default_slot_ref.name == checkpoint
+    ) or any(ref.name == checkpoint for ref in trainer._slot_stack)
+    state = (slot is not None, False if slot is None else slot.snapshot, active)
+    if any(value != state for value in _gather(state, group)):
+        raise trainer._slot_state_error(
+            "Checkpoint snapshot state differs across ranks"
+        )
+    if slot is None:
+        return
+    if not slot.snapshot:
+        raise trainer._slot_state_error(
+            f"Checkpoint {checkpoint!r} is not a forward-only snapshot"
+        )
+    if active:
+        raise trainer._slot_state_error(
+            f"Cannot discard selected checkpoint snapshot {checkpoint!r}"
+        )
+    if any(_gather(trainer._has_live_slot_graph(trainer._slot_ref(checkpoint)), group)):
+        raise trainer._slot_state_error(
+            f"Cannot discard checkpoint snapshot {checkpoint!r} with live outputs"
+        )
+    model_snapshot = _slot_snapshot(trainer)
+    try:
+        ref = trainer._slot_ref(checkpoint)
+        for chunk in trainer.runtime.model:
+            for module in chunk.modules():
+                discard = getattr(module, "_discard_lora_slot", None)
+                if callable(discard):
+                    discard(ref)
+        trainer._checkpoint_slots.pop(checkpoint)
+        trainer._prune_slot_graphs(ref)
+    except BaseException:
+        _restore_slots(model_snapshot)
+        trainer._checkpoint_slots[checkpoint] = slot
+        raise
 
 
 def _commit_slot(trainer: TrainerRank, source: str, destination: str) -> None:
@@ -1620,7 +1824,11 @@ def _rollback_load(
 
 
 def load_checkpoint(
-    trainer: TrainerRank, source: PreparedCheckpoint, name: str
+    trainer: TrainerRank,
+    source: PreparedCheckpoint,
+    name: str,
+    *,
+    forward_only: bool = False,
 ) -> None:
     group = _ensure_group(trainer)
     if any(value != source.digest for value in _gather(source.digest, group)):
@@ -1688,17 +1896,31 @@ def load_checkpoint(
             "validate staged checkpoint",
             group,
         )
+        if forward_only:
+            for param in params:
+                param.requires_grad_(False)
         from art.trainer_rank._impl import _CheckpointSlot
 
         trainer._checkpoint_slots[temporary] = _CheckpointSlot(
-            params, config, custom_payload=source.custom
+            params,
+            config,
+            custom_payload=(
+                _forward_custom_payload(source.custom)
+                if forward_only
+                else source.custom
+            ),
+            snapshot=forward_only,
         )
         _phase(
             lambda: trainer._validate_loaded_checkpoint_config(temporary, config),
             "validate loaded checkpoint config",
             group,
         )
-        if source.manifest is not None and source.manifest["optimizer"] is not None:
+        if (
+            not forward_only
+            and source.manifest is not None
+            and source.manifest["optimizer"] is not None
+        ):
             optimizer_state = _phase(
                 lambda: _optimizer_state(trainer, source, temporary),
                 "read checkpoint optimizer",
@@ -1722,6 +1944,27 @@ def load_checkpoint(
     except BaseException:
         _rollback_load(trainer, snapshot, temporary, name, previous, group)
         raise
+
+
+def snapshot_prepared_checkpoint(
+    trainer: TrainerRank, source: PreparedCheckpoint, destination: str
+) -> bool:
+    """Load prepared state into a forward-only resident slot."""
+    group = _ensure_group(trainer)
+    slot = trainer._checkpoint_slots.get(destination)
+    state = None if slot is None else slot.snapshot
+    if any(value != state for value in _gather(state, group)):
+        raise trainer._slot_state_error(
+            "Checkpoint snapshot state differs across ranks"
+        )
+    if slot is not None:
+        if not slot.snapshot:
+            raise trainer._slot_state_error(
+                f"Checkpoint {destination!r} is already loaded"
+            )
+        return False
+    load_checkpoint(trainer, source, destination, forward_only=True)
+    return True
 
 
 def _ensure_groups(

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -4,16 +4,15 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import (
-    Awaitable,
     Callable,
-    Generator,
     Iterable,
     Iterator,
     Mapping,
     Sequence,
 )
+from concurrent.futures import Future, ThreadPoolExecutor
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from dataclasses import field as dataclass_field
 import math
 import os
@@ -93,6 +92,23 @@ T = TypeVar("T")
 ModuleT = TypeVar("ModuleT", bound=torch.nn.Module)
 
 _MEMORY_PROFILE_TRUST_GROWTH = 8
+_CHECKPOINT_PREFETCH_EXECUTOR: tuple[int, ThreadPoolExecutor] | None = None
+_CHECKPOINT_PREFETCH_EXECUTOR_LOCK = threading.Lock()
+
+
+def _checkpoint_prefetch_executor() -> ThreadPoolExecutor:
+    global _CHECKPOINT_PREFETCH_EXECUTOR
+    pid = os.getpid()
+    with _CHECKPOINT_PREFETCH_EXECUTOR_LOCK:
+        if (
+            _CHECKPOINT_PREFETCH_EXECUTOR is None
+            or _CHECKPOINT_PREFETCH_EXECUTOR[0] != pid
+        ):
+            _CHECKPOINT_PREFETCH_EXECUTOR = (
+                pid,
+                ThreadPoolExecutor(thread_name_prefix="art-checkpoint-prefetch"),
+            )
+        return _CHECKPOINT_PREFETCH_EXECUTOR[1]
 
 
 class _AdapterConfig(TypedDict):
@@ -126,6 +142,8 @@ class ForwardOutput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
     top_k: TopKT
     logits: LogitsT
     hidden_states: HiddenStatesT
+    checkpoint: str | None = None
+    no_grad: bool = False
 
 
 @dataclass(slots=True)
@@ -135,6 +153,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
     top_k: int | None = None
     logits: bool = False
     hidden_states: bool = False
+    no_grad: bool | None = None
     checkpoint: AdapterSelection = Unset
 
     @overload
@@ -146,6 +165,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: None = None,
         logits: Literal[False] = False,
         hidden_states: Literal[False] = False,
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[None, None, None, None]": ...
 
@@ -158,6 +178,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: None = None,
         logits: Literal[False] = False,
         hidden_states: Literal[False] = False,
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[torch.Tensor, None, None, None]": ...
 
@@ -170,6 +191,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: int,
         logits: Literal[False] = False,
         hidden_states: Literal[False] = False,
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[None, TopK, None, None]": ...
 
@@ -182,6 +204,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: None = None,
         logits: Literal[True],
         hidden_states: Literal[False] = False,
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[None, None, torch.Tensor, None]": ...
 
@@ -194,6 +217,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: None = None,
         logits: Literal[False] = False,
         hidden_states: Literal[True],
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[None, None, None, torch.Tensor]": ...
 
@@ -206,6 +230,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: int,
         logits: Literal[False] = False,
         hidden_states: Literal[False] = False,
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[torch.Tensor, TopK, None, None]": ...
 
@@ -218,6 +243,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: None = None,
         logits: Literal[True],
         hidden_states: Literal[False] = False,
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[torch.Tensor, None, torch.Tensor, None]": ...
 
@@ -230,6 +256,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: None = None,
         logits: Literal[False] = False,
         hidden_states: Literal[True],
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[torch.Tensor, None, None, torch.Tensor]": ...
 
@@ -242,6 +269,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: int,
         logits: Literal[True],
         hidden_states: Literal[False] = False,
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[None, TopK, torch.Tensor, None]": ...
 
@@ -254,6 +282,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: int,
         logits: Literal[False] = False,
         hidden_states: Literal[True],
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[None, TopK, None, torch.Tensor]": ...
 
@@ -266,6 +295,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: None = None,
         logits: Literal[True],
         hidden_states: Literal[True],
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[None, None, torch.Tensor, torch.Tensor]": ...
 
@@ -278,6 +308,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: int,
         logits: Literal[True],
         hidden_states: Literal[False] = False,
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[torch.Tensor, TopK, torch.Tensor, None]": ...
 
@@ -290,6 +321,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: int,
         logits: Literal[False] = False,
         hidden_states: Literal[True],
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[torch.Tensor, TopK, None, torch.Tensor]": ...
 
@@ -302,6 +334,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: None = None,
         logits: Literal[True],
         hidden_states: Literal[True],
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[torch.Tensor, None, torch.Tensor, torch.Tensor]": ...
 
@@ -314,6 +347,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: int,
         logits: Literal[True],
         hidden_states: Literal[True],
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[None, TopK, torch.Tensor, torch.Tensor]": ...
 
@@ -326,6 +360,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: int,
         logits: Literal[True],
         hidden_states: Literal[True],
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[torch.Tensor, TopK, torch.Tensor, torch.Tensor]": ...
 
@@ -338,6 +373,7 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: int | None = None,
         logits: bool = False,
         hidden_states: bool = False,
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> "ForwardInput[torch.Tensor | None, TopK | None, torch.Tensor | None, torch.Tensor | None]": ...
 
@@ -349,9 +385,30 @@ class ForwardInput(Generic[LogprobsT, TopKT, LogitsT, HiddenStatesT]):
         top_k: int | None = None,
         logits: bool = False,
         hidden_states: bool = False,
+        no_grad: bool | None = None,
         checkpoint: AdapterSelection = Unset,
     ) -> Self:
         return object.__new__(cls)
+
+    def __init__(
+        self,
+        *,
+        input_tokens: torch.Tensor,
+        target_tokens: torch.Tensor | None = None,
+        top_k: int | None = None,
+        logits: bool = False,
+        hidden_states: bool = False,
+        no_grad: bool | None = None,
+        checkpoint: AdapterSelection = Unset,
+    ) -> None:
+        self.input_tokens = input_tokens
+        self.target_tokens = target_tokens
+        self.top_k = top_k
+        self.logits = logits
+        self.hidden_states = hidden_states
+        self.no_grad = no_grad
+        self.checkpoint = checkpoint
+        self.__post_init__()
 
     def __post_init__(self) -> None:
         if self.top_k is not None and self.top_k < 1:
@@ -632,6 +689,7 @@ class _CheckpointSlot:
     revision: int = 0
     custom: dict[str, _CustomObject] = dataclass_field(default_factory=dict)
     custom_payload: "PreparedCustomPayload | None" = None
+    snapshot: bool = False
 
 
 @dataclass(frozen=True)
@@ -647,24 +705,13 @@ class PushedCheckpoint:
     _trainer: "TrainerRank"
     _path: str | None
     _directory: str | None
-    _task: asyncio.Task[None] | None = None
     _entered: bool = False
     _closed: bool = False
-
-    def __await__(self) -> Generator[object, None, None]:
-        return self._ensure_task().__await__()
 
     def __enter__(self) -> "PushedCheckpoint":
         if self._entered or self._closed:
             raise RuntimeError("Pushed checkpoint context cannot be entered twice")
-        if self._task is not None:
-            if not self._task.done():
-                raise RuntimeError(
-                    "Checkpoint push is running asynchronously; use 'async with'"
-                )
-            self._task.result()
-        else:
-            self._trainer._push_checkpoint_sync(self._path, self._directory)
+        self._trainer._push_checkpoint_sync(self._path, self._directory)
         self._entered = True
         return self
 
@@ -676,34 +723,6 @@ class PushedCheckpoint:
     ) -> bool:
         self._exit(exception)
         return False
-
-    async def __aenter__(self) -> "PushedCheckpoint":
-        if self._entered or self._closed:
-            raise RuntimeError("Pushed checkpoint context cannot be entered twice")
-        task = self._ensure_task()
-        try:
-            await task
-        except asyncio.CancelledError:
-            if task.done() and not task.cancelled() and task.exception() is None:
-                self._entered = True
-                self._pop()
-            raise
-        self._entered = True
-        return self
-
-    async def __aexit__(
-        self,
-        exception_type: type[BaseException] | None,
-        exception: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> bool:
-        self._exit(exception)
-        return False
-
-    def _ensure_task(self) -> asyncio.Task[None]:
-        if self._task is None:
-            self._task = self._trainer._activate_checkpoint(self._path, self._directory)
-        return self._task
 
     def _exit(self, body_error: BaseException | None) -> None:
         try:
@@ -754,11 +773,13 @@ class _MemorySignature:
     slot_group_count: int
     request_mix: tuple[str, ...]
     grad_enabled: bool
+    grad_modes: tuple[bool, ...]
 
 
 @dataclass(frozen=True)
 class _ForwardGroupPlan:
     slot_ref: "LoRASlotRef | None"
+    grad_enabled: bool
     request_indices: tuple[int, ...]
     items: tuple[_ForwardItem, ...]
     packed: PrefixTreePack
@@ -767,6 +788,7 @@ class _ForwardGroupPlan:
 @dataclass(frozen=True)
 class _FlatForwardPlan:
     request_count: int
+    output_metadata: tuple[tuple[str | None, bool], ...]
     groups: tuple[_ForwardGroupPlan, ...]
     packed_tokens: int
     logical_tokens: int
@@ -823,8 +845,10 @@ class TrainerRank:
         self._slot_stack: list[LoRASlotRef] = []
         self._checkpoint_slots: dict[str, _CheckpointSlot] = {}
         self._prepared_lora_exports: dict[str, tuple[str, _PreparedLoraExport]] = {}
-        self._checkpoint_prefetches: dict[str, asyncio.Task[PreparedCheckpoint]] = {}
-        self._checkpoint_mutation_tail: asyncio.Task[None] | None = None
+        self._checkpoint_prefetches: dict[str, Future[PreparedCheckpoint]] = {}
+        self._checkpoint_prefetch_sources: dict[str, str] = {}
+        self._checkpoint_prefetch_lock = threading.Lock()
+        self._checkpoint_mutation_lock = threading.RLock()
         self._checkpoint_process_group: dist.ProcessGroup | None = None
         self._checkpoint_finalize_process_group: dist.ProcessGroup | None = None
         self._checkpoint_group_lock = threading.Lock()
@@ -956,11 +980,14 @@ class TrainerRank:
                 if not isinstance(value, torch.nn.Module):
                     raise TypeError("module() factory must return torch.nn.Module")
                 value = value.to(device=self.device)
+                if slot.snapshot:
+                    value.requires_grad_(False)
             elif kind == "parameter":
                 if not isinstance(value, torch.Tensor):
                     raise TypeError("parameter() factory must return torch.Tensor")
                 value = torch.nn.Parameter(
-                    value.detach().to(device=self.device).clone(), requires_grad=True
+                    value.detach().to(device=self.device).clone(),
+                    requires_grad=not slot.snapshot,
                 )
             else:
                 if not isinstance(value, torch.Tensor):
@@ -1019,6 +1046,7 @@ class TrainerRank:
             raise TrainerRankSlotStateError(
                 "Custom checkpoint objects require a loaded named checkpoint"
             )
+        self._ensure_checkpoint_slots((name,))
         if name not in self._checkpoint_slots:
             raise TrainerRankSlotStateError(f"Unknown checkpoint: {name!r}")
         return name
@@ -1135,50 +1163,154 @@ class TrainerRank:
     def prefetch_checkpoints(
         self, *checkpoints: str | MaterializedCheckpoint
     ) -> asyncio.Task[None]:
-        sources = tuple(
-            self._checkpoint_source(checkpoint)[1] for checkpoint in checkpoints
-        )
-        assert all(source is not None for source in sources)
+        futures = []
+        for checkpoint in checkpoints:
+            logical, source = self._checkpoint_source(checkpoint)
+            assert logical is not None and source is not None
+            futures.append(self._register_checkpoint_prefetch(logical, source))
 
         async def prefetch() -> None:
             await asyncio.gather(
-                *(
-                    self._prefetch_checkpoint(source)
-                    for source in sources
-                    if source is not None
-                )
+                *(self._await_checkpoint_prefetch(future) for future in futures)
             )
 
         return asyncio.create_task(prefetch())
 
-    def load_checkpoint(
-        self, checkpoint: str | MaterializedCheckpoint | None
-    ) -> asyncio.Task[None]:
+    @staticmethod
+    async def _await_checkpoint_prefetch(
+        future: Future[PreparedCheckpoint],
+    ) -> PreparedCheckpoint:
+        return await asyncio.shield(asyncio.wrap_future(future))
+
+    def _register_checkpoint_prefetch(
+        self,
+        checkpoint: str,
+        source: str,
+        prepare: Callable[[], PreparedCheckpoint] | None = None,
+    ) -> Future[PreparedCheckpoint]:
+        key = self._checkpoint_source_key(source)
+        with self._checkpoint_prefetch_lock:
+            previous = self._checkpoint_prefetch_sources.get(checkpoint)
+            self._checkpoint_prefetch_sources[checkpoint] = key
+            if (
+                previous is not None
+                and previous != key
+                and previous not in self._checkpoint_prefetch_sources.values()
+            ):
+                self._checkpoint_prefetches.pop(previous, None)
+            future = self._checkpoint_prefetches.get(key)
+            if future is None or (
+                future.done() and (future.cancelled() or future.exception() is not None)
+            ):
+                if prepare is None:
+                    from ._checkpoint import prepare_checkpoint
+
+                    prepare = lambda: prepare_checkpoint(key)
+                future = _checkpoint_prefetch_executor().submit(prepare)
+                self._checkpoint_prefetches[key] = future
+            return future
+
+    def _checkpoint_prefetch_waiter(self, *checkpoints: str) -> asyncio.Task[None]:
+        with self._checkpoint_prefetch_lock:
+            futures = [
+                self._checkpoint_prefetches[self._checkpoint_prefetch_sources[name]]
+                for name in checkpoints
+                if name not in self._checkpoint_slots
+            ]
+
+        async def wait() -> None:
+            await asyncio.gather(
+                *(self._await_checkpoint_prefetch(future) for future in futures)
+            )
+
+        return asyncio.create_task(wait())
+
+    def _prefetched_checkpoint(self, checkpoint: str) -> PreparedCheckpoint:
+        with self._checkpoint_prefetch_lock:
+            key = self._checkpoint_prefetch_sources.get(checkpoint)
+            future = None if key is None else self._checkpoint_prefetches.get(key)
+        if future is None:
+            raise TrainerRankSlotStateError(
+                f"Checkpoint {checkpoint!r} has not been prefetched"
+            )
+        return future.result()
+
+    def _load_registered_checkpoint(self, checkpoint: str) -> None:
+        from . import _checkpoint
+
+        source: PreparedCheckpoint | None = None
+        error: BaseException | None = None
+        try:
+            source = self._prefetched_checkpoint(checkpoint)
+        except BaseException as exc:
+            error = exc
+        group = _checkpoint._ensure_group(self)
+        _checkpoint.raise_distributed(error, "prepare checkpoint", group)
+        assert source is not None
+        _checkpoint.load_checkpoint(self, source, checkpoint)
+
+    def _ensure_checkpoint_slots(self, checkpoints: Iterable[str]) -> None:
+        from . import _checkpoint
+
+        requested = tuple(dict.fromkeys(checkpoints))
+        with self._checkpoint_mutation_lock:
+            group = _checkpoint._ensure_group(self)
+            names = sorted(
+                {
+                    name
+                    for rank_names in _checkpoint._gather(requested, group)
+                    for name in rank_names
+                }
+            )
+            for name in names:
+                with self._checkpoint_prefetch_lock:
+                    state = (
+                        name in self._checkpoint_slots,
+                        name in self._checkpoint_prefetch_sources,
+                    )
+                states = _checkpoint._gather(state, group)
+                if all(loaded for loaded, _prefetched in states):
+                    continue
+                if any(loaded for loaded, _prefetched in states):
+                    raise TrainerRankSlotStateError(
+                        f"Checkpoint {name!r} is not loaded consistently across ranks"
+                    )
+                if not all(prefetched for _loaded, prefetched in states):
+                    raise TrainerRankSlotStateError(
+                        f"Explicit selection references unloaded checkpoint {name!r}; "
+                        "it has not been prefetched on every rank"
+                    )
+                self._load_registered_checkpoint(name)
+
+    def load_checkpoint(self, checkpoint: str | MaterializedCheckpoint | None) -> None:
         logical, source = self._checkpoint_source(checkpoint)
-        return self._load_checkpoint(logical, source)
-
-    def _load_checkpoint(
-        self, logical_path: str | None, source_path: str | None
-    ) -> asyncio.Task[None]:
-        prefetch = (
-            None
-            if source_path is None
-            else asyncio.create_task(self._prefetch_checkpoint(source_path))
-        )
-
-        async def load() -> None:
+        with self._checkpoint_mutation_lock:
             if self._slot_stack:
                 raise RuntimeError("Cannot load a checkpoint while one is pushed")
-            if logical_path is None:
+            if logical is None:
                 self._set_default_slot(self._slot_ref(None))
                 return
-            assert source_path is not None and prefetch is not None
-            await self._load_checkpoint_path(
-                logical_path, source_path=source_path, prefetch=prefetch
-            )
-            self._set_default_slot(self._slot_ref(logical_path))
+            assert source is not None
+            if (
+                isinstance(checkpoint, MaterializedCheckpoint)
+                or logical not in self._checkpoint_prefetch_sources
+            ):
+                self._register_checkpoint_prefetch(logical, source)
+            self._load_registered_checkpoint(logical)
+            self._set_default_slot(self._slot_ref(logical))
 
-        return self._checkpoint_mutation_task(load)
+    def snapshot_checkpoint(self, source: str, destination: str) -> bool:
+        """Clone a loaded checkpoint into a forward-only resident snapshot."""
+        from . import _checkpoint
+
+        self._ensure_checkpoint_slots((source,))
+        return _checkpoint.snapshot_checkpoint(self, source, destination)
+
+    def _discard_snapshot_checkpoint(self, checkpoint: str) -> None:
+        """Discard a forward-only resident snapshot."""
+        from . import _checkpoint
+
+        _checkpoint.discard_snapshot_checkpoint(self, checkpoint)
 
     def push_checkpoint(
         self, checkpoint: str | MaterializedCheckpoint | None
@@ -1186,69 +1318,29 @@ class TrainerRank:
         logical, directory = self._checkpoint_source(checkpoint)
         return PushedCheckpoint(self, logical, directory)
 
-    def _activate_checkpoint(
-        self, logical_path: str | None, source_path: str | None
-    ) -> asyncio.Task[None]:
-        prefetch = (
-            asyncio.create_task(self._prefetch_checkpoint(source_path))
-            if source_path is not None and logical_path not in self._checkpoint_slots
-            else None
-        )
-
-        async def push() -> None:
-            if prefetch is not None and logical_path not in self._checkpoint_slots:
-                assert logical_path is not None and source_path is not None
-                await self._load_checkpoint_path(
-                    logical_path, source_path=source_path, prefetch=prefetch
-                )
-            self._slot_stack.append(self._slot_ref(logical_path))
-
-        return self._checkpoint_mutation_task(push)
+    def _push_checkpoint(self, checkpoint: str | MaterializedCheckpoint | None) -> None:
+        logical, source = self._checkpoint_source(checkpoint)
+        self._push_checkpoint_sync(logical, source)
 
     def _push_checkpoint_sync(
         self, logical_path: str | None, source_path: str | None
     ) -> None:
-        predecessor = self._checkpoint_mutation_tail
-        if predecessor is not None:
-            if not predecessor.done():
-                raise RuntimeError(
-                    "A checkpoint mutation is running asynchronously; use 'async with'"
-                )
-            if not predecessor.cancelled():
-                predecessor.exception()
-        if source_path is not None and logical_path not in self._checkpoint_slots:
-            assert logical_path is not None
-            from . import _checkpoint
-
-            source = _checkpoint.prepare_checkpoint(source_path)
-            _checkpoint.load_checkpoint(self, source, logical_path)
-        self._slot_stack.append(self._slot_ref(logical_path))
-
-    def _checkpoint_mutation_task(
-        self, operation: Callable[[], Awaitable[None]]
-    ) -> asyncio.Task[None]:
-        predecessor = self._checkpoint_mutation_tail
-
-        async def ordered() -> None:
-            if predecessor is not None:
-                try:
-                    await asyncio.shield(predecessor)
-                except asyncio.CancelledError:
-                    current = asyncio.current_task()
-                    if current is not None and current.cancelling():
-                        raise
-                except Exception:
-                    pass
-            await operation()
-
-        task = asyncio.create_task(ordered())
-        self._checkpoint_mutation_tail = task
-        return task
+        with self._checkpoint_mutation_lock:
+            if source_path is not None:
+                assert logical_path is not None
+                if (
+                    logical_path not in self._checkpoint_slots
+                    and logical_path not in self._checkpoint_prefetch_sources
+                ):
+                    self._register_checkpoint_prefetch(logical_path, source_path)
+                self._ensure_checkpoint_slots((logical_path,))
+            self._slot_stack.append(self._slot_ref(logical_path))
 
     def pop_checkpoint(self) -> None:
-        if not self._slot_stack:
-            raise RuntimeError("No pushed checkpoint to pop")
-        self._slot_stack.pop()
+        with self._checkpoint_mutation_lock:
+            if not self._slot_stack:
+                raise RuntimeError("No pushed checkpoint to pop")
+            self._slot_stack.pop()
 
     def save_checkpoint(
         self,
@@ -1332,46 +1424,9 @@ class TrainerRank:
             return checkpoint.path, checkpoint.directory
         return checkpoint, checkpoint
 
-    async def _prefetch_checkpoint(self, source_path: str) -> PreparedCheckpoint:
-        key = self._checkpoint_source_key(source_path)
-        task = self._checkpoint_prefetches.get(key)
-        if task is None:
-            from ._checkpoint import prepare_checkpoint
-
-            task = self._checkpoint_prefetches[key] = asyncio.create_task(
-                asyncio.to_thread(prepare_checkpoint, key)
-            )
-        try:
-            return await asyncio.shield(task)
-        except BaseException:
-            if task.done():
-                self._checkpoint_prefetches.pop(key, None)
-            raise
-
-    async def _load_checkpoint_path(
-        self,
-        logical_path: str,
-        *,
-        source_path: str,
-        prefetch: asyncio.Task[PreparedCheckpoint],
-    ) -> None:
-        from . import _checkpoint
-
-        key = self._checkpoint_source_key(source_path)
-        source: PreparedCheckpoint | None = None
-        error: BaseException | None = None
-        try:
-            source = await asyncio.shield(prefetch)
-        except BaseException as exc:
-            error = exc
-        group = _checkpoint._ensure_group(self)
-        _checkpoint.raise_distributed(error, "prepare checkpoint", group)
-        assert source is not None
-        _checkpoint.load_checkpoint(self, source, logical_path)
-        self._checkpoint_prefetches.pop(key, None)
-
     def _resolve_checkpoint_name(self, checkpoint_path: str | Literal["active"]) -> str:
         if checkpoint_path != "active":
+            self._ensure_checkpoint_slots((checkpoint_path,))
             return checkpoint_path
         ref = self._slot_stack[-1] if self._slot_stack else self._default_slot_ref
         if ref is None or ref.name is None:
@@ -1573,12 +1628,12 @@ class TrainerRank:
     ) -> Iterator[MicroBatch[ForwardInputs, ForwardOutputs]]:
         items = [_materialize(item) for item in inputs]
         requests = list(_flatten(items))
+        self._validate_replicated_top_level_count(len(items))
         for _, indices in self._group_active_request_indices(
             requests, checkpoint=checkpoint
         ):
             for index in indices:
                 self._forward_item(requests[index])
-        self._validate_replicated_top_level_count(len(items))
         start = 0
         while start < len(items):
             with _telemetry_phase(
@@ -1944,6 +1999,8 @@ class TrainerRank:
         self,
         checkpoints: Sequence[str] | None,
     ) -> tuple[str, ...]:
+        if checkpoints is not None:
+            self._ensure_checkpoint_slots(checkpoints)
         loaded = set(self._checkpoint_slots)
         if not loaded:
             raise TrainerRankSlotStateError(
@@ -1963,6 +2020,13 @@ class TrainerRank:
             )
         if unknown := set(requested) - loaded:
             raise ValueError(f"Unknown checkpoint slots: {sorted(unknown)}")
+        if snapshots := [
+            name for name in requested if self._checkpoint_slots[name].snapshot
+        ]:
+            raise TrainerRankSlotStateError(
+                "Snapshot checkpoints are forward-only and cannot be stepped: "
+                f"{snapshots}"
+            )
         flags = self._checkpoint_grad_flags(requested)
         selected = tuple(
             name for name, has_grad in zip(requested, flags, strict=True) if has_grad
@@ -2541,7 +2605,7 @@ class TrainerRank:
         output_bytes = self._estimate_group_request_output_bytes(requests)
         logical_tokens = sum(int(request.input_tokens.numel()) for request in requests)
         groups = self._group_active_request_indices(requests, checkpoint=checkpoint)
-        for slot_ref, group_indices in groups:
+        for (slot_ref, grad_enabled), group_indices in groups:
             items = tuple(
                 self._forward_item(requests[index]) for index in group_indices
             )
@@ -2552,6 +2616,7 @@ class TrainerRank:
             plans.append(
                 _ForwardGroupPlan(
                     slot_ref=slot_ref,
+                    grad_enabled=grad_enabled,
                     request_indices=tuple(group_indices),
                     items=items,
                     packed=packed,
@@ -2560,6 +2625,10 @@ class TrainerRank:
 
         return _FlatForwardPlan(
             request_count=len(requests),
+            output_metadata=tuple(
+                self._forward_output_metadata(request, checkpoint=checkpoint)
+                for request in requests
+            ),
             groups=tuple(plans),
             packed_tokens=sum(int(plan.packed.tokens.numel()) for plan in plans),
             logical_tokens=logical_tokens,
@@ -2567,6 +2636,7 @@ class TrainerRank:
             signature=self._memory_signature_from_requests(
                 requests,
                 slot_group_count=len(plans),
+                grad_modes=tuple(mode for (_, mode), _ in groups),
             ),
         )
 
@@ -2593,6 +2663,7 @@ class TrainerRank:
             self._memory_signature_from_requests(
                 requests,
                 slot_group_count=len(groups),
+                grad_modes=tuple(mode for (_, mode), _ in groups),
             ),
         )
 
@@ -2601,8 +2672,27 @@ class TrainerRank:
         requests: Sequence[AnyForwardInput],
         *,
         checkpoint: AdapterSelection = Unset,
-    ) -> tuple[tuple["LoRASlotRef | None", tuple[int, ...]], ...]:
-        groups: dict[LoRASlotRef | None, list[int]] = {}
+    ) -> tuple[tuple[tuple["LoRASlotRef | None", bool], tuple[int, ...]], ...]:
+        self._ensure_checkpoint_slots(
+            cast(str, selection)
+            for request in requests
+            if (
+                request.target_tokens is not None
+                or request.logits
+                or request.top_k is not None
+                or request.hidden_states
+            )
+            if (
+                selection := (
+                    request.checkpoint
+                    if request.checkpoint is not Unset
+                    else checkpoint
+                )
+            )
+            is not Unset
+            and selection is not None
+        )
+        groups: dict[tuple[LoRASlotRef | None, bool], list[int]] = {}
         for index, request in enumerate(requests):
             if (
                 request.target_tokens is not None
@@ -2611,7 +2701,15 @@ class TrainerRank:
                 or request.hidden_states
             ):
                 groups.setdefault(
-                    self._resolve_slot_ref(request, checkpoint=checkpoint), []
+                    (
+                        self._resolve_slot_ref(request, checkpoint=checkpoint),
+                        (
+                            torch.is_grad_enabled()
+                            if request.no_grad is None
+                            else not request.no_grad
+                        ),
+                    ),
+                    [],
                 ).append(index)
         return tuple((slot_ref, tuple(indices)) for slot_ref, indices in groups.items())
 
@@ -2665,6 +2763,7 @@ class TrainerRank:
             "slot_group_count": plan.signature.slot_group_count,
             "request_mix": plan.signature.request_mix,
             "grad_enabled": plan.signature.grad_enabled,
+            "grad_modes": plan.signature.grad_modes,
         }
 
     @classmethod
@@ -2684,7 +2783,8 @@ class TrainerRank:
 
     def _execute_flat_plan(self, plan: _FlatForwardPlan) -> list[AnyForwardOutput]:
         outputs = [
-            ForwardOutput(None, None, None, None) for _ in range(plan.request_count)
+            ForwardOutput(None, None, None, None, checkpoint, no_grad)
+            for checkpoint, no_grad in plan.output_metadata
         ]
         self._validate_hybridep_topology()
         hybridep = (
@@ -2700,12 +2800,23 @@ class TrainerRank:
 
                 if hybridep is not None:
                     self._set_hybridep_rows(hybridep[0][group_index])
-                with use_lora_slot(group.slot_ref):
-                    prepared = self._prepare_packed_forward(group.packed)
-                    item_outputs = self._forward_packed(group.items, prepared)
-                item_outputs = self._track_slot_graph_outputs(
-                    group.slot_ref, item_outputs
-                )
+                with torch.set_grad_enabled(group.grad_enabled):
+                    with use_lora_slot(group.slot_ref):
+                        prepared = self._prepare_packed_forward(group.packed)
+                        item_outputs = self._forward_packed(group.items, prepared)
+                    item_outputs = [
+                        replace(
+                            output,
+                            checkpoint=(
+                                None if group.slot_ref is None else group.slot_ref.name
+                            ),
+                            no_grad=not group.grad_enabled,
+                        )
+                        for output in item_outputs
+                    ]
+                    item_outputs = self._track_slot_graph_outputs(
+                        group.slot_ref, item_outputs
+                    )
                 for index, output in zip(
                     group.request_indices, item_outputs, strict=True
                 ):
@@ -2748,6 +2859,8 @@ class TrainerRank:
                 ),
                 logits=track(output.logits),
                 hidden_states=track(output.hidden_states),
+                checkpoint=output.checkpoint,
+                no_grad=output.no_grad,
             )
             for output in outputs
         ]
@@ -2758,6 +2871,25 @@ class TrainerRank:
             if track_hybridep:
                 self._hybridep_graphs().append(marker_ref)
         return tracked_outputs
+
+    def _forward_output_metadata(
+        self,
+        request: AnyForwardInput,
+        *,
+        checkpoint: AdapterSelection,
+    ) -> tuple[str | None, bool]:
+        selection = (
+            request.checkpoint if request.checkpoint is not Unset else checkpoint
+        )
+        if selection is Unset:
+            ref = self._slot_stack[-1] if self._slot_stack else self._default_slot_ref
+            name = None if ref is None else ref.name
+        else:
+            name = cast(str | None, selection)
+        enabled = (
+            torch.is_grad_enabled() if request.no_grad is None else not request.no_grad
+        )
+        return name, not enabled
 
     def _hybridep_graphs(self) -> list[weakref.ReferenceType[torch.Tensor]]:
         graphs = getattr(self, "_pending_hybridep_graphs", None)
@@ -2800,6 +2932,10 @@ class TrainerRank:
 
     def _guard_slot_can_load(self, ref: "LoRASlotRef") -> None:
         slot = None if ref.name is None else self._checkpoint_slots.get(ref.name)
+        if slot is not None and slot.snapshot:
+            raise TrainerRankSlotStateError(
+                f"Cannot load over forward-only snapshot checkpoint {ref.name!r}"
+            )
         if slot is not None and any(param.grad is not None for param in slot.params):
             raise TrainerRankSlotStateError(
                 f"Cannot load checkpoint {ref.name!r} while it has accumulated "
@@ -2881,7 +3017,9 @@ class TrainerRank:
         requests: Sequence[AnyForwardInput],
         *,
         slot_group_count: int,
+        grad_modes: Iterable[bool],
     ) -> _MemorySignature:
+        modes = tuple(sorted(grad_modes))
         return _MemorySignature(
             topology=self._topology_key(),
             shared_prefix_max_depth=self.shared_prefix_max_depth,
@@ -2889,7 +3027,8 @@ class TrainerRank:
             request_mix=tuple(
                 sorted({_request_mix_key(request) for request in requests})
             ),
-            grad_enabled=torch.is_grad_enabled(),
+            grad_enabled=any(modes),
+            grad_modes=modes,
         )
 
     def _topology_key(self) -> tuple[int, int, int, int]:

--- a/tests/integration/megatron/lora/test_dynamic_lora_slots.py
+++ b/tests/integration/megatron/lora/test_dynamic_lora_slots.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import os
 from pathlib import Path
 import socket
+import threading
 from types import SimpleNamespace
 from typing import cast
 
@@ -609,7 +610,9 @@ def _trainer_for(lora: LoRA, device: torch.device) -> TrainerRank:
         for name in ("A", "B")
     }
     trainer._checkpoint_prefetches = {}
-    trainer._checkpoint_mutation_tail = None
+    trainer._checkpoint_prefetch_sources = {}
+    trainer._checkpoint_prefetch_lock = threading.Lock()
+    trainer._checkpoint_mutation_lock = threading.RLock()
     return trainer
 
 

--- a/tests/unit/test_trainer_rank_custom_tensors.py
+++ b/tests/unit/test_trainer_rank_custom_tensors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 import copy
 from dataclasses import dataclass
@@ -19,6 +20,7 @@ import torch.multiprocessing as mp
 
 from art.trainer_rank import (
     AdamParams,
+    MaterializedCheckpoint,
     TrainerRank,
     TrainerRankSlotStateError,
     Unset,
@@ -552,6 +554,65 @@ def test_custom_objects_clone_factory_storage_and_deepcopy_independently() -> No
     assert isinstance(restored(torch.ones(1)), _HeadOutput)
 
 
+def test_forward_snapshot_clones_custom_tensor_state() -> None:
+    trainer, rank = _trainer("student")
+    source_parameter = rank.parameter(
+        "temperature", lambda: torch.tensor([2.0]), checkpoint="student"
+    )
+    source_buffer = rank.buffer(
+        "offset", lambda: torch.tensor([3.0]), checkpoint="student"
+    )
+    source_head = rank.module("head", _DirectHead, checkpoint="student")
+
+    assert trainer.snapshot_checkpoint("student", "saved")
+    saved_parameter = rank.parameter(
+        "temperature", lambda: torch.zeros(1), checkpoint="saved"
+    )
+    saved_buffer = rank.buffer("offset", lambda: torch.zeros(1), checkpoint="saved")
+    saved_head = rank.module("head", _DirectHead, checkpoint="saved")
+    source_parameter.data.fill_(7)
+    source_buffer.fill_(8)
+    source_head.weight.data.fill_(9)
+
+    torch.testing.assert_close(saved_parameter, torch.tensor([2.0]))
+    torch.testing.assert_close(saved_buffer, torch.tensor([3.0]))
+    torch.testing.assert_close(saved_head.weight, torch.tensor([2.0]))
+    assert not saved_parameter.requires_grad
+    assert not saved_head.weight.requires_grad
+
+    trainer._discard_snapshot_checkpoint("saved")
+    with pytest.raises(TrainerRankSlotStateError, match="stale"):
+        saved_parameter + 1
+
+
+def test_forward_snapshot_copies_unmaterialized_custom_payload() -> None:
+    trainer, rank = _trainer("student")
+    trainer._checkpoint_slots["student"].custom_payload = PreparedCustomPayload(
+        {
+            "temperature": cast(
+                Any,
+                {
+                    "kind": "parameter",
+                    "tensor_keys": ["temperature"],
+                    "trainable_keys": ["temperature"],
+                    "parameter_aliases": [["temperature"]],
+                    "buffer_aliases": [],
+                    "persistent_buffer_keys": [],
+                },
+            )
+        },
+        {"temperature": torch.tensor([4.0])},
+        {},
+    )
+
+    assert trainer.snapshot_checkpoint("student", "saved")
+    trainer._checkpoint_slots["student"].custom_payload.tensors["temperature"].fill_(9)
+    saved = rank.parameter("temperature", lambda: torch.zeros(1), checkpoint="saved")
+
+    torch.testing.assert_close(saved, torch.tensor([4.0]))
+    assert not saved.requires_grad
+
+
 def test_no_grad_custom_objects_do_not_create_graph_guards() -> None:
     trainer, rank = _trainer("student")
     head = rank.module("head", _ClassFactoryHead, checkpoint="student")
@@ -939,6 +1000,46 @@ def test_loaded_custom_payload_is_owned_after_source_removal(
 
 
 @pytest.mark.skipif(find_spec("megatron") is None, reason="requires Megatron")
+def test_prepared_forward_snapshot_restores_frozen_custom_tensors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from art.trainer_rank import _checkpoint
+
+    original, original_api = _real_lora_trainer()
+    original_head, original_temperature, original_running = _register_custom_tensors(
+        original_api
+    )
+    original_running.fill_(7)
+    _step_custom_tensors(original, original_head, original_temperature, monkeypatch)
+    saved = tmp_path / "saved"
+    original.save_checkpoint(str(saved), "student")
+
+    restored, api = _empty_real_lora_trainer()
+    assert _checkpoint.snapshot_prepared_checkpoint(
+        restored, prepare_checkpoint(str(saved)), "snapshot"
+    )
+    head = api.module("value_head", lambda: _ValueHead(3), checkpoint="snapshot")
+    temperature = api.parameter(
+        "temperature", lambda: torch.tensor(0.5), checkpoint="snapshot"
+    )
+    running = api.buffer("running_mean", lambda: torch.zeros(3), checkpoint="snapshot")
+
+    for expected, actual in zip(
+        original_head.parameters(), head.parameters(), strict=True
+    ):
+        torch.testing.assert_close(expected, actual)
+    torch.testing.assert_close(original_temperature, temperature)
+    torch.testing.assert_close(original_running, running)
+    assert not temperature.requires_grad
+    assert all(not parameter.requires_grad for parameter in head.parameters())
+    assert restored._checkpoint_slots["snapshot"].optimizer is None
+    with pytest.raises(TrainerRankSlotStateError, match="forward-only"):
+        restored.optim_step(
+            params=AdamParams(learning_rate=1e-3), checkpoints=["snapshot"]
+        )
+
+
+@pytest.mark.skipif(find_spec("megatron") is None, reason="requires Megatron")
 def test_custom_tensors_and_optimizer_restore_lazily_and_survive_unmaterialized_save(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -956,7 +1057,13 @@ def test_custom_tensors_and_optimizer_restore_lazily_and_survive_unmaterialized_
     original.save_checkpoint(str(saved), "student")
 
     restored, restored_api = _empty_real_lora_trainer()
-    _checkpoint.load_checkpoint(restored, prepare_checkpoint(str(saved)), "student")
+
+    async def prefetch() -> None:
+        await restored.prefetch_checkpoints(
+            MaterializedCheckpoint("student", str(saved))
+        )
+
+    asyncio.run(prefetch())
 
     resaved = tmp_path / "resaved-before-registration"
     restored.save_checkpoint(str(resaved), "student")

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -47,9 +47,11 @@ from art.trainer_rank._checkpoint import (
     _validate_save_state,
     abort_checkpoint_save,
     finish_checkpoint_save,
+    materialize_checkpoint,
     materialize_lora,
     prepare_checkpoint,
     prepare_checkpoint_save,
+    snapshot_prepared_checkpoint,
     validate_checkpoint,
 )
 from art.trainer_rank._impl import (
@@ -364,6 +366,88 @@ def test_dp_rank_forward_grad_mode(
     assert seen == [expected]
 
 
+@pytest.mark.parametrize("api", ("dp_rank_forward", "forward_micro_batches"))
+def test_forward_input_overrides_grad_mode_by_group(
+    monkeypatch: pytest.MonkeyPatch,
+    api: str,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    seen: list[bool] = []
+
+    def execute(plan: object, **_kwargs: object) -> list[ForwardOutput]:
+        seen.extend(group.grad_enabled for group in cast(Any, plan).groups)
+        return _empty_outputs(plan)
+
+    _stub_forward(monkeypatch, trainer, execute, profiled=True)
+    inputs = [
+        ForwardInput(
+            input_tokens=torch.tensor([token, token + 1]),
+            target_tokens=torch.tensor([token, token + 1]),
+            no_grad=no_grad,
+        )
+        for token, no_grad in ((1, True), (2, False))
+    ]
+    if api == "dp_rank_forward":
+        trainer.dp_rank_forward(inputs)
+    else:
+        list(trainer.forward_micro_batches(inputs))
+
+    assert seen == [False, True]
+
+
+def test_forward_groups_execute_in_their_selected_grad_modes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    seen: list[bool] = []
+    groups = tuple(
+        SimpleNamespace(
+            slot_ref=_slot_ref(checkpoint),
+            grad_enabled=enabled,
+            packed=None,
+            items=(None,),
+            request_indices=(index,),
+        )
+        for index, (checkpoint, enabled) in enumerate(
+            (("teacher", False), ("student", True))
+        )
+    )
+    plan = SimpleNamespace(
+        request_count=2,
+        output_metadata=(("teacher", True), ("student", False)),
+        groups=groups,
+    )
+
+    monkeypatch.setattr(trainer, "_validate_hybridep_topology", lambda: None)
+    monkeypatch.setattr(trainer, "_topology", lambda: object())
+    monkeypatch.setattr(trainer, "_configure_hybridep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(trainer, "_prepare_packed_forward", lambda _packed: None)
+
+    class UseLoRASlot:
+        def __enter__(self) -> None:
+            pass
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+    lora = ModuleType("art.megatron.lora")
+    cast(Any, lora).use_lora_slot = lambda _slot: UseLoRASlot()
+    monkeypatch.setitem(sys.modules, "art.megatron.lora", lora)
+
+    def forward(_items: object, _prepared: object) -> list[ForwardOutput]:
+        seen.append(torch.is_grad_enabled())
+        return [ForwardOutput(None, None, None, None)]
+
+    monkeypatch.setattr(trainer, "_forward_packed", forward)
+    outputs = cast(Any, trainer)._execute_flat_plan(plan)
+
+    assert seen == [False, True]
+    assert [(output.checkpoint, output.no_grad) for output in outputs] == [
+        ("teacher", True),
+        ("student", False),
+    ]
+
+
 def test_forward_micro_batches_keeps_grad_mode_across_iteration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -573,24 +657,23 @@ def test_hybridep_rejects_buffer_growth_with_live_graph(
         )
 
 
-async def test_trainer_rank_checkpoint_stack_errors() -> None:
+def test_trainer_rank_checkpoint_stack_errors() -> None:
     trainer = TrainerRank(_runtime())
 
     with pytest.raises(RuntimeError, match="No pushed checkpoint"):
         trainer.pop_checkpoint()
     trainer._slot_stack.append(object())  # type: ignore
     with pytest.raises(RuntimeError, match="Cannot load a checkpoint"):
-        await trainer.load_checkpoint("teacher")
+        trainer.load_checkpoint("teacher")
 
 
-async def test_checkpoint_tasks_and_async_context(
+async def test_checkpoint_prefetch_and_sync_mutations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     trainer = TrainerRank(_runtime())
-    trainer._checkpoint_prefetches = {}
     fetched: list[str] = []
 
-    async def prefetch(path: str) -> object:
+    def prepare(path: str) -> object:
         fetched.append(path)
         return object()
 
@@ -598,34 +681,31 @@ async def test_checkpoint_tasks_and_async_context(
         trainer._checkpoint_slots.setdefault(path, _CheckpointSlot()).params = ()
         trainer._checkpoint_slots[path].revision = 0
 
-    monkeypatch.setattr(trainer, "_prefetch_checkpoint", prefetch)
+    monkeypatch.setattr("art.trainer_rank._checkpoint.prepare_checkpoint", prepare)
     monkeypatch.setattr("art.trainer_rank._checkpoint.load_checkpoint", install)
 
-    task = trainer.load_checkpoint("student")
-    assert isinstance(task, asyncio.Task)
-    await task
-    assert fetched == ["student"]
+    assert trainer.load_checkpoint("student") is None
+    assert fetched == [trainer._checkpoint_source_key("student")]
     assert trainer._default_slot_ref == trainer._slot_ref("student")
 
     task = trainer.prefetch_checkpoints("teacher", "reference")
     assert isinstance(task, asyncio.Task)
     await task
-    assert fetched[-2:] == ["teacher", "reference"]
+    assert fetched[-2:] == [
+        trainer._checkpoint_source_key("teacher"),
+        trainer._checkpoint_source_key("reference"),
+    ]
 
-    pushed = trainer.push_checkpoint("student")
-    await pushed
-    assert trainer._slot_stack == [trainer._slot_ref("student")]
-    trainer.pop_checkpoint()
-    async with trainer.push_checkpoint("student"):
+    with trainer.push_checkpoint("student"):
         assert trainer._slot_stack == [trainer._slot_ref("student")]
-        async with trainer.push_checkpoint("missing"):
+        with trainer.push_checkpoint("missing"):
             assert trainer._slot_stack == [
                 trainer._slot_ref("student"),
                 trainer._slot_ref("missing"),
             ]
         assert trainer._slot_stack == [trainer._slot_ref("student")]
     assert trainer._slot_stack == []
-    assert fetched[-1] == "missing"
+    assert fetched[-1] == trainer._checkpoint_source_key("missing")
 
 
 def test_checkpoint_sync_context_and_body_error_preservation(
@@ -652,69 +732,13 @@ def test_checkpoint_sync_context_and_body_error_preservation(
     }
 
 
-async def test_checkpoint_context_cancellation_after_successful_push_cleans_stack(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    trainer = TrainerRank(_runtime())
-    trainer._checkpoint_slots.setdefault("student", _CheckpointSlot()).params = ()
-    parent = asyncio.current_task()
-    assert parent is not None
-    original_slot_ref = trainer._slot_ref
-    cancellation_scheduled = False
-
-    def cancel_parent_after_resolving(path: str | None):
-        nonlocal cancellation_scheduled
-        ref = original_slot_ref(path)
-        if not cancellation_scheduled:
-            cancellation_scheduled = True
-            asyncio.get_running_loop().call_soon(parent.cancel)
-        return ref
-
-    monkeypatch.setattr(trainer, "_slot_ref", cancel_parent_after_resolving)
-    pushed = trainer.push_checkpoint("student")
-    entered = False
-
-    with pytest.raises(asyncio.CancelledError):
-        async with pushed:
-            entered = True
-
-    assert cancellation_scheduled
-    assert pushed._task is not None
-    assert pushed._task.done() and not pushed._task.cancelled()
-    assert not entered
-    assert trainer._slot_stack == []
-
-
-async def test_checkpoint_context_cancellation_while_push_is_pending_does_not_leak(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    trainer = TrainerRank(_runtime())
-    started = asyncio.Event()
-    release = asyncio.Event()
-
-    async def prefetch(_path: str) -> object:
-        started.set()
-        await release.wait()
-        return object()
-
-    monkeypatch.setattr(trainer, "_prefetch_checkpoint", prefetch)
-    pushed = trainer.push_checkpoint("student")
-    entering = asyncio.create_task(pushed.__aenter__())
-    await started.wait()
-    entering.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await entering
-    release.set()
-    await asyncio.sleep(0)
-
-    assert pushed._task is not None and pushed._task.cancelled()
-    assert trainer._slot_stack == []
-
-
 def test_pushed_checkpoint_cannot_be_reused() -> None:
     trainer = TrainerRank(_runtime())
     trainer._checkpoint_slots["student"] = _CheckpointSlot()
     pushed = trainer.push_checkpoint("student")
+    assert not isinstance(pushed, asyncio.Future)
+    assert not hasattr(pushed, "__await__")
+    assert not hasattr(pushed, "__aenter__")
 
     with pushed:
         pass
@@ -723,23 +747,174 @@ def test_pushed_checkpoint_cannot_be_reused() -> None:
             pass
 
 
-async def test_shared_checkpoint_prefetch_survives_waiter_cancellation(
+def test_snapshot_disposal_is_not_public() -> None:
+    assert not hasattr(TrainerRank, "discard_snapshot_checkpoint")
+
+
+@pytest.mark.parametrize(
+    "consumer",
+    (
+        "module",
+        "parameter",
+        "buffer",
+        "forward",
+        "forward_micro_batches",
+        "optim_step",
+        "save",
+        "export_lora",
+        "snapshot",
+    ),
+)
+def test_explicit_consumers_activate_prefetched_checkpoint(
+    consumer: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    trainer = TrainerRank(_runtime())
+    installed: list[str] = []
+
+    def install(target: TrainerRank, _source: object, name: str) -> None:
+        installed.append(name)
+        target._checkpoint_slots[name] = _CheckpointSlot()
+
+    trainer._register_checkpoint_prefetch(
+        "student", "student", lambda: cast(PreparedCheckpoint, object())
+    )
+    monkeypatch.setattr("art.trainer_rank._checkpoint.load_checkpoint", install)
+
+    if consumer == "module":
+        trainer.module("head", lambda: torch.nn.Linear(1, 1), checkpoint="student")
+    elif consumer == "parameter":
+        trainer.parameter("bias", lambda: torch.ones(1), checkpoint="student")
+    elif consumer == "buffer":
+        trainer.buffer("mean", lambda: torch.zeros(1), checkpoint="student")
+    elif consumer == "forward":
+        _stub_forward(monkeypatch, trainer)
+        trainer.dp_rank_forward([_target_request(1)], checkpoint="student")
+    elif consumer == "forward_micro_batches":
+        _stub_forward(monkeypatch, trainer, profiled=True)
+        list(trainer.forward_micro_batches([_target_request(1)], checkpoint="student"))
+    elif consumer == "optim_step":
+        with pytest.raises(TrainerRankSlotStateError, match="no gradients"):
+            trainer.optim_step(
+                checkpoints=["student"], params=AdamParams(learning_rate=1e-3)
+            )
+    elif consumer == "save":
+        monkeypatch.setattr(
+            "art.trainer_rank._checkpoint.prepare_checkpoint_save",
+            lambda *_args: None,
+        )
+        trainer.prepare_checkpoint_save(str(tmp_path), "student")
+    elif consumer == "export_lora":
+        monkeypatch.setattr(
+            "art.trainer_rank._lora_export.export_lora", lambda *_args: 1
+        )
+        assert trainer.export_lora(str(tmp_path), "student") == 1
+    else:
+        monkeypatch.setattr(
+            "art.trainer_rank._checkpoint.snapshot_checkpoint",
+            lambda *_args: True,
+        )
+        assert trainer.snapshot_checkpoint("student", "saved")
+
+    assert installed == ["student"]
+    assert trainer._default_slot_ref is None
+
+
+def test_implicit_optim_step_does_not_activate_prefetched_checkpoints() -> None:
+    trainer = TrainerRank(_runtime())
+    future = trainer._register_checkpoint_prefetch(
+        "student", "student", lambda: cast(PreparedCheckpoint, object())
+    )
+    future.result()
+
+    with pytest.raises(TrainerRankSlotStateError, match="requires a loaded checkpoint"):
+        trainer.optim_step(params=AdamParams(learning_rate=1e-3))
+
+    assert "student" not in trainer._checkpoint_slots
+    assert "student" in trainer._checkpoint_prefetch_sources
+
+
+def test_collective_activation_loads_required_union_deterministically(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     trainer = TrainerRank(_runtime())
-    started = asyncio.Event()
-    release = asyncio.Event()
-    source = object()
+    loaded: list[str] = []
+    for name in ("a", "b"):
+        trainer._register_checkpoint_prefetch(
+            name, name, lambda: cast(PreparedCheckpoint, object())
+        ).result()
 
-    async def delayed_to_thread(_function: object, *_args: object) -> object:
+    def gather(value: object, _group: object = None) -> tuple[object, ...]:
+        if isinstance(value, tuple) and value and isinstance(value[0], str):
+            return (("b",), ("a",))
+        return (value, value)
+
+    def install(target: TrainerRank, _source: object, name: str) -> None:
+        loaded.append(name)
+        target._checkpoint_slots[name] = _CheckpointSlot()
+
+    monkeypatch.setattr("art.trainer_rank._checkpoint._gather", gather)
+    monkeypatch.setattr("art.trainer_rank._checkpoint.load_checkpoint", install)
+
+    trainer._ensure_checkpoint_slots(("b",))
+
+    assert loaded == ["a", "b"]
+
+
+def test_concurrent_first_consumers_install_prefetched_slot_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    started = threading.Event()
+    release = threading.Event()
+    installed = 0
+    errors: list[BaseException] = []
+
+    def prepare() -> PreparedCheckpoint:
         started.set()
-        await release.wait()
+        assert release.wait(5)
+        return cast(PreparedCheckpoint, object())
+
+    def install(target: TrainerRank, _source: object, name: str) -> None:
+        nonlocal installed
+        installed += 1
+        target._checkpoint_slots[name] = _CheckpointSlot()
+
+    def consume() -> None:
+        try:
+            trainer._ensure_checkpoint_slots(("student",))
+        except BaseException as error:
+            errors.append(error)
+
+    trainer._register_checkpoint_prefetch("student", "student", prepare)
+    monkeypatch.setattr("art.trainer_rank._checkpoint.load_checkpoint", install)
+    first = threading.Thread(target=consume)
+    second = threading.Thread(target=consume)
+    first.start()
+    assert started.wait(5)
+    second.start()
+    release.set()
+    first.join()
+    second.join()
+
+    assert errors == []
+    assert installed == 1
+
+
+async def test_shared_checkpoint_prefetch_survives_waiter_cancellation() -> None:
+    trainer = TrainerRank(_runtime())
+    started = threading.Event()
+    release = threading.Event()
+    source = cast(PreparedCheckpoint, object())
+
+    def prepare() -> PreparedCheckpoint:
+        started.set()
+        release.wait()
         return source
 
-    monkeypatch.setattr(asyncio, "to_thread", delayed_to_thread)
-    first = asyncio.create_task(trainer._prefetch_checkpoint("student"))
-    second = asyncio.create_task(trainer._prefetch_checkpoint("student"))
-    await started.wait()
+    future = trainer._register_checkpoint_prefetch("student", "student", prepare)
+    first = asyncio.create_task(trainer._await_checkpoint_prefetch(future))
+    second = asyncio.create_task(trainer._await_checkpoint_prefetch(future))
+    await asyncio.to_thread(started.wait)
     first.cancel()
     with pytest.raises(asyncio.CancelledError):
         await first
@@ -750,27 +925,25 @@ async def test_shared_checkpoint_prefetch_survives_waiter_cancellation(
     assert cached.result() is source
 
 
-async def test_shared_checkpoint_prefetch_serves_successful_waiters(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_shared_checkpoint_prefetch_serves_successful_waiters() -> None:
     trainer = TrainerRank(_runtime())
-    started = asyncio.Event()
-    release = asyncio.Event()
-    source = object()
+    started = threading.Event()
+    release = threading.Event()
+    source = cast(PreparedCheckpoint, object())
     calls = 0
 
-    async def delayed_to_thread(_function: object, *_args: object) -> object:
+    def prepare() -> PreparedCheckpoint:
         nonlocal calls
         calls += 1
         started.set()
-        await release.wait()
+        release.wait()
         return source
 
-    monkeypatch.setattr(asyncio, "to_thread", delayed_to_thread)
-    first = asyncio.create_task(trainer._prefetch_checkpoint("student"))
-    second = asyncio.create_task(trainer._prefetch_checkpoint("student"))
-    await started.wait()
-    await asyncio.sleep(0)
+    first_future = trainer._register_checkpoint_prefetch("student", "shared", prepare)
+    second_future = trainer._register_checkpoint_prefetch("teacher", "shared", prepare)
+    first = asyncio.create_task(trainer._await_checkpoint_prefetch(first_future))
+    second = asyncio.create_task(trainer._await_checkpoint_prefetch(second_future))
+    await asyncio.to_thread(started.wait)
     release.set()
 
     assert await asyncio.gather(first, second) == [source, source]
@@ -805,14 +978,16 @@ async def test_materialized_sources_keep_logical_checkpoint_identities(
     logical_b = "wandb-artifact:///entity/project/run-teacher:step1"
     logical_c = "wandb-artifact:///entity/project/run-reference:step1"
 
-    await asyncio.gather(
-        trainer.load_checkpoint(MaterializedCheckpoint(logical_a, root_a)),
-        trainer.load_checkpoint(MaterializedCheckpoint(logical_b, root_a)),
+    await trainer.prefetch_checkpoints(
+        MaterializedCheckpoint(logical_a, root_a),
+        MaterializedCheckpoint(logical_b, root_a),
     )
+    trainer.load_checkpoint(MaterializedCheckpoint(logical_a, root_a))
+    trainer.load_checkpoint(MaterializedCheckpoint(logical_b, root_a))
     assert prepared == [trainer._checkpoint_source_key(root_a)]
 
     await trainer.prefetch_checkpoints(MaterializedCheckpoint(logical_c, root_b))
-    await trainer.load_checkpoint(MaterializedCheckpoint(logical_c, root_b))
+    trainer.load_checkpoint(MaterializedCheckpoint(logical_c, root_b))
     assert sorted(prepared) == sorted(
         (trainer._checkpoint_source_key(root_a), trainer._checkpoint_source_key(root_b))
     )
@@ -832,18 +1007,16 @@ async def test_materialized_sources_keep_logical_checkpoint_identities(
         assert trainer._resolve_slot_ref(request) == trainer._slot_ref(logical_path)
 
     refreshed_root = str(tmp_path / "immutable-new")
-    await trainer.load_checkpoint(MaterializedCheckpoint(logical_a, refreshed_root))
+    trainer.load_checkpoint(MaterializedCheckpoint(logical_a, refreshed_root))
     assert installed[-1][0] == logical_a
     assert prepared[-1] == trainer._checkpoint_source_key(refreshed_root)
 
     prepared_before_push = tuple(prepared)
-    pushed = trainer.push_checkpoint(
+    with trainer.push_checkpoint(
         MaterializedCheckpoint(logical_a, str(tmp_path / "unused-while-loaded"))
-    )
-    await pushed
-    assert tuple(prepared) == prepared_before_push
-    assert trainer._slot_stack == [trainer._slot_ref(logical_a)]
-    trainer.pop_checkpoint()
+    ):
+        assert tuple(prepared) == prepared_before_push
+        assert trainer._slot_stack == [trainer._slot_ref(logical_a)]
 
 
 async def test_prefetch_does_not_silently_ignore_empty_materialized_path(
@@ -852,29 +1025,22 @@ async def test_prefetch_does_not_silently_ignore_empty_materialized_path(
     trainer = TrainerRank(_runtime())
     seen: list[str] = []
 
-    async def prefetch(path: str) -> object:
+    def prepare(path: str) -> object:
         seen.append(path)
         return object()
 
-    monkeypatch.setattr(trainer, "_prefetch_checkpoint", prefetch)
+    monkeypatch.setattr("art.trainer_rank._checkpoint.prepare_checkpoint", prepare)
     await trainer.prefetch_checkpoints(MaterializedCheckpoint("logical", ""))
-    assert seen == [""]
+    assert seen == [trainer._checkpoint_source_key("")]
 
 
-async def test_checkpoint_mutations_follow_call_order_and_recover_from_failure(
+def test_checkpoint_mutations_are_synchronous_and_recover_from_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     trainer = TrainerRank(_runtime())
-    trainer._checkpoint_prefetches = {}
-    started = {name: asyncio.Event() for name in ("first", "second")}
-    ready = {name: asyncio.Event() for name in ("first", "second")}
     installed: list[str] = []
 
-    async def prefetch(path: str) -> object:
-        event = started.get(path)
-        if event is not None:
-            event.set()
-            await ready[path].wait()
+    def prepare(_path: str) -> object:
         return object()
 
     def install(trainer: TrainerRank, _source: object, path: str) -> None:
@@ -884,48 +1050,49 @@ async def test_checkpoint_mutations_follow_call_order_and_recover_from_failure(
         trainer._checkpoint_slots.setdefault(path, _CheckpointSlot()).params = ()
         trainer._checkpoint_slots[path].revision = 0
 
-    monkeypatch.setattr(trainer, "_prefetch_checkpoint", prefetch)
+    monkeypatch.setattr("art.trainer_rank._checkpoint.prepare_checkpoint", prepare)
     monkeypatch.setattr("art.trainer_rank._checkpoint.load_checkpoint", install)
-    first = trainer.load_checkpoint("first")
-    second = trainer.load_checkpoint("second")
-    await asyncio.gather(*(event.wait() for event in started.values()))
-    ready["second"].set()
-    await asyncio.sleep(0)
-    assert installed == []
-    ready["first"].set()
-    await asyncio.gather(first, second)
+    trainer.load_checkpoint("first")
+    trainer.load_checkpoint("second")
     assert installed == ["first", "second"]
 
-    bad = trainer.load_checkpoint("bad")
-    after = trainer.load_checkpoint("after")
     with pytest.raises(RuntimeError, match="injected load failure"):
-        await bad
-    await after
+        trainer.load_checkpoint("bad")
+    trainer.load_checkpoint("after")
     assert installed[-2:] == ["bad", "after"]
 
 
-@pytest.mark.parametrize("local_failure", [False, True])
-async def test_checkpoint_prefetch_failures_are_coordinated(
-    monkeypatch: pytest.MonkeyPatch, local_failure: bool
+def test_checkpoint_prefetch_failure_propagates_original_error(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     trainer = TrainerRank(_runtime())
 
-    async def prefetch(_path: str) -> object:
-        if local_failure:
-            raise OSError("rank-local prefetch failed")
-        return object()
+    def prepare(_path: str) -> object:
+        raise OSError("rank-local prefetch failed")
+
+    monkeypatch.setattr("art.trainer_rank._checkpoint.prepare_checkpoint", prepare)
+    with pytest.raises(OSError, match="rank-local prefetch failed"):
+        trainer.load_checkpoint("student")
+
+
+def test_remote_checkpoint_prefetch_failures_are_coordinated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
 
     def coordinated(
         error: BaseException | None, phase: str, _group: object | None = None
     ) -> None:
         assert phase == "prepare checkpoint"
-        assert isinstance(error, OSError) is local_failure
+        assert error is None
         raise RuntimeError("a rank failed to prepare checkpoint")
 
-    monkeypatch.setattr(trainer, "_prefetch_checkpoint", prefetch)
+    monkeypatch.setattr(
+        "art.trainer_rank._checkpoint.prepare_checkpoint", lambda _path: object()
+    )
     monkeypatch.setattr("art.trainer_rank._checkpoint.raise_distributed", coordinated)
     with pytest.raises(RuntimeError, match="a rank failed"):
-        await trainer.load_checkpoint("student")
+        trainer.load_checkpoint("student")
 
 
 def test_trainer_rank_rejects_adapter_keys_without_installed_lora_site() -> None:
@@ -1153,9 +1320,96 @@ def test_checkpoint_slot_snapshot_preserves_loaded_slot_refs(
     assert snapshot[0][3] == {"slot_0": ref}
 
 
+@pytest.mark.skipif(find_spec("megatron") is None, reason="requires Megatron")
+def test_forward_snapshot_is_independent_and_forward_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from art.megatron import lora as lora_module
+    from art.megatron.lora import LoRA, LoRASlotRef
+
+    monkeypatch.setattr(lora_module.ps, "get_expert_model_parallel_rank", lambda: 0)
+    lora = LoRA("layer", 3, 4, 2, 2, torch.float32, torch.device("cpu"))
+    trainer = TrainerRank(_runtime(lora))
+    source = LoRASlotRef("checkpoint", "student")
+    assert lora.load_lora_slot(
+        source,
+        {
+            "layer.lora_A.weight": torch.randn(2, 3),
+            "layer.lora_B.weight": torch.randn(4, 2),
+        },
+        alpha=2,
+        requires_grad=True,
+    )
+    trainer._checkpoint_slots["student"] = _CheckpointSlot(
+        tuple(lora.lora_slot_params(source)),
+        cast(
+            Any,
+            {
+                "base_model_name_or_path": "test/model",
+                "r": 2,
+                "lora_alpha": 2,
+                "target_modules": ["q_proj"],
+            },
+        ),
+    )
+
+    assert trainer.snapshot_checkpoint("student", "saved")
+    assert not trainer.snapshot_checkpoint("student", "saved")
+    saved = LoRASlotRef("checkpoint", "saved")
+    before = tuple(param.detach().clone() for param in lora.lora_slot_params(saved))
+    with torch.no_grad():
+        for param in lora.lora_slot_params(source):
+            param.add_(1)
+    assert all(
+        torch.equal(expected, actual)
+        for expected, actual in zip(before, lora.lora_slot_params(saved), strict=True)
+    )
+    assert all(not param.requires_grad for param in lora.lora_slot_params(saved))
+    request = ForwardInput(
+        input_tokens=torch.tensor([1]),
+        target_tokens=torch.tensor([1]),
+        checkpoint="saved",
+    )
+    assert trainer._resolve_slot_ref(request) == saved
+    with pytest.raises(TrainerRankSlotStateError, match="forward-only"):
+        trainer.optim_step(params=AdamParams(learning_rate=1e-3), checkpoints=["saved"])
+    with pytest.raises(TrainerRankSlotStateError, match="load over forward-only"):
+        trainer._guard_slot_can_load(saved)
+
+    trainer._discard_snapshot_checkpoint("saved")
+    assert "saved" not in trainer._checkpoint_slots
+    assert lora._slot(saved) is None
+
+
+def test_prepared_snapshot_loads_forward_only_without_replacing_slots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    source = cast(Any, object())
+    calls: list[tuple[object, str, bool]] = []
+
+    def load(
+        target: TrainerRank,
+        prepared: object,
+        destination: str,
+        *,
+        forward_only: bool = False,
+    ) -> None:
+        calls.append((prepared, destination, forward_only))
+        target._checkpoint_slots[destination] = _CheckpointSlot(snapshot=forward_only)
+
+    monkeypatch.setattr("art.trainer_rank._checkpoint.load_checkpoint", load)
+    assert snapshot_prepared_checkpoint(trainer, source, "saved")
+    assert calls == [(source, "saved", True)]
+    assert not snapshot_prepared_checkpoint(trainer, source, "saved")
+    trainer._checkpoint_slots["loaded"] = _CheckpointSlot()
+    with pytest.raises(TrainerRankSlotStateError, match="already loaded"):
+        snapshot_prepared_checkpoint(trainer, source, "loaded")
+
+
 def test_checkpoint_export_requires_retained_adapter_config() -> None:
     trainer = TrainerRank(_runtime())
-    with pytest.raises(ValueError, match="Unknown checkpoint"):
+    with pytest.raises(TrainerRankSlotStateError, match="unloaded checkpoint"):
         trainer.export_lora("/unused", "missing")
 
     trainer._checkpoint_slots.setdefault("student", _CheckpointSlot()).params = ()
@@ -1296,6 +1550,15 @@ def test_weights_only_checkpoint_validation_is_canonical(tmp_path: Path) -> None
     assert validate_checkpoint(root) == manifest
     with pytest.raises(RuntimeError, match="does not contain optimizer state"):
         validate_checkpoint(root, require_optimizer=True)
+
+
+def test_materialize_checkpoint_preserves_validated_state(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    manifest = _canonical_checkpoint(source)
+    output = tmp_path / "output"
+
+    assert materialize_checkpoint(source, output) == manifest["digest"]
+    assert validate_checkpoint(output) == manifest
 
 
 def test_weights_only_load_replaces_stale_optimizer_and_recreates_it_lazily(
@@ -2585,15 +2848,20 @@ def test_optim_step_live_graph_error_is_collective(tmp_path: Path) -> None:
 
 def test_dp_rank_forward_preserves_nested_shape_for_inactive_requests() -> None:
     trainer = TrainerRank(_runtime())
+    trainer._default_slot_ref = _slot_ref("teacher")
     request_a = ForwardInput(input_tokens=torch.tensor([1]))
     request_b = ForwardInput(input_tokens=torch.tensor([2]))
 
-    outputs = trainer.dp_rank_forward([[request_a], [request_b]])
+    outputs = trainer.dp_rank_forward([[request_a], [request_b]], no_grad=True)
 
     assert len(outputs) == 2
     assert len(outputs[0]) == 1
     assert outputs[0][0].target_logprobs is None
     assert outputs[1][0].target_logprobs is None
+    assert outputs[0][0].checkpoint == "teacher"
+    assert outputs[1][0].checkpoint == "teacher"
+    assert outputs[0][0].no_grad
+    assert outputs[1][0].no_grad
     assert not hasattr(trainer, "forward")
     assert not hasattr(trainer, "micro_batches")
 

--- a/tests/unit/test_trainer_rank_weird_shapes.py
+++ b/tests/unit/test_trainer_rank_weird_shapes.py
@@ -392,6 +392,8 @@ def test_adaptive_planner_probes_new_heterogeneous_signatures(
         "_resolve_slot_ref",
         lambda request, **_kwargs: request.checkpoint,
     )
+    for index in range(4):
+        rank._checkpoint_slots.setdefault(f"S{index}", _CheckpointSlot()).params = ()
     inputs = [
         _target_request(_tokens(index), checkpoint=f"S{index % 4}")
         for index in range(16)
@@ -487,11 +489,19 @@ def test_forward_micro_batches_shrinks_when_memory_budget_drops(
 def test_heterogeneous_slots_split_packing_without_losing_output_estimates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    class SlotRef(str):
+        @property
+        def name(self) -> str:
+            return str(self)
+
+    def slot_ref(name: str | None) -> SlotRef | None:
+        return None if name is None else SlotRef(name)
+
     rank = TrainerRank(_runtime(), shared_prefix_max_depth=4)
     monkeypatch.setattr(
         TrainerRank,
         "_slot_ref",
-        staticmethod(lambda name: name),
+        staticmethod(slot_ref),
     )
     rank._default_slot_ref = rank._slot_ref("student")
     for name in ("student", "teacher", "critic"):


### PR DESCRIPTION
## Summary

- make rank-local checkpoint loading and pushed contexts synchronous while retaining explicit background prefetching
- transparently activate explicitly selected prefetched checkpoints across forward, optimization, save, export, and custom-object APIs
- add forward-only resident checkpoint snapshots, including custom tensors, with private lifecycle cleanup
- support per-input `no_grad` execution and expose resolved `checkpoint` / `no_grad` metadata on every `ForwardOutput`
- coalesce checkpoint preparation with cancellation-safe shared futures and deterministic distributed activation

## Validation

- `uv run ruff check` on all changed files
- `uv run ruff format --check` on all changed files
- `uv run ty check` on changed TrainerRank source
- full Torch/Megatron and distributed coverage delegated to repository CI because the local lightweight ART environment does not include PyTorch

## Dependency

This is the prerequisite for the paired Caladan runtime/dynamics PR.