### PR TITLE
Preserve exact tokens across length-normalized chat history

### DIFF
--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -491,6 +491,34 @@ def _translate_token_mask(
     return translated
 
 
+def _prove_exact_sampled_assistant_span(
+    matches: Sequence[tuple[int, int]],
+    assistant_mask: Sequence[bool],
+    *,
+    after: int,
+    expected_start: int,
+) -> tuple[int, int] | None:
+    """Accept one exact output only at a provenance-backed assistant boundary."""
+
+    if len(matches) != 1 or matches[0][0] != expected_start:
+        return None
+    start, end = matches[0]
+    intervening_start = after
+    # ``after`` may still point into template-owned tail tokens in the assistant
+    # run that contained the preceding sampled output.
+    if after > 0 and assistant_mask[after - 1]:
+        while intervening_start < start and assistant_mask[intervening_start]:
+            intervening_start += 1
+    if (
+        any(assistant_mask[intervening_start:start])
+        or not all(assistant_mask[start:end])
+        or (start > 0 and assistant_mask[start - 1])
+        or (end < len(assistant_mask) and assistant_mask[end])
+    ):
+        return None
+    return start, end
+
+
 def _rendered_flag(assistant: bool, stop: bool) -> TokenFlag:
     flag = TokenFlag.ASSISTANT if assistant else TokenFlag(0)
     return flag | TokenFlag.STOP if stop else flag
@@ -4896,9 +4924,37 @@ def _tokenize_chat_view(
                 history.messages[message_index], source
             )
         )
+        authoritative_prompt = (
+            source_prompt_tokens(source) if sampled and source is not None else None
+        )
+        initial_proven_bounds = marked_bounds.get(message_index) or probed_bounds.get(
+            message_index
+        )
+        exact_output_matches: list[tuple[int, int]] | None = None
+        exact_output_span: tuple[int, int] | None = None
+        if (
+            complete_sampled_message
+            and source is not None
+            and full_exact
+            and _projection_matches is True
+            and chat_template is None
+            and chat_template_kwargs is None
+            and source_matches_context(source)
+            and _source_stop_evidence(source, _sampled_source_key(source))[0]
+            != "length"
+        ):
+            exact_output_matches = locations(full_exact, search_cursor)
+            if authoritative_prompt is not None:
+                exact_output_span = _prove_exact_sampled_assistant_span(
+                    exact_output_matches,
+                    assistant_mask,
+                    after=search_cursor,
+                    expected_start=len(authoritative_prompt),
+                )
         if (
             complete_sampled_message
             and full_exact is not None
+            and exact_output_span is None
             and message_index in marked_bounds
             and isinstance(getattr(source, "exchange", None), ChatCompletionsExchange)
             and marked_bounds[message_index][1] - marked_bounds[message_index][0]
@@ -4942,12 +4998,31 @@ def _tokenize_chat_view(
             else:
                 marked_bounds.pop(message_index, None)
                 marked_part_bounds.pop(message_index, None)
+        proven_bounds = (
+            marked_bounds.get(message_index)
+            or probed_bounds.get(message_index)
+            or initial_proven_bounds
+        )
+        if (
+            exact_output_span is None
+            and exact_output_matches is not None
+            and proven_bounds is not None
+        ):
+            exact_output_span = _prove_exact_sampled_assistant_span(
+                exact_output_matches,
+                assistant_mask,
+                after=search_cursor,
+                expected_start=proven_bounds[0],
+            )
         source_boundary = False
         generation_start: int | None = None
         sampled_bounds: tuple[int, int] | None = None
         content_bounds_proven = False
         if sampled:
-            if direct_bounds:
+            if exact_output_span is not None:
+                sampled_bounds = exact_output_span
+                content_bounds_proven = True
+            elif direct_bounds:
                 sampled_bounds = direct_bounds[message_index]
                 content_bounds_proven = True
             elif message_index in marked_bounds:
@@ -5016,6 +5091,7 @@ def _tokenize_chat_view(
             and full_matches
             and (
                 (source_boundary and full_matches[0][0] == search_cursor)
+                or exact_output_span is not None
                 or (
                     complete_sampled_message
                     and len(full_matches) == 1

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -219,6 +219,42 @@ class _StopTokenizer:
         raise AssertionError(content)
 
 
+class _BoundaryTokenizer(_StopTokenizer):
+    def __init__(self, *segments: tuple[str, list[int]]) -> None:
+        self.renders: dict[tuple[str, ...], list[int]] = {}
+        roles: list[str] = []
+        rendered: list[int] = []
+        for role, tokens in segments:
+            roles.append(role)
+            rendered.extend(tokens)
+            self.renders[tuple(roles)] = list(rendered)
+
+    def __call__(self, text: str, **kwargs: object) -> list[int]:
+        del kwargs
+        return {
+            "answer": [2],
+            "complete answer": [2, 9],
+            "tool result": [3],
+            "turn 0": [1],
+            "turn 1": [3],
+            "turn 2": [5],
+        }.get(text, [77])
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool,
+        **kwargs: object,
+    ) -> list[int]:
+        del kwargs
+        if messages:
+            assert add_generation_prompt == (messages[-1].get("role") != "assistant")
+        return list(
+            self.renders[tuple(str(message.get("role")) for message in messages)]
+        )
+
+
 def test_exact_sampled_eos_is_stop_when_tokenizer_identifies_it() -> None:
     exchange = _chat_exchange([1], [2, 9])
 
@@ -276,6 +312,38 @@ def test_length_stop_keeps_sampled_content_and_adds_synthetic_stop() -> None:
     ]
 
 
+def test_terminal_length_with_sampled_eos_still_adds_synthetic_stop() -> None:
+    exchange = _chat_exchange([1], [2, 9])
+    exchange.response.choices[0].finish_reason = "length"
+
+    tokenized = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[exchange])
+    ).tokenize(tokenizer=_StopTokenizer())
+
+    assert tokenized.tokens == [1, 2, 9, 9]
+    assert tokenized.flags[-2:] == [
+        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.STOP,
+    ]
+
+
+def test_terminal_length_stays_synthetic_after_an_earlier_length_stop() -> None:
+    first = _chat_exchange([1], [2])
+    first.response.choices[0].finish_reason = "length"
+    second = _chat_exchange([1, 2, 9, 3], [4, 9], offset=1)
+    second.response.choices[0].finish_reason = "length"
+
+    tokenized = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second])
+    ).tokenize(tokenizer=_StopTokenizer())
+
+    assert tokenized.tokens == [1, 2, 9, 3, 4, 9, 9]
+    assert tokenized.flags[-2:] == [
+        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.STOP,
+    ]
+
+
 def test_later_exact_prompt_upgrades_synthetic_stop_without_sampling_it() -> None:
     first = _chat_exchange([1], [2])
     first.response.choices[0].finish_reason = "length"
@@ -290,6 +358,168 @@ def test_later_exact_prompt_upgrades_synthetic_stop_without_sampling_it() -> Non
         tr.TokenFlag.EXACT | tr.TokenFlag.ASSISTANT | tr.TokenFlag.STOP
     )
     assert not tokenized.flags[2] & tr.TokenFlag.SAMPLED
+
+
+def test_exact_output_boundaries_survive_prefix_order_drift_and_length_stop() -> None:
+    first = _chat_exchange([1], [2, 9])
+    second = _chat_exchange([1, 2, 9, 3], [4], offset=1)
+    second.response.choices[0].finish_reason = "length"
+    third = _chat_exchange([1, 2, 9, 3, 4, 9, 5], [6, 9], offset=2)
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second, third])
+    ).chat_completions_history()
+    tokenizer = _BoundaryTokenizer(
+        ("user", [8]),
+        ("assistant", [2, 9]),
+        ("user", [3]),
+        ("assistant", [4, 9]),
+        ("user", [5]),
+        ("assistant", [6, 9]),
+    )
+
+    tokenized = history.tokenize(tokenizer=tokenizer)
+
+    assert tokenized.tokens == [1, 2, 9, 3, 4, 9, 5, 6, 9]
+    sampled = [
+        index
+        for index, flag in enumerate(tokenized.flags)
+        if flag & tr.TokenFlag.SAMPLED
+    ]
+    assert sampled == [1, 2, 4, 7, 8]
+    assert [
+        index for index, flag in enumerate(tokenized.flags) if flag & tr.TokenFlag.STOP
+    ] == [2, 5, 8]
+    assert all(math.isfinite(tokenized.logprobs[index]) for index in sampled)
+
+    with pytest.raises(
+        ValueError,
+        match="Could not prove a sampled history message boundary",
+    ):
+        history.tokenize(tokenizer=tokenizer, chat_template="explicit override")
+
+
+def test_exact_output_boundary_after_sampled_tool_call() -> None:
+    first = _chat_exchange([1], [2, 7, 9])
+    first_data = first.response.model_dump(mode="python")
+    first_data["choices"][0]["finish_reason"] = "tool_calls"
+    first_data["choices"][0]["message"] = {
+        "role": "assistant",
+        "content": "answer",
+        "tool_calls": [
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }
+        ],
+    }
+    first.response = ChatCompletion.model_validate(first_data)
+
+    second = _chat_exchange([1, 2, 7, 9, 3], [4, 9], offset=1)
+    second.request["messages"] = [
+        {"role": "user", "content": "turn 0"},
+        first.response.choices[0].message.model_dump(mode="python", exclude_none=True),
+        {"role": "tool", "tool_call_id": "call-1", "content": "tool result"},
+    ]
+    third = _chat_exchange([1, 2, 7, 9, 3, 4, 9, 5], [6], offset=2)
+    third.request["messages"] = [
+        *second.request["messages"],
+        second.response.choices[0].message.model_dump(mode="python", exclude_none=True),
+        {"role": "user", "content": "turn 2"},
+    ]
+    third.response.choices[0].finish_reason = "length"
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second, third])
+    ).chat_completions_history()
+    tokenizer = _BoundaryTokenizer(
+        ("user", [8]),
+        ("assistant", [2, 7, 9]),
+        ("tool", [3]),
+        ("assistant", [4, 9]),
+        ("user", [5]),
+        ("assistant", [6, 9]),
+    )
+
+    tokenized = history.tokenize(tokenizer=tokenizer)
+
+    assert tokenized.tokens == [1, 2, 7, 9, 3, 4, 9, 5, 6, 9]
+    sampled = [
+        index
+        for index, flag in enumerate(tokenized.flags)
+        if flag & tr.TokenFlag.SAMPLED
+    ]
+    assert sampled == [1, 2, 3, 5, 6, 8]
+    assert [
+        index for index, flag in enumerate(tokenized.flags) if flag & tr.TokenFlag.STOP
+    ] == [3, 6, 9]
+
+
+def test_proven_exact_output_boundary_does_not_require_prompt_token_ids() -> None:
+    first = _chat_exchange([1], [2, 9])
+    first.response.choices[0].message.content = "complete answer"
+    assert first.response.choices[0].model_extra is not None
+    first.response.choices[0].model_extra.pop("prompt_token_ids")
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first])
+    ).chat_completions_history()
+    from art.trajectories._tokenize import _tokenize_chat_view
+
+    tokenized = _tokenize_chat_view(
+        history,
+        base_model=None,
+        tokenizer=_BoundaryTokenizer(
+            ("user", [8]),
+            ("assistant", [2, 9]),
+        ),
+        chat_template=None,
+        chat_template_kwargs=None,
+        _projection_matches=True,
+    )
+
+    assert tokenized.tokens == [8, 2, 9]
+    assert tokenized.flags[1] & tr.TokenFlag.SAMPLED
+    assert tokenized.flags[2] & tr.TokenFlag.SAMPLED
+
+
+@pytest.mark.parametrize(
+    ("matches", "assistant_mask", "after", "expected_start"),
+    [
+        ([(0, 2)], [False, False], 0, 0),  # a user quote
+        ([(6, 8)], [False, True, False, True, False, False, True, True], 1, 6),
+        ([(1, 3), (4, 6)], [False, True, True, False, True, True], 0, 1),
+        ([(2, 4)], [False, False, True, True], 0, 1),  # prefix drift
+        ([], [], 0, 0),
+    ],
+    ids=("user-quote", "later-assistant", "ambiguous", "prefix-drift", "empty"),
+)
+def test_exact_output_boundary_proof_rejects_unproved_spans(
+    matches: list[tuple[int, int]],
+    assistant_mask: list[bool],
+    after: int,
+    expected_start: int,
+) -> None:
+    from art.trajectories._tokenize import _prove_exact_sampled_assistant_span
+
+    assert (
+        _prove_exact_sampled_assistant_span(
+            matches,
+            assistant_mask,
+            after=after,
+            expected_start=expected_start,
+        )
+        is None
+    )
+
+
+def test_exact_output_boundary_proof_accepts_first_maximal_assistant_run() -> None:
+    from art.trajectories._tokenize import _prove_exact_sampled_assistant_span
+
+    assert _prove_exact_sampled_assistant_span(
+        [(4, 6)],
+        [False, True, True, False, True, True, False],
+        after=2,
+        expected_start=4,
+    ) == (4, 6)
 
 
 def test_integer_stop_reason_marks_raw_completions_without_assistant() -> None:


### PR DESCRIPTION
## Summary

- preserve exact sampled output tokens and logprobs when a projection-valid multi-turn chat render diverges from authoritative inference prefixes
- admit an exact output only when it is unique after the monotonic cursor, begins at the authoritative source-prompt length or an independently proven renderer boundary, and exactly fills the first new maximal assistant run
- keep terminal length responses on the existing synthetic-stop path and fail closed for explicit template overrides, ambiguous or replayed output, user quotes, prefix drift, and empty evidence

This fixes two independent experiment 046 tensorization failures caused by tool-schema JSON key ordering changing between inference and later reconstruction. In both captures, whole-prefix equality was unavailable while each complete sampled output remained token-exact at a renderer-proven assistant boundary.

## Verification

- `pytest -q tests/unit/trajectories/test_tokenize.py` in the trainer-capable environment: 202 passed
- focused exact-boundary, length, and empty suite: 13 passed
- `ruff check`, `ruff format --check`, `ty check`, and `git diff --check`
- replayed batch-116 capture: 12,147 tokens; 4,566 sampled; 4,570 assistant; 3 stops; every sampled logprob finite
- replayed batch-150 capture after a sampled tool call: 14,679 tokens; 7,027 sampled; 7,031 assistant; 5 stops; every sampled logprob finite
- fresh blocker review after remediation: no remaining findings