### PR TITLE
Retry malformed RULER score counts

### DIFF
--- a/src/art/rewards/ruler.py
+++ b/src/art/rewards/ruler.py
@@ -48,6 +48,9 @@ DEFAULT_RUBRIC = dedent(
 """Default rubric used by RULER. This generic rubric works well for most tasks,
 as RULER extracts task understanding from the system prompts in the trajectories."""
 
+# A malformed relative ranking is usually transient; permit one bounded re-judge.
+_SCORE_COUNT_ATTEMPTS = 2
+
 
 def _judge_provider(judge_model: str) -> str | None:
     provider, separator, _ = judge_model.partition("/")
@@ -217,50 +220,53 @@ async def ruler(
         {"role": "user", "content": user_text},
     ]
 
-    response = await acompletion(
-        model=judge_model,
-        messages=messages,
-        response_format=Response,
-        caching=False,
-        **extra_litellm_params if extra_litellm_params else {},
-    )
-    assert isinstance(response, ModelResponse)
-    _record_ruler_cost(judge_model, response)
+    for attempt in range(_SCORE_COUNT_ATTEMPTS):
+        response = await acompletion(
+            model=judge_model,
+            messages=messages,
+            response_format=Response,
+            caching=False,
+            **extra_litellm_params if extra_litellm_params else {},
+        )
+        assert isinstance(response, ModelResponse)
+        _record_ruler_cost(judge_model, response)
 
-    if len(response.choices) == 0:
-        raise ValueError(f"No choices in response: {response}")
-    first_choice = response.choices[0]
+        if len(response.choices) == 0:
+            raise ValueError(f"No choices in response: {response}")
+        first_choice = response.choices[0]
 
-    if debug:
-        raw_content = first_choice.message.content or "{}"
-        try:
-            print("\n[RULER] Pretty-printed LLM choice JSON:")
-            print(json.loads(raw_content))
-        except json.JSONDecodeError as e:
-            print(f"[RULER] Could not parse choice content as JSON: {e}")
-            print(f"[RULER] Raw choice content: {raw_content}")
+        if debug:
+            raw_content = first_choice.message.content or "{}"
+            try:
+                print("\n[RULER] Pretty-printed LLM choice JSON:")
+                print(json.loads(raw_content))
+            except json.JSONDecodeError as e:
+                print(f"[RULER] Could not parse choice content as JSON: {e}")
+                print(f"[RULER] Raw choice content: {raw_content}")
 
-    content = first_choice.message.content or "{}"
-    parsed = Response.model_validate_json(content)
-
-    # If all trajectories were identical, we only sent one to the judge
-    # Duplicate the score for all trajectories
-    if all_identical:
-        if len(parsed.scores) != 1:
+        content = first_choice.message.content or "{}"
+        parsed = Response.model_validate_json(content)
+        expected_scores = 1 if all_identical else len(message_lists)
+        if len(parsed.scores) != expected_scores:
+            if attempt + 1 < _SCORE_COUNT_ATTEMPTS:
+                continue
+            qualifier = " for identical trajectories" if all_identical else ""
             raise ValueError(
-                f"Expected 1 score for identical trajectories, but got {len(parsed.scores)}"
+                f"Expected {expected_scores} score{'' if expected_scores == 1 else 's'}"
+                f"{qualifier}, but got {len(parsed.scores)}"
             )
-        single_score = parsed.scores[0]
-        return [
-            single_score.model_copy(update={"trajectory_id": str(i)})
-            for i in range(1, len(message_lists) + 1)
-        ]
-    else:
-        if len(parsed.scores) != len(message_lists):
-            raise ValueError(
-                f"Expected {len(message_lists)} scores, but got {len(parsed.scores)}"
-            )
+
+        # If all trajectories were identical, we only sent one to the judge.
+        # Duplicate the score for all trajectories.
+        if all_identical:
+            single_score = parsed.scores[0]
+            return [
+                single_score.model_copy(update={"trajectory_id": str(i)})
+                for i in range(1, len(message_lists) + 1)
+            ]
         return parsed.scores
+
+    raise AssertionError("RULER score-count retry loop did not return")
 
 
 async def ruler_score_group(

--- a/src/art/rewards/ruler.py
+++ b/src/art/rewards/ruler.py
@@ -49,7 +49,7 @@ DEFAULT_RUBRIC = dedent(
 as RULER extracts task understanding from the system prompts in the trajectories."""
 
 # A malformed relative ranking is usually transient; permit one bounded re-judge.
-_SCORE_COUNT_ATTEMPTS = 2
+_STRUCTURAL_ATTEMPTS = 2
 
 
 def _judge_provider(judge_model: str) -> str | None:
@@ -220,7 +220,7 @@ async def ruler(
         {"role": "user", "content": user_text},
     ]
 
-    for attempt in range(_SCORE_COUNT_ATTEMPTS):
+    for attempt in range(_STRUCTURAL_ATTEMPTS):
         response = await acompletion(
             model=judge_model,
             messages=messages,
@@ -247,26 +247,41 @@ async def ruler(
         content = first_choice.message.content or "{}"
         parsed = Response.model_validate_json(content)
         expected_scores = 1 if all_identical else len(message_lists)
+        structure_error: ValueError | None = None
         if len(parsed.scores) != expected_scores:
-            if attempt + 1 < _SCORE_COUNT_ATTEMPTS:
-                continue
             qualifier = " for identical trajectories" if all_identical else ""
-            raise ValueError(
+            structure_error = ValueError(
                 f"Expected {expected_scores} score{'' if expected_scores == 1 else 's'}"
                 f"{qualifier}, but got {len(parsed.scores)}"
             )
+        expected_ids = [str(index) for index in range(1, expected_scores + 1)]
+        scores_by_id = {score.trajectory_id: score for score in parsed.scores}
+        if structure_error is None and (
+            len(scores_by_id) != expected_scores
+            or set(scores_by_id) != set(expected_ids)
+        ):
+            structure_error = ValueError(
+                f"Expected trajectory ids {expected_ids}, but got "
+                f"{[score.trajectory_id for score in parsed.scores]}"
+            )
+        if structure_error is not None:
+            if attempt + 1 < _STRUCTURAL_ATTEMPTS:
+                continue
+            raise structure_error
+
+        ordered_scores = [scores_by_id[trajectory_id] for trajectory_id in expected_ids]
 
         # If all trajectories were identical, we only sent one to the judge.
         # Duplicate the score for all trajectories.
         if all_identical:
-            single_score = parsed.scores[0]
+            single_score = ordered_scores[0]
             return [
                 single_score.model_copy(update={"trajectory_id": str(i)})
                 for i in range(1, len(message_lists) + 1)
             ]
-        return parsed.scores
+        return ordered_scores
 
-    raise AssertionError("RULER score-count retry loop did not return")
+    raise AssertionError("RULER structural retry loop did not return")
 
 
 async def ruler_score_group(

--- a/tests/unit/test_ruler_metrics.py
+++ b/tests/unit/test_ruler_metrics.py
@@ -62,19 +62,23 @@ class _FakeResponse:
         )
 
 
-def _score_content(count: int) -> str:
+def _score_content_for_ids(trajectory_ids: list[str]) -> str:
     return json.dumps(
         {
             "scores": [
                 {
-                    "trajectory_id": str(index),
-                    "explanation": f"Trajectory {index}.",
-                    "score": index / 10,
+                    "trajectory_id": trajectory_id,
+                    "explanation": f"Trajectory {trajectory_id}.",
+                    "score": int(trajectory_id) / 10,
                 }
-                for index in range(1, count + 1)
+                for trajectory_id in trajectory_ids
             ]
         }
     )
+
+
+def _score_content(count: int) -> str:
+    return _score_content_for_ids([str(index) for index in range(1, count + 1)])
 
 
 def _response(count: int, *, cost: float | None = None) -> _FakeResponse:
@@ -256,14 +260,17 @@ async def test_ruler_structural_retry_propagates_cancellation(monkeypatch):
     async def _fake_acompletion(**_kwargs):
         nonlocal calls
         calls += 1
+        if calls == 1:
+            return _response(1)
         raise asyncio.CancelledError
 
     monkeypatch.setattr(ruler_module, "acompletion", _fake_acompletion)
+    monkeypatch.setattr(ruler_module, "ModelResponse", _FakeResponse)
 
     with pytest.raises(asyncio.CancelledError):
         await ruler_module.ruler(_TWO_TRAJECTORIES)
 
-    assert calls == 1
+    assert calls == 2
 
 
 @pytest.mark.asyncio
@@ -290,3 +297,49 @@ async def test_ruler_records_cost_for_every_structural_attempt(monkeypatch):
 
     assert len(scores) == 2
     assert metrics["costs/train/judge/ruler"] == pytest.approx(0.03)
+
+
+@pytest.mark.asyncio
+async def test_ruler_retries_duplicate_trajectory_ids(monkeypatch):
+    responses = iter(
+        [
+            _FakeResponse(
+                content=_score_content_for_ids(["1", "1"]),
+                prompt_tokens=100,
+                completion_tokens=50,
+            ),
+            _response(2),
+        ]
+    )
+    calls = 0
+
+    async def _fake_acompletion(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return next(responses)
+
+    monkeypatch.setattr(ruler_module, "acompletion", _fake_acompletion)
+    monkeypatch.setattr(ruler_module, "ModelResponse", _FakeResponse)
+
+    scores = await ruler_module.ruler(_TWO_TRAJECTORIES)
+
+    assert calls == 2
+    assert [score.trajectory_id for score in scores] == ["1", "2"]
+
+
+@pytest.mark.asyncio
+async def test_ruler_orders_scores_by_trajectory_id(monkeypatch):
+    async def _fake_acompletion(**_kwargs):
+        return _FakeResponse(
+            content=_score_content_for_ids(["2", "1"]),
+            prompt_tokens=100,
+            completion_tokens=50,
+        )
+
+    monkeypatch.setattr(ruler_module, "acompletion", _fake_acompletion)
+    monkeypatch.setattr(ruler_module, "ModelResponse", _FakeResponse)
+
+    scores = await ruler_module.ruler(_TWO_TRAJECTORIES)
+
+    assert [score.trajectory_id for score in scores] == ["1", "2"]
+    assert [score.score for score in scores] == pytest.approx([0.1, 0.2])

--- a/tests/unit/test_ruler_metrics.py
+++ b/tests/unit/test_ruler_metrics.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import json
 
@@ -59,6 +60,36 @@ class _FakeResponse:
             cost=cost,
             model_extra=model_extra,
         )
+
+
+def _score_content(count: int) -> str:
+    return json.dumps(
+        {
+            "scores": [
+                {
+                    "trajectory_id": str(index),
+                    "explanation": f"Trajectory {index}.",
+                    "score": index / 10,
+                }
+                for index in range(1, count + 1)
+            ]
+        }
+    )
+
+
+def _response(count: int, *, cost: float | None = None) -> _FakeResponse:
+    return _FakeResponse(
+        content=_score_content(count),
+        prompt_tokens=100,
+        completion_tokens=50,
+        cost=cost,
+    )
+
+
+_TWO_TRAJECTORIES = [
+    [{"role": "user", "content": "first"}],
+    [{"role": "user", "content": "second"}],
+]
 
 
 @pytest.mark.asyncio
@@ -178,3 +209,84 @@ async def test_ruler_records_direct_cost_for_openrouter_judges(monkeypatch):
 
     assert scores[0].score == pytest.approx(0.8)
     assert metrics["costs/train/judge/ruler"] == pytest.approx(1.68e-05)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_count", [1, 3])
+async def test_ruler_retries_missing_or_extra_scores(monkeypatch, invalid_count):
+    responses = iter([_response(invalid_count), _response(2)])
+    calls = 0
+
+    async def _fake_acompletion(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return next(responses)
+
+    monkeypatch.setattr(ruler_module, "acompletion", _fake_acompletion)
+    monkeypatch.setattr(ruler_module, "ModelResponse", _FakeResponse)
+
+    scores = await ruler_module.ruler(_TWO_TRAJECTORIES)
+
+    assert calls == 2
+    assert [score.trajectory_id for score in scores] == ["1", "2"]
+
+
+@pytest.mark.asyncio
+async def test_ruler_raises_after_structural_attempts_are_exhausted(monkeypatch):
+    calls = 0
+
+    async def _fake_acompletion(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return _response(1)
+
+    monkeypatch.setattr(ruler_module, "acompletion", _fake_acompletion)
+    monkeypatch.setattr(ruler_module, "ModelResponse", _FakeResponse)
+
+    with pytest.raises(ValueError, match="Expected 2 scores, but got 1"):
+        await ruler_module.ruler(_TWO_TRAJECTORIES)
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_ruler_structural_retry_propagates_cancellation(monkeypatch):
+    calls = 0
+
+    async def _fake_acompletion(**_kwargs):
+        nonlocal calls
+        calls += 1
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(ruler_module, "acompletion", _fake_acompletion)
+
+    with pytest.raises(asyncio.CancelledError):
+        await ruler_module.ruler(_TWO_TRAJECTORIES)
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ruler_records_cost_for_every_structural_attempt(monkeypatch):
+    responses = iter([_response(1, cost=0.01), _response(2, cost=0.02)])
+
+    async def _fake_acompletion(**_kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(ruler_module, "acompletion", _fake_acompletion)
+    monkeypatch.setattr(ruler_module, "ModelResponse", _FakeResponse)
+
+    builder = MetricsBuilder(cost_context="train")
+    token = builder.activate()
+    try:
+        scores = await ruler_module.ruler(
+            _TWO_TRAJECTORIES,
+            judge_model="openrouter/openai/gpt-4.1-mini",
+        )
+    finally:
+        token.var.reset(token)
+
+    metrics = await builder.flush()
+
+    assert len(scores) == 2
+    assert metrics["costs/train/judge/ruler"] == pytest.approx(0.03)

--- a/tests/unit/test_ruler_metrics.py
+++ b/tests/unit/test_ruler_metrics.py
@@ -2,6 +2,9 @@ import asyncio
 import importlib
 import json
 
+from openai.types.chat.chat_completion_message_param import (
+    ChatCompletionMessageParam,
+)
 import pytest
 
 from art.metrics import MetricsBuilder
@@ -90,7 +93,7 @@ def _response(count: int, *, cost: float | None = None) -> _FakeResponse:
     )
 
 
-_TWO_TRAJECTORIES = [
+_TWO_TRAJECTORIES: list[list[ChatCompletionMessageParam]] = [
     [{"role": "user", "content": "first"}],
     [{"role": "user", "content": "second"}],
 ]


### PR DESCRIPTION
## Summary
- retry a RULER judge once when a valid structured response has the wrong number of scores
- preserve strict one-score-per-candidate semantics and fail after the bounded retry
- preserve cancellation and record the cost of every judge attempt

## Motivation
Experiment 046 produced 7 scores for an 8-trajectory group and aborted before its first resumed batch. This fixes that transient structural failure below the experiment API without padding or dropping candidates.

## Verification
- `uv run pytest -q tests/unit/test_ruler_metrics.py` (8 passed)
- `uv run pytest -q tests/unit/trajectories/test_history.py -k ruler` (2 passed)
- Ruff format/check and Ty pass for changed source/tests
