### PR TITLE
Use UTC-aware trajectory timestamps

### DIFF
--- a/src/art/trajectories/__init__.py
+++ b/src/art/trajectories/__init__.py
@@ -9,7 +9,7 @@ from collections.abc import (
     Mapping,
 )
 from contextlib import AbstractContextManager, asynccontextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import IntFlag
 import time
 from types import TracebackType
@@ -84,6 +84,13 @@ from ._serialization import (
 from ._serialization import (
     _intern_strings as _intern_string_graph,
 )
+
+
+def _utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
+_UtcDateTime = Annotated[datetime, pydantic.AfterValidator(_utc)]
 
 # Deliberately open: Pydantic enforces serializability when callers dump in JSON mode.
 MetadataValue = Any
@@ -226,11 +233,16 @@ class MessagesRequest(TypedDict, total=False, extra_items=Any):
     chat_template_kwargs: dict[str, Any]
 
 
-class ChatCompletionsExchange(pydantic.BaseModel):
+class _Exchange(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(validate_assignment=True)
+
+    start_time: _UtcDateTime
+    end_time: _UtcDateTime
+
+
+class ChatCompletionsExchange(_Exchange):
     request: _Preserved[ChatCompletionsRequest]
     response: ChatCompletion
-    start_time: datetime
-    end_time: datetime
 
     @pydantic.field_serializer("response", when_used="json")
     def serialize_response(self, response: ChatCompletion) -> dict[str, Any]:
@@ -243,11 +255,9 @@ class ChatCompletionsExchange(pydantic.BaseModel):
         return requested if isinstance(requested, str) else self.response.model
 
 
-class CompletionsExchange(pydantic.BaseModel):
+class CompletionsExchange(_Exchange):
     request: _Preserved[CompletionsRequest]
     response: Completion
-    start_time: datetime
-    end_time: datetime
 
     @pydantic.computed_field
     @property
@@ -256,11 +266,9 @@ class CompletionsExchange(pydantic.BaseModel):
         return requested if isinstance(requested, str) else self.response.model
 
 
-class ResponsesExchange(pydantic.BaseModel):
+class ResponsesExchange(_Exchange):
     request: _Preserved[ResponsesRequest]
     response: Response
-    start_time: datetime
-    end_time: datetime
 
     @pydantic.computed_field
     @property
@@ -269,11 +277,9 @@ class ResponsesExchange(pydantic.BaseModel):
         return requested if isinstance(requested, str) else self.response.model
 
 
-class MessagesExchange(pydantic.BaseModel):
+class MessagesExchange(_Exchange):
     request: _Preserved[MessagesRequest]
     response: AnthropicMessage
-    start_time: datetime
-    end_time: datetime
 
     @pydantic.computed_field
     @property
@@ -526,6 +532,8 @@ TrajectoryHistory: TypeAlias = (
 
 
 class Trajectory(_CompactModel):
+    model_config = pydantic.ConfigDict(validate_assignment=True)
+
     exchanges: TrajectoryExchanges = pydantic.Field(default_factory=TrajectoryExchanges)
     messages_and_choices: MessagesAndChoices = pydantic.Field(
         default_factory=list,
@@ -541,7 +549,9 @@ class Trajectory(_CompactModel):
     metrics: dict[str, float | int | bool] = pydantic.Field(default_factory=dict)
     metadata: dict[str, MetadataValue] = pydantic.Field(default_factory=dict)
     logs: list[str] = pydantic.Field(default_factory=list)
-    start_time: datetime = pydantic.Field(default_factory=datetime.now, exclude=True)
+    start_time: _UtcDateTime = pydantic.Field(
+        default_factory=lambda: datetime.now(UTC), exclude=True
+    )
     _policy_token_counts: dict[int, int] | None = pydantic.PrivateAttr(default=None)
 
     @pydantic.field_serializer("messages_and_choices", when_used="json")
@@ -586,7 +596,7 @@ class Trajectory(_CompactModel):
         self.logs.append(message)
 
     def finish(self) -> Trajectory:
-        self.metrics["duration"] = (datetime.now() - self.start_time).total_seconds()
+        self.metrics["duration"] = (datetime.now(UTC) - self.start_time).total_seconds()
         return self
 
     @asynccontextmanager

--- a/src/art/trajectories/_capture/core.py
+++ b/src/art/trajectories/_capture/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextvars
 from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 import json
 import logging
 from typing import Any, assert_never
@@ -66,7 +66,7 @@ class CaptureState:
     trajectory: Trajectory
     endpoint: Endpoint
     request: dict[str, Any]
-    start_time: datetime = field(default_factory=datetime.now)
+    start_time: datetime = field(default_factory=lambda: datetime.now(UTC))
     status_code: int | None = None
     body: bytearray = field(default_factory=bytearray)
     captured: bool = False
@@ -112,7 +112,7 @@ class CaptureState:
                 self.request,
                 bytes(self.body),
                 start_time=self.start_time,
-                end_time=datetime.now(),
+                end_time=datetime.now(UTC),
             )
         except Exception as exc:
             logger.debug("Ignoring incomplete trajectory exchange: %s", exc)

--- a/tests/unit/test_trajectory_parquet.py
+++ b/tests/unit/test_trajectory_parquet.py
@@ -9,6 +9,7 @@ Tests cover:
 5. Golden file regression tests
 """
 
+from datetime import UTC
 import json
 import os
 from pathlib import Path
@@ -283,6 +284,7 @@ def test_legacy_serializer_round_trips_complete_exchange_group() -> None:
     assert loaded.model_dump(
         mode="json", exclude_defaults=False
     ) == original.model_dump(mode="json", exclude_defaults=False)
+    assert loaded.trajectories[0].exchanges.chat_completions[0].start_time.tzinfo is UTC
 
 
 def test_legacy_serializer_round_trips_complete_legacy_trajectory() -> None:

--- a/tests/unit/trajectories/test_capture.py
+++ b/tests/unit/trajectories/test_capture.py
@@ -9,7 +9,7 @@ from collections.abc import (
     Iterable,
 )
 import copy
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 import gzip
 import json
 from typing import Any, cast
@@ -55,6 +55,39 @@ def test_root_trajectory_exports_are_minimal() -> None:
     assert all(
         not hasattr(art, name) for name in set(art.trajectories.__all__) - expected
     )
+
+
+def test_trajectory_timestamps_normalize_to_utc() -> None:
+    naive = datetime(2026, 1, 2, 3, 4, 5)
+    offset = timezone(timedelta(hours=-7))
+    exchange = cast(
+        ChatCompletionsExchange,
+        build_exchange(
+            "chat_completions",
+            {"model": "test/model", "messages": []},
+            json.dumps(CHAT).encode(),
+            start_time=naive,
+            end_time=naive.replace(tzinfo=offset),
+        ),
+    )
+    trajectory = art.Trajectory(start_time=naive)
+
+    assert exchange.start_time == naive.replace(tzinfo=UTC)
+    assert exchange.end_time == naive.replace(tzinfo=offset).astimezone(UTC)
+    assert trajectory.start_time == naive.replace(tzinfo=UTC)
+    exchange.start_time = naive
+    trajectory.start_time = naive
+    assert exchange.start_time.tzinfo is UTC
+    assert trajectory.start_time.tzinfo is UTC
+    restored_exchange = type(exchange).model_validate_json(exchange.model_dump_json())
+    assert restored_exchange.start_time.tzinfo is UTC
+    trajectory.exchanges.chat_completions.append(exchange)
+    restored = art.trajectories.compact_validate(
+        trajectory.compact_dump(), type=art.Trajectory
+    )
+    assert restored.exchanges.chat_completions[0].start_time.tzinfo is UTC
+    trajectory.finish()
+    assert trajectory.metrics["duration"] >= 0
 
 
 CHAT: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- normalize exchange and trajectory timestamps to timezone-aware UTC
- treat legacy naive timestamps as UTC while normalizing other aware offsets
- emit UTC timestamps from capture and trajectory lifecycle paths
- cover model, compact, and Parquet round trips

## Validation
- `uv run --no-sync pytest -q tests/unit/trajectories/test_capture.py tests/unit/trajectories/test_history.py tests/unit/trajectories/test_compact_serialization.py tests/unit/test_trajectory_parquet.py` (208 passed, 3 skipped)
- `uv run --no-sync ruff check src/art/trajectories tests/unit/trajectories/test_capture.py tests/unit/test_trajectory_parquet.py`
- `uv run --no-sync ty check src/art/trajectories/__init__.py src/art/trajectories/_capture/core.py tests/unit/trajectories/test_capture.py tests/unit/test_trajectory_parquet.py`

The repository-wide local suite requires optional Torch/Tinker/Transformers environments; CI covers those matrices.