### PR TITLE
Make RULER structural retries corrective

### DIFF
--- a/src/art/rewards/ruler.py
+++ b/src/art/rewards/ruler.py
@@ -215,7 +215,19 @@ async def ruler(
         """
     )
 
-    messages = [
+    expected_scores = 1 if all_identical else len(message_lists)
+    expected_ids = [str(index) for index in range(1, expected_scores + 1)]
+    required_ids = ", ".join(expected_ids)
+    judge_prompt += dedent(
+        f"""
+
+        Return exactly {expected_scores} score object{"" if expected_scores == 1 else "s"},
+        one for each of these trajectory IDs, with no duplicates or omissions:
+        {required_ids}
+        """
+    )
+
+    messages: list[ChatCompletionMessageParam] = [
         {"role": "system", "content": judge_prompt},
         {"role": "user", "content": user_text},
     ]
@@ -246,7 +258,6 @@ async def ruler(
 
         content = first_choice.message.content or "{}"
         parsed = Response.model_validate_json(content)
-        expected_scores = 1 if all_identical else len(message_lists)
         structure_error: ValueError | None = None
         if len(parsed.scores) != expected_scores:
             qualifier = " for identical trajectories" if all_identical else ""
@@ -254,8 +265,21 @@ async def ruler(
                 f"Expected {expected_scores} score{'' if expected_scores == 1 else 's'}"
                 f"{qualifier}, but got {len(parsed.scores)}"
             )
-        expected_ids = [str(index) for index in range(1, expected_scores + 1)]
         scores_by_id = {score.trajectory_id: score for score in parsed.scores}
+        received_ids = [score.trajectory_id for score in parsed.scores]
+        missing_ids = [
+            trajectory_id
+            for trajectory_id in expected_ids
+            if trajectory_id not in scores_by_id
+        ]
+        duplicate_ids = sorted(
+            {
+                trajectory_id
+                for trajectory_id in received_ids
+                if received_ids.count(trajectory_id) > 1
+            }
+        )
+        unexpected_ids = sorted(set(received_ids) - set(expected_ids))
         if structure_error is None and (
             len(scores_by_id) != expected_scores
             or set(scores_by_id) != set(expected_ids)
@@ -266,6 +290,23 @@ async def ruler(
             )
         if structure_error is not None:
             if attempt + 1 < _STRUCTURAL_ATTEMPTS:
+                messages = [
+                    *messages,
+                    {"role": "assistant", "content": content},
+                    {
+                        "role": "user",
+                        "content": (
+                            f"Your response had {len(parsed.scores)} score object"
+                            f"{'' if len(parsed.scores) == 1 else 's'}; expected "
+                            f"{expected_scores}. Missing trajectory IDs: "
+                            f"{', '.join(missing_ids) or 'none'}. Duplicate trajectory "
+                            f"IDs: {', '.join(duplicate_ids) or 'none'}. Unexpected "
+                            f"trajectory IDs: {', '.join(unexpected_ids) or 'none'}. "
+                            f"Return one complete replacement using each trajectory ID "
+                            f"exactly once: {required_ids}."
+                        ),
+                    },
+                ]
                 continue
             raise structure_error
 

--- a/tests/unit/test_ruler_metrics.py
+++ b/tests/unit/test_ruler_metrics.py
@@ -222,11 +222,10 @@ async def test_ruler_records_direct_cost_for_openrouter_judges(monkeypatch):
 @pytest.mark.parametrize("invalid_count", [1, 3])
 async def test_ruler_retries_missing_or_extra_scores(monkeypatch, invalid_count):
     responses = iter([_response(invalid_count), _response(2)])
-    calls = 0
+    calls = []
 
-    async def _fake_acompletion(**_kwargs):
-        nonlocal calls
-        calls += 1
+    async def _fake_acompletion(**kwargs):
+        calls.append(kwargs)
         return next(responses)
 
     monkeypatch.setattr(ruler_module, "acompletion", _fake_acompletion)
@@ -234,17 +233,42 @@ async def test_ruler_retries_missing_or_extra_scores(monkeypatch, invalid_count)
 
     scores = await ruler_module.ruler(_TWO_TRAJECTORIES)
 
-    assert calls == 2
+    assert len(calls) == 2
     assert [score.trajectory_id for score in scores] == ["1", "2"]
+    initial_messages = calls[0]["messages"]
+    assert len(initial_messages) == 2
+    assert "exactly 2 score objects" in initial_messages[0]["content"]
+    assert "1, 2" in initial_messages[0]["content"]
+    retry_messages = calls[1]["messages"]
+    assert retry_messages[:2] == initial_messages
+    assert retry_messages[2] == {
+        "role": "assistant",
+        "content": _score_content(invalid_count),
+    }
+    correction = retry_messages[3]["content"]
+    assert f"had {invalid_count} score object" in correction
+    assert (
+        "Missing trajectory IDs: 2"
+        if invalid_count == 1
+        else "Missing trajectory IDs: none"
+    ) in correction
+    assert "Duplicate trajectory IDs: none" in correction
+    assert (
+        "Unexpected trajectory IDs: 3"
+        if invalid_count == 3
+        else "Unexpected trajectory IDs: none"
+    ) in correction
+    assert "using each trajectory ID exactly once: 1, 2" in correction
 
 
 @pytest.mark.asyncio
 async def test_ruler_raises_after_structural_attempts_are_exhausted(monkeypatch):
-    calls = 0
+    # Reproduce the 046 capture: two trajectories requested, but both otherwise-valid
+    # judge responses return only trajectory 1.
+    calls = []
 
-    async def _fake_acompletion(**_kwargs):
-        nonlocal calls
-        calls += 1
+    async def _fake_acompletion(**kwargs):
+        calls.append(kwargs)
         return _response(1)
 
     monkeypatch.setattr(ruler_module, "acompletion", _fake_acompletion)
@@ -253,7 +277,13 @@ async def test_ruler_raises_after_structural_attempts_are_exhausted(monkeypatch)
     with pytest.raises(ValueError, match="Expected 2 scores, but got 1"):
         await ruler_module.ruler(_TWO_TRAJECTORIES)
 
-    assert calls == 2
+    assert len(calls) == 2
+    retry_messages = calls[1]["messages"]
+    assert retry_messages[2] == {
+        "role": "assistant",
+        "content": _score_content(1),
+    }
+    assert "Missing trajectory IDs: 2" in retry_messages[3]["content"]
 
 
 @pytest.mark.asyncio
@@ -314,11 +344,10 @@ async def test_ruler_retries_duplicate_trajectory_ids(monkeypatch):
             _response(2),
         ]
     )
-    calls = 0
+    calls = []
 
-    async def _fake_acompletion(**_kwargs):
-        nonlocal calls
-        calls += 1
+    async def _fake_acompletion(**kwargs):
+        calls.append(kwargs)
         return next(responses)
 
     monkeypatch.setattr(ruler_module, "acompletion", _fake_acompletion)
@@ -326,8 +355,11 @@ async def test_ruler_retries_duplicate_trajectory_ids(monkeypatch):
 
     scores = await ruler_module.ruler(_TWO_TRAJECTORIES)
 
-    assert calls == 2
+    assert len(calls) == 2
     assert [score.trajectory_id for score in scores] == ["1", "2"]
+    correction = calls[1]["messages"][3]["content"]
+    assert "Missing trajectory IDs: 2" in correction
+    assert "Duplicate trajectory IDs: 1" in correction
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- tell the judge the exact number of RULER score objects and trajectory IDs required
- make the existing single structural retry corrective by appending the malformed response and a concise count/missing/duplicate/unexpected-ID correction
- preserve strict final validation, cancellation propagation, and per-attempt cost accounting

## Motivation

A live experiment 046 capture requested two scores from `gpt-5.6-luna`, but both otherwise-valid responses returned only trajectory ID 1. The existing retry resent the identical 30,827-token prompt, so it repeated the same under-specified response. This change supplies the missing structural information initially and gives the one existing retry concrete correction context.

## Verification

- `uv run pytest -q tests/unit/test_ruler_metrics.py` (10 passed)
- `uv run ruff check src/art/rewards/ruler.py tests/unit/test_ruler_metrics.py`
- `uv run ruff format --check src/art/rewards/ruler.py tests/unit/test_ruler_metrics.py`
- `uv run ty check src/art/rewards/ruler.py`
- `git diff --check`
- fresh blocker review: no findings