### PR TITLE
Ignore forward snapshots in implicit optimizer steps

### DIFF
--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -2009,11 +2009,21 @@ class TrainerRank:
                 "that slot before stepping."
             )
         requested = (
-            tuple(sorted(loaded))
+            tuple(
+                sorted(
+                    name for name in loaded if not self._checkpoint_slots[name].snapshot
+                )
+            )
             if checkpoints is None
             else tuple(dict.fromkeys(checkpoints))
         )
         if not requested:
+            if checkpoints is None:
+                raise TrainerRankSlotStateError(
+                    "TrainerRank.optim_step requires a loaded trainable checkpoint "
+                    "slot. Call load_checkpoint(...) and run backward on outputs "
+                    "produced by that slot before stepping."
+                )
             raise TrainerRankSlotStateError(
                 "TrainerRank.optim_step(checkpoints=...) received no checkpoint "
                 "names. Pass at least one loaded checkpoint slot."

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -2463,6 +2463,48 @@ def test_optim_step_implicitly_steps_only_slots_with_grads(
     torch.testing.assert_close(untouched, before_untouched)
 
 
+def test_optim_step_implicitly_ignores_resident_forward_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    student = torch.nn.Parameter(torch.ones(2))
+    student.grad = torch.ones_like(student)
+    snapshot = torch.nn.Parameter(torch.full((2,), 2.0), requires_grad=False)
+    trainer._checkpoint_slots["student"] = _CheckpointSlot(params=(student,))
+    trainer._checkpoint_slots["saved"] = _CheckpointSlot(
+        params=(snapshot,), snapshot=True
+    )
+    monkeypatch.setattr(trainer, "_slot_ref", _slot_ref)
+    trainer._set_default_slot(_slot_ref("student"))
+    _stub_forward(monkeypatch, trainer, profiled=True)
+    list(
+        trainer.forward_micro_batches(
+            [_target_request(1)], checkpoint="saved", no_grad=True
+        )
+    )
+    monkeypatch.setattr(
+        trainer,
+        "_reduce_dynamic_grads",
+        lambda params, **_kwargs: tuple(param.grad.float() for param in params),
+    )
+
+    before_student = student.detach().clone()
+    before_snapshot = snapshot.detach().clone()
+    trainer.optim_step(
+        params=AdamParams(learning_rate=1e-2, weight_decay=0.0, grad_clip_norm=10.0)
+    )
+
+    assert not torch.equal(before_student, student)
+    torch.testing.assert_close(snapshot, before_snapshot)
+    assert trainer._checkpoint_slots["saved"].optimizer is None
+    assert trainer._default_slot_ref == _slot_ref("student")
+    with pytest.raises(TrainerRankSlotStateError, match="forward-only"):
+        trainer.optim_step(params=AdamParams(learning_rate=1e-2), checkpoints=["saved"])
+    del trainer._checkpoint_slots["student"]
+    with pytest.raises(TrainerRankSlotStateError, match="trainable checkpoint"):
+        trainer.optim_step(params=AdamParams(learning_rate=1e-2))
+
+
 def test_dynamic_optimizer_zeroes_internal_padding_grads_before_step(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- exclude resident forward-only snapshots from implicit `TrainerRank.optim_step()` selection
- preserve strict errors when callers explicitly request a snapshot
- keep the previously active mutable checkpoint selected across no-grad snapshot validation

## Failure

The extended 047 dynamics run trained through step 64, then loaded its saved checkpoint for validation. Step 65 failed with `TrainerRankSlotStateError: Snapshot checkpoints are forward-only and cannot be stepped` because implicit optimizer selection enumerated every resident slot before filtering for gradients.

Run evidence: https://wandb.ai/wandb/047-dynamics-smoke-experiments-dynamics/runs/047-adversarial-dynamics-bmQwen-Qwen3.5-4B-r32-ttmapping-vtmapping-bonnie-4096-32-asof-20260821-v5-h589c3c6b530435c1

This was not a default-slot leak: snapshot validation leaves the mutable default selection unchanged. The forward-only snapshot legitimately remains resident and should not be an implicit optimizer candidate.

## Verification

- `tests/unit/test_trainer_rank_validation.py`: 132 passed
- focused snapshot/implicit-optimizer regression: 3 passed
- Ruff check and format
- Ty

`PipelineTrainer` is unchanged.