### PR TITLE
Preserve exact histories across nonterminal length stops

### DIFF
--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -3886,6 +3886,21 @@ def _rendered_length_stop_boundary(
     )
 
 
+def _next_assistant_span_start(
+    assistant_mask: Sequence[bool], *, after: int
+) -> int | None:
+    if not 0 <= after < len(assistant_mask):
+        return None
+    return next(
+        (
+            index
+            for index in range(after + 1, len(assistant_mask))
+            if assistant_mask[index] and not assistant_mask[index - 1]
+        ),
+        None,
+    )
+
+
 def _tokenize_exact_projected_chat_history(
     history: ChatCompletionsHistory,
     *,
@@ -3919,15 +3934,33 @@ def _tokenize_exact_projected_chat_history(
     if final_prompt is None or final_output is None:
         return None
     final_key = _sampled_source_key(final_source)
-    if (
-        length_stop_boundaries is not None
-        and _source_stop_evidence(final_source, final_key)[0] == "length"
+    final_stop_reason = _source_stop_evidence(final_source, final_key)[0]
+    terminal_boundary = (
+        (length_stop_boundaries or {}).get(final_key)
+        if final_stop_reason == "length"
+        else None
+    )
+    if final_stop_reason == "length" and (
+        terminal_boundary is None or not terminal_boundary.tail
     ):
-        # There is no later authoritative prompt containing the template-owned
-        # stop for a terminal length-limited response. Render that boundary.
         return None
 
-    token_ids = [*final_prompt, *final_output]
+    # The final prompt proves every earlier boundary. Only this terminal tail
+    # remains renderer-owned, so keep it synthetic as in ordinary rendering.
+    terminal_tail = (
+        [*terminal_boundary.tail, *terminal_boundary.following]
+        if terminal_boundary is not None
+        else []
+    )
+    terminal_flags = (
+        [
+            *([TokenFlag.ASSISTANT] * len(terminal_boundary.tail)),
+            *([TokenFlag(0)] * len(terminal_boundary.following)),
+        ]
+        if terminal_boundary is not None
+        else []
+    )
+    token_ids = [*final_prompt, *final_output, *terminal_tail]
     logprobs = [
         *([math.nan] * len(final_prompt)),
         *(
@@ -3935,6 +3968,7 @@ def _tokenize_exact_projected_chat_history(
             if len(final_logprobs) == len(final_output)
             else [math.nan] * len(final_output)
         ),
+        *([math.nan] * len(terminal_tail)),
     ]
     flags = [
         *([TokenFlag.EXACT] * len(final_prompt)),
@@ -3942,10 +3976,16 @@ def _tokenize_exact_projected_chat_history(
             [TokenFlag.EXACT | TokenFlag.SAMPLED | TokenFlag.ASSISTANT]
             * len(final_output)
         ),
+        *terminal_flags,
     ]
+    if terminal_boundary is not None:
+        flags[
+            len(final_prompt) + len(final_output) + len(terminal_boundary.tail) - 1
+        ] = TokenFlag.STOP
     source_keys: list[_SampledSourceKey | None] = [
         *([None] * len(final_prompt)),
         *([final_key] * len(final_output)),
+        *([None] * len(terminal_tail)),
     ]
     sources: dict[_SampledSourceKey, object] = {final_key: final_source}
     for index, source in enumerate(sampled_sources[:-1]):
@@ -5075,33 +5115,42 @@ def _tokenize_chat_view(
             if _source_stop_evidence(source, source_key)[0] != "length":
                 continue
             length_stop_count += 1
-            if position + 1 >= len(sampled_message_indices):
-                break
-            next_message_index = sampled_message_indices[position + 1]
             bounds = (
                 direct_bounds[message_index]
                 if direct_bounds
                 else marked_bounds.get(message_index)
                 or probed_bounds.get(message_index)
             )
-            next_bounds = (
-                direct_bounds[next_message_index]
-                if direct_bounds
-                else marked_bounds.get(next_message_index)
-                or probed_bounds.get(next_message_index)
-            )
+            next_prompt_end: int | None
+            if position + 1 < len(sampled_message_indices):
+                next_message_index = sampled_message_indices[position + 1]
+                next_bounds = (
+                    direct_bounds[next_message_index]
+                    if direct_bounds
+                    else marked_bounds.get(next_message_index)
+                    or probed_bounds.get(next_message_index)
+                )
+                next_prompt_end = (
+                    next_bounds[0]
+                    if next_bounds is not None
+                    else _next_assistant_span_start(assistant_mask, after=bounds[1])
+                    if bounds is not None
+                    else None
+                )
+            else:
+                next_prompt_end = len(rendered)
             boundary = (
                 _rendered_length_stop_boundary(
                     rendered,
                     assistant_mask,
                     stop_mask,
                     content_end=bounds[1],
-                    next_prompt_end=next_bounds[0],
+                    next_prompt_end=next_prompt_end,
                 )
                 if (
                     bounds is not None
                     and source_matches_context(source)
-                    and next_bounds is not None
+                    and next_prompt_end is not None
                 )
                 else None
             )

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -3846,10 +3846,52 @@ def _mark_sampled_stops(
             flags[index] |= TokenFlag.STOP
 
 
+@dataclass(frozen=True)
+class _RenderedLengthStopBoundary:
+    tail: tuple[int, ...]
+    following: tuple[int, ...]
+
+
+def _rendered_length_stop_boundary(
+    token_ids: Sequence[int],
+    assistant_mask: Sequence[bool],
+    stop_mask: Sequence[bool],
+    *,
+    content_end: int,
+    next_prompt_end: int,
+) -> _RenderedLengthStopBoundary | None:
+    """Prove one assistant stop tail through the next generation boundary."""
+
+    if not (
+        len(token_ids) == len(assistant_mask) == len(stop_mask)
+        and 0 <= content_end < next_prompt_end <= len(token_ids)
+    ):
+        return None
+    end = content_end
+    stops: list[int] = []
+    while end < len(token_ids) and assistant_mask[end]:
+        if stop_mask[end]:
+            stops.append(end)
+        end += 1
+    if (
+        len(stops) != 1
+        or stops[0] != end - 1
+        or end > next_prompt_end
+        or any(assistant_mask[end:next_prompt_end])
+    ):
+        return None
+    return _RenderedLengthStopBoundary(
+        tail=tuple(token_ids[content_end:end]),
+        following=tuple(token_ids[end:next_prompt_end]),
+    )
+
+
 def _tokenize_exact_projected_chat_history(
     history: ChatCompletionsHistory,
     *,
     tokenizer: Tokenizer | None,
+    length_stop_boundaries: Mapping[_SampledSourceKey, _RenderedLengthStopBoundary]
+    | None = None,
     projection_validated: bool = False,
     _trace: _TraceBuilder | None = None,
 ) -> TokenizedHistory | None:
@@ -3876,6 +3918,14 @@ def _tokenize_exact_projected_chat_history(
     final_output, final_logprobs = _chat_source_full_tokens(final_source)
     if final_prompt is None or final_output is None:
         return None
+    final_key = _sampled_source_key(final_source)
+    if (
+        length_stop_boundaries is not None
+        and _source_stop_evidence(final_source, final_key)[0] == "length"
+    ):
+        # There is no later authoritative prompt containing the template-owned
+        # stop for a terminal length-limited response. Render that boundary.
+        return None
 
     token_ids = [*final_prompt, *final_output]
     logprobs = [
@@ -3893,7 +3943,6 @@ def _tokenize_exact_projected_chat_history(
             * len(final_output)
         ),
     ]
-    final_key = _sampled_source_key(final_source)
     source_keys: list[_SampledSourceKey | None] = [
         *([None] * len(final_prompt)),
         *([final_key] * len(final_output)),
@@ -3938,6 +3987,31 @@ def _tokenize_exact_projected_chat_history(
         ] * len(retained_ids)
         logprobs[start:end] = retained_logprobs
         source_key = _sampled_source_key(source)
+        if _source_stop_evidence(source, source_key)[0] == "length":
+            boundary = (length_stop_boundaries or {}).get(source_key)
+            next_prompt = _chat_source_prompt_tokens(sampled_sources[index + 1])
+            boundary_end = (
+                end + len(boundary.tail) + len(boundary.following)
+                if boundary is not None
+                else end
+            )
+            if (
+                retained_ids != output
+                or boundary is None
+                or not boundary.tail
+                or next_prompt is None
+                or len(next_prompt) != boundary_end
+                or final_prompt[end:boundary_end]
+                != [*boundary.tail, *boundary.following]
+            ):
+                # Without a later exact prompt containing the complete sampled
+                # output and renderer-proven boundary, render the stop.
+                return None
+            tail_end = end + len(boundary.tail)
+            flags[end:tail_end] = [TokenFlag.EXACT | TokenFlag.ASSISTANT] * len(
+                boundary.tail
+            )
+            flags[tail_end - 1] = TokenFlag.EXACT | TokenFlag.STOP
         source_keys[start:end] = [source_key] * len(retained_ids)
         sources[source_key] = source
     if history.model is None:
@@ -4968,6 +5042,86 @@ def _tokenize_chat_view(
                 continue
             if span := differing_span(probe):
                 probed_bounds[message_index] = span
+
+    if (
+        _projection_matches is True
+        and chat_template is None
+        and chat_template_kwargs is None
+        and not _history_needs_synthetic_stop(history, resolved_tokenizer)
+    ):
+        sampled_message_indices: list[int] = []
+        seen_signatures: set[tuple[object, ...]] = set()
+        for message_index, (message, source) in enumerate(
+            zip(messages, history.message_sources, strict=True)
+        ):
+            signature = _source_signature(source)
+            if (
+                message.get("role") == "assistant"
+                and source is not None
+                and signature is not None
+                and signature not in seen_signatures
+                and _source_is_sampled(source)
+            ):
+                seen_signatures.add(signature)
+                sampled_message_indices.append(message_index)
+        length_stop_boundaries: dict[
+            _SampledSourceKey, _RenderedLengthStopBoundary
+        ] = {}
+        length_stop_count = 0
+        for position, message_index in enumerate(sampled_message_indices):
+            source = history.message_sources[message_index]
+            assert source is not None
+            source_key = _sampled_source_key(source)
+            if _source_stop_evidence(source, source_key)[0] != "length":
+                continue
+            length_stop_count += 1
+            if position + 1 >= len(sampled_message_indices):
+                break
+            next_message_index = sampled_message_indices[position + 1]
+            bounds = (
+                direct_bounds[message_index]
+                if direct_bounds
+                else marked_bounds.get(message_index)
+                or probed_bounds.get(message_index)
+            )
+            next_bounds = (
+                direct_bounds[next_message_index]
+                if direct_bounds
+                else marked_bounds.get(next_message_index)
+                or probed_bounds.get(next_message_index)
+            )
+            boundary = (
+                _rendered_length_stop_boundary(
+                    rendered,
+                    assistant_mask,
+                    stop_mask,
+                    content_end=bounds[1],
+                    next_prompt_end=next_bounds[0],
+                )
+                if (
+                    bounds is not None
+                    and source_matches_context(source)
+                    and next_bounds is not None
+                )
+                else None
+            )
+            if boundary is None:
+                break
+            length_stop_boundaries[source_key] = boundary
+        if (
+            length_stop_count
+            and len(length_stop_boundaries) == length_stop_count
+            and (
+                exact := _tokenize_exact_projected_chat_history(
+                    history,
+                    tokenizer=resolved_tokenizer,
+                    length_stop_boundaries=length_stop_boundaries,
+                    projection_validated=True,
+                    _trace=_trace,
+                )
+            )
+        ):
+            return exact
 
     sampled_message_count = sum(
         message.get("role") == "assistant"

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -27,6 +27,7 @@ import art
 import art.trajectories as tr
 from art.trajectories import (
     ChatCompletionsExchange,
+    ChatCompletionsHistory,
     ChatCompletionsMessageSource,
     ChatCompletionsRequest,
     CompletionsExchange,
@@ -292,6 +293,82 @@ class _BoundaryTokenizer(_StopTokenizer):
         )
 
 
+class _CharacterTemplateTokenizer:
+    eos_token_id = 9
+    unk_token_id = 0
+    all_special_tokens = ["§"]
+    special_tokens_map = {"eos_token": "§"}
+
+    @staticmethod
+    def _encode(text: str) -> list[int]:
+        return [9 if character == "§" else ord(character) + 100 for character in text]
+
+    def __call__(self, text: str, **kwargs: object) -> dict[str, object]:
+        result: dict[str, object] = {"input_ids": self._encode(text)}
+        if kwargs.get("return_offsets_mapping"):
+            result["offset_mapping"] = [
+                (index, index + 1) for index in range(len(text))
+            ]
+        return result
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        return 9 if token == "§" else 0
+
+    def decode(self, token_ids: list[int], **kwargs: object) -> str:
+        del kwargs
+        return "".join(
+            "§" if token == 9 else "a" if token >= 7000 else chr(token - 100)
+            for token in token_ids
+        )
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tokenize: bool = True,
+        add_generation_prompt: bool,
+        **kwargs: object,
+    ) -> str | list[int]:
+        del add_generation_prompt, kwargs
+        text = "".join(
+            str(message.get("content") or "")
+            + ("§" if message.get("role") == "assistant" else "")
+            for message in messages
+        )
+        return self._encode(text) if tokenize else text
+
+
+def _character_template_history(
+    *,
+    following_user: str = "turn 2",
+    omit_length_tail: bool = False,
+) -> tuple[ChatCompletionsHistory, _CharacterTemplateTokenizer, list[int]]:
+    tokenizer = _CharacterTemplateTokenizer()
+    answer = tokenizer._encode("answer")
+    first_prompt = tokenizer._encode("turn 0")
+    first_output = [7001, *answer[1:], 9]
+    second_prompt = [*first_prompt, *first_output, *tokenizer._encode("turn 1")]
+    second_output = [7002, *answer[1:]]
+    third_prompt = [
+        *second_prompt,
+        *second_output,
+        *([] if omit_length_tail else [9]),
+        *tokenizer._encode(following_user),
+    ]
+    third_output = [*answer, 9]
+
+    first = _chat_exchange(first_prompt, first_output)
+    second = _chat_exchange(second_prompt, second_output, offset=1)
+    second.response.choices[0].finish_reason = "length"
+    third = _chat_exchange(third_prompt, third_output, offset=2)
+    if following_user != "turn 2":
+        third.request["messages"][-1] = {"role": "user", "content": following_user}
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second, third])
+    ).chat_completions_history()
+    return history, tokenizer, [*third_prompt, *third_output]
+
+
 def test_exact_sampled_eos_is_stop_when_tokenizer_identifies_it() -> None:
     exchange = _chat_exchange([1], [2, 9])
 
@@ -510,6 +587,164 @@ def test_exact_output_boundaries_survive_prefix_order_drift_and_length_stop() ->
         match="Could not prove a sampled history message boundary",
     ):
         history.tokenize(tokenizer=tokenizer, chat_template="explicit override")
+
+
+def test_public_exact_chain_preserves_raw_drift_across_proven_length_boundary() -> None:
+    history, tokenizer, expected = _character_template_history()
+
+    tokenized = history.tokenize(tokenizer=tokenizer)
+
+    assert tokenized.tokens == expected
+    assert 7001 in tokenized.tokens
+    length_start = tokenized.tokens.index(7002)
+    tail = length_start + len("answer")
+    assert tokenized.flags[tail] == tr.TokenFlag.EXACT | tr.TokenFlag.STOP
+    assert not tokenized.flags[tail] & tr.TokenFlag.SAMPLED
+
+
+def test_public_exact_chain_rejects_user_token_colliding_with_missing_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "art.trajectories._tokenize._WARNED_PREFIX_RETOKENIZATION", False
+    )
+    history, tokenizer, authoritative = _character_template_history(
+        following_user="§turn 2",
+        omit_length_tail=True,
+    )
+
+    with pytest.warns(UserWarning, match="retokenized an earlier sampled response"):
+        tokenized = history.tokenize(tokenizer=tokenizer)
+
+    assert tokenized.tokens != authoritative
+    length_start = tokenized.tokens.index(7002)
+    boundary = length_start + len("answer")
+    assert tokenized.tokens[boundary : boundary + 2] == [9, 9]
+    assert not tokenized.flags[boundary] & tr.TokenFlag.ASSISTANT
+    assert tokenized.flags[boundary] & tr.TokenFlag.STOP
+    assert not tokenized.flags[boundary + 1] & tr.TokenFlag.ASSISTANT
+    assert not tokenized.flags[boundary + 1] & tr.TokenFlag.STOP
+
+
+def test_exact_chain_preserves_raw_output_across_proven_length_tail() -> None:
+    first = _chat_exchange([1], [2, 7, 9])
+    second = _chat_exchange([1, 2, 7, 9, 3], [4], offset=1)
+    second.response.choices[0].finish_reason = "length"
+    third = _chat_exchange([1, 2, 7, 9, 3, 4, 8, 9, 5], [6, 9], offset=2)
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second, third])
+    ).chat_completions_history()
+    from art.trajectories._tokenize import (
+        _RenderedLengthStopBoundary,
+        _sampled_source_key,
+        _tokenize_exact_projected_chat_history,
+    )
+
+    length_source = history.message_sources[3]
+    assert length_source is not None
+    tokenized = _tokenize_exact_projected_chat_history(
+        history,
+        tokenizer=_StopTokenizer(),
+        length_stop_boundaries={
+            _sampled_source_key(length_source): _RenderedLengthStopBoundary(
+                tail=(8, 9), following=(5,)
+            )
+        },
+        projection_validated=True,
+    )
+
+    assert tokenized is not None
+    assert tokenized.tokens == [1, 2, 7, 9, 3, 4, 8, 9, 5, 6, 9]
+    assert [
+        index for index, flag in enumerate(tokenized.flags) if flag & tr.TokenFlag.STOP
+    ] == [3, 7, 10]
+    assert tokenized.flags[6:8] == [
+        tr.TokenFlag.EXACT | tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.EXACT | tr.TokenFlag.STOP,
+    ]
+    assert not any(flag & tr.TokenFlag.SAMPLED for flag in tokenized.flags[6:8])
+
+
+def test_exact_chain_declines_unrecognized_or_mismatched_length_boundary() -> None:
+    first = _chat_exchange([1], [2])
+    first.response.choices[0].finish_reason = "length"
+    second = _chat_exchange([1, 2, 8, 9, 3], [4, 9], offset=1)
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second])
+    ).chat_completions_history()
+    from art.trajectories._tokenize import (
+        _RenderedLengthStopBoundary,
+        _sampled_source_key,
+        _tokenize_exact_projected_chat_history,
+    )
+
+    length_source = history.message_sources[1]
+    assert length_source is not None
+    tokenizer = _StopTokenizer()
+    assert (
+        _tokenize_exact_projected_chat_history(
+            history,
+            tokenizer=tokenizer,
+            projection_validated=True,
+        )
+        is None
+    )
+    assert (
+        _tokenize_exact_projected_chat_history(
+            history,
+            tokenizer=tokenizer,
+            length_stop_boundaries={
+                _sampled_source_key(length_source): _RenderedLengthStopBoundary(
+                    tail=(7, 9), following=(3,)
+                )
+            },
+            projection_validated=True,
+        )
+        is None
+    )
+
+
+def test_rendered_length_stop_boundary_requires_unique_assistant_terminal_stop() -> (
+    None
+):
+    from art.trajectories._tokenize import (
+        _rendered_length_stop_boundary,
+        _RenderedLengthStopBoundary,
+    )
+
+    tokens = [1, 2, 8, 9, 3]
+    assistant_mask = [False, True, True, True, False]
+    stop_mask = [False, False, False, True, False]
+    assert _rendered_length_stop_boundary(
+        tokens,
+        assistant_mask,
+        stop_mask,
+        content_end=2,
+        next_prompt_end=5,
+    ) == _RenderedLengthStopBoundary(tail=(8, 9), following=(3,))
+
+    # A special token belonging to the following user turn cannot certify an
+    # assistant stop, even when it is a tokenizer terminator.
+    assert (
+        _rendered_length_stop_boundary(
+            tokens,
+            [False, True, True, False, False],
+            stop_mask,
+            content_end=2,
+            next_prompt_end=5,
+        )
+        is None
+    )
+    assert (
+        _rendered_length_stop_boundary(
+            tokens,
+            assistant_mask,
+            [False, False, True, True, False],
+            content_end=2,
+            next_prompt_end=5,
+        )
+        is None
+    )
 
 
 def test_exact_output_boundary_after_sampled_tool_call() -> None:

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -665,6 +665,51 @@ def test_exact_chain_preserves_raw_output_across_proven_length_tail() -> None:
     assert not any(flag & tr.TokenFlag.SAMPLED for flag in tokenized.flags[6:8])
 
 
+def test_exact_chain_appends_renderer_owned_terminal_length_tail() -> None:
+    first = _chat_exchange([1], [2])
+    first.response.choices[0].finish_reason = "length"
+    second = _chat_exchange([1, 2, 7, 9, 3], [4], offset=1)
+    second.response.choices[0].finish_reason = "length"
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second])
+    ).chat_completions_history()
+    from art.trajectories._tokenize import (
+        _RenderedLengthStopBoundary,
+        _sampled_source_key,
+        _tokenize_exact_projected_chat_history,
+    )
+
+    first_source = history.message_sources[1]
+    final_source = history.message_sources[3]
+    assert first_source is not None
+    assert final_source is not None
+    tokenized = _tokenize_exact_projected_chat_history(
+        history,
+        tokenizer=_StopTokenizer(),
+        length_stop_boundaries={
+            _sampled_source_key(first_source): _RenderedLengthStopBoundary(
+                tail=(7, 9), following=(3,)
+            ),
+            _sampled_source_key(final_source): _RenderedLengthStopBoundary(
+                tail=(8, 9), following=()
+            ),
+        },
+        projection_validated=True,
+    )
+
+    assert tokenized is not None
+    assert tokenized.tokens == [1, 2, 7, 9, 3, 4, 8, 9]
+    assert tokenized.flags[2:4] == [
+        tr.TokenFlag.EXACT | tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.EXACT | tr.TokenFlag.STOP,
+    ]
+    assert tokenized.flags[-2:] == [
+        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.STOP,
+    ]
+    assert not any(flag & tr.TokenFlag.SAMPLED for flag in tokenized.flags[-2:])
+
+
 def test_exact_chain_declines_unrecognized_or_mismatched_length_boundary() -> None:
     first = _chat_exchange([1], [2])
     first.response.choices[0].finish_reason = "length"
@@ -708,6 +753,7 @@ def test_rendered_length_stop_boundary_requires_unique_assistant_terminal_stop()
     None
 ):
     from art.trajectories._tokenize import (
+        _next_assistant_span_start,
         _rendered_length_stop_boundary,
         _RenderedLengthStopBoundary,
     )
@@ -722,6 +768,16 @@ def test_rendered_length_stop_boundary_requires_unique_assistant_terminal_stop()
         content_end=2,
         next_prompt_end=5,
     ) == _RenderedLengthStopBoundary(tail=(8, 9), following=(3,))
+    assert (
+        _next_assistant_span_start(
+            [False, True, True, True, False, False, True, True], after=2
+        )
+        == 6
+    )
+    assert (
+        _next_assistant_span_start([False, True, True, True, False, False], after=2)
+        is None
+    )
 
     # A special token belonging to the following user turn cannot certify an
     # assistant stop, even when it is a tokenizer terminator.


### PR DESCRIPTION
## Summary

- admit exact projected chat histories across nonterminal length-limited responses only when the renderer proves a unique assistant stop boundary
- verify the complete renderer-owned suffix through the next sampled generation boundary against the next authoritative prompt, preventing cross-role stop-token collisions
- keep terminal, ambiguous, context-changed, explicitly overridden, or otherwise unproven histories on the existing renderer fallback
- rebase onto current `main`, including #830's length-stop provenance semantics

## Provenance semantics

The fully retained raw sampled output remains exact, sampled, and assistant-owned. Preceding non-stop renderer-tail tokens are exact, assistant-owned, and unsampled. The unique template-added terminal boundary token is exactly `EXACT | STOP`, without `ASSISTANT`, matching #830.

## Verification

- `216 passed`: full `tests/unit/trajectories/test_tokenize.py` with the Torch-enabled ART environment
- `211 passed, 5 deselected`: the same focused tokenizer file in the lightweight environment
- `408 passed`: current post-rebase `tests/unit/trajectories` suite
- `1026 passed, 33 skipped`: broad feasible unit suite before the final rebase (optional Megatron/Transformer Engine/Unsloth runtime files excluded locally)
- Ruff format/check, Ty, prek, and `git diff --check` pass
- the post-#830 reviewer blocker is resolved by assigning the terminal renderer-tail token exactly `EXACT | STOP`; all three stale expectations are updated
- independent blocker review: otherwise clean after fixing an omitted-tail/following-user-token collision
- replayed all three captured Qwen3.5-4B histories as the exact final authoritative prompt plus final output:
  - 12,145 tokens / 4,566 sampled / 3 stops
  - 14,678 tokens / 7,027 sampled / 5 stops
  - 30,601 tokens / 22,594 sampled / 9 stops

## Regression coverage

- public raw-token drift across a proven nonterminal length boundary
- omitted assistant boundary colliding with an identical following user special token
- multi-token renderer tails, ambiguous stops, mismatched tails, terminal length fallback, and explicit template override fallback
