### PR TITLE
Add adaptive collection tokenization and tensorization

### DIFF
--- a/src/art/__init__.py
+++ b/src/art/__init__.py
@@ -76,6 +76,8 @@ from .trajectories import (
     TrajectoryGroup,
     current_trajectory,
     no_capture,
+    tensorize,
+    tokenize,
     trajectory,
     trajectory_group,
 )
@@ -128,6 +130,8 @@ __all__ = [
     "TrainResult",
     "Trajectory",
     "TrajectoryGroup",
+    "tokenize",
+    "tensorize",
     "trajectory",
     "trajectory_group",
     "capture_yielded_trajectory",

--- a/src/art/trajectories/__init__.py
+++ b/src/art/trajectories/__init__.py
@@ -23,6 +23,7 @@ from typing import (
     TypeAlias,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
@@ -1388,6 +1389,206 @@ async def trajectory_group(
     )
 
 
+@overload
+async def tokenize(
+    items: Iterable[Trajectory],
+    *,
+    multi_history: Literal[False] = False,
+    reconcile_text_equivalent_tokenizations: bool = False,
+    model: str | None = None,
+    base_model: str | None = None,
+    tokenizer: Tokenizer | None = None,
+    chat_template: str | None = None,
+    chat_template_kwargs: Mapping[str, object] | None = None,
+) -> list[TokenizedTrajectory]: ...
+
+
+@overload
+async def tokenize(
+    items: Iterable[Trajectory],
+    *,
+    multi_history: Literal[True],
+    reconcile_text_equivalent_tokenizations: bool = False,
+    model: str | None = None,
+    base_model: str | None = None,
+    tokenizer: Tokenizer | None = None,
+    chat_template: str | None = None,
+    chat_template_kwargs: Mapping[str, object] | None = None,
+) -> list[TokenizedMultiHistoryTrajectory]: ...
+
+
+@overload
+async def tokenize(
+    items: Iterable[TrajectoryGroup],
+    *,
+    multi_history: Literal[False] = False,
+    reconcile_text_equivalent_tokenizations: bool = False,
+    model: str | None = None,
+    base_model: str | None = None,
+    tokenizer: Tokenizer | None = None,
+    chat_template: str | None = None,
+    chat_template_kwargs: Mapping[str, object] | None = None,
+) -> list[TokenizedTrajectoryGroup[TokenizedTrajectory]]: ...
+
+
+@overload
+async def tokenize(
+    items: Iterable[TrajectoryGroup],
+    *,
+    multi_history: Literal[True],
+    reconcile_text_equivalent_tokenizations: bool = False,
+    model: str | None = None,
+    base_model: str | None = None,
+    tokenizer: Tokenizer | None = None,
+    chat_template: str | None = None,
+    chat_template_kwargs: Mapping[str, object] | None = None,
+) -> list[TokenizedTrajectoryGroup[TokenizedMultiHistoryTrajectory]]: ...
+
+
+async def tokenize(
+    items: Iterable[Trajectory] | Iterable[TrajectoryGroup],
+    *,
+    multi_history: bool = False,
+    reconcile_text_equivalent_tokenizations: bool = False,
+    model: str | None = None,
+    base_model: str | None = None,
+    tokenizer: Tokenizer | None = None,
+    chat_template: str | None = None,
+    chat_template_kwargs: Mapping[str, object] | None = None,
+) -> (
+    list[TokenizedTrajectory]
+    | list[TokenizedMultiHistoryTrajectory]
+    | list[TokenizedTrajectoryGroup[TokenizedTrajectory]]
+    | list[TokenizedTrajectoryGroup[TokenizedMultiHistoryTrajectory]]
+):
+    """Tokenize trajectories concurrently using an automatically sized CPU pool.
+
+    ``items`` must be a homogeneous iterable of trajectories or trajectory groups.
+    Results preserve input order and group metadata. All remaining arguments are
+    forwarded to :meth:`Trajectory.tokenize`.
+    """
+
+    from ._parallel import transform
+
+    return cast(
+        Any,
+        await transform(
+            items,
+            operation="tokenize",
+            multi_history=multi_history,
+            reconcile_text_equivalent_tokenizations=reconcile_text_equivalent_tokenizations,
+            model=model,
+            base_model=base_model,
+            tokenizer=tokenizer,
+            chat_template=chat_template,
+            chat_template_kwargs=chat_template_kwargs,
+        ),
+    )
+
+
+@overload
+async def tensorize(
+    items: Iterable[Trajectory],
+    *,
+    multi_history: Literal[False] = False,
+    reconcile_text_equivalent_tokenizations: bool = False,
+    model: str | None = None,
+    base_model: str | None = None,
+    tokenizer: Tokenizer | None = None,
+    chat_template: str | None = None,
+    chat_template_kwargs: Mapping[str, object] | None = None,
+    device: torch.device | str | None = None,
+) -> list[TensorizedTrajectory]: ...
+
+
+@overload
+async def tensorize(
+    items: Iterable[Trajectory],
+    *,
+    multi_history: Literal[True],
+    reconcile_text_equivalent_tokenizations: bool = False,
+    model: str | None = None,
+    base_model: str | None = None,
+    tokenizer: Tokenizer | None = None,
+    chat_template: str | None = None,
+    chat_template_kwargs: Mapping[str, object] | None = None,
+    device: torch.device | str | None = None,
+) -> list[TensorizedMultiHistoryTrajectory]: ...
+
+
+@overload
+async def tensorize(
+    items: Iterable[TrajectoryGroup],
+    *,
+    multi_history: Literal[False] = False,
+    reconcile_text_equivalent_tokenizations: bool = False,
+    model: str | None = None,
+    base_model: str | None = None,
+    tokenizer: Tokenizer | None = None,
+    chat_template: str | None = None,
+    chat_template_kwargs: Mapping[str, object] | None = None,
+    device: torch.device | str | None = None,
+) -> list[TensorizedTrajectoryGroup[TensorizedTrajectory]]: ...
+
+
+@overload
+async def tensorize(
+    items: Iterable[TrajectoryGroup],
+    *,
+    multi_history: Literal[True],
+    reconcile_text_equivalent_tokenizations: bool = False,
+    model: str | None = None,
+    base_model: str | None = None,
+    tokenizer: Tokenizer | None = None,
+    chat_template: str | None = None,
+    chat_template_kwargs: Mapping[str, object] | None = None,
+    device: torch.device | str | None = None,
+) -> list[TensorizedTrajectoryGroup[TensorizedMultiHistoryTrajectory]]: ...
+
+
+async def tensorize(
+    items: Iterable[Trajectory] | Iterable[TrajectoryGroup],
+    *,
+    multi_history: bool = False,
+    reconcile_text_equivalent_tokenizations: bool = False,
+    model: str | None = None,
+    base_model: str | None = None,
+    tokenizer: Tokenizer | None = None,
+    chat_template: str | None = None,
+    chat_template_kwargs: Mapping[str, object] | None = None,
+    device: torch.device | str | None = None,
+) -> (
+    list[TensorizedTrajectory]
+    | list[TensorizedMultiHistoryTrajectory]
+    | list[TensorizedTrajectoryGroup[TensorizedTrajectory]]
+    | list[TensorizedTrajectoryGroup[TensorizedMultiHistoryTrajectory]]
+):
+    """Tokenize and tensorize trajectories using an automatically sized CPU pool.
+
+    ``items`` must be a homogeneous iterable of trajectories or trajectory groups.
+    CPU tensorization runs in the pool; completed tensors are then moved to
+    ``device`` while preserving input order and group metadata.
+    """
+
+    from ._parallel import transform
+
+    return cast(
+        Any,
+        await transform(
+            items,
+            operation="tensorize",
+            multi_history=multi_history,
+            reconcile_text_equivalent_tokenizations=reconcile_text_equivalent_tokenizations,
+            model=model,
+            base_model=base_model,
+            tokenizer=tokenizer,
+            chat_template=chat_template,
+            chat_template_kwargs=chat_template_kwargs,
+            device=device,
+        ),
+    )
+
+
 def get_messages(messages_and_choices: MessagesAndChoices) -> Messages:
     from ._compat import messages_from_legacy_history
 
@@ -1475,5 +1676,7 @@ __all__ = [
     "no_capture",
     "trajectory",
     "trajectory_group",
+    "tokenize",
+    "tensorize",
     "get_messages",
 ]

--- a/src/art/trajectories/_parallel.py
+++ b/src/art/trajectories/_parallel.py
@@ -1,27 +1,40 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Iterable, Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass, field
 from functools import lru_cache
 import math
+import multiprocessing
 import os
 from pathlib import Path
+import pickle
+import sys
 import threading
 import time
+from types import ModuleType
 from typing import Any, Literal, TypeVar, cast
+import warnings
 
 from . import (
+    TokenizedMultiHistoryTrajectory,
+    TokenizedTrajectory,
     TokenizedTrajectoryGroup,
     Tokenizer,
     Trajectory,
     TrajectoryGroup,
 )
+from ._serialization import _rebind_history_sources, _without_pickle_string_interning
 
 _ResultT = TypeVar("_ResultT")
+_ValueT = TypeVar("_ValueT")
 _InputKind = Literal["trajectory", "group"]
 _Operation = Literal["tokenize", "tensorize"]
+_PROCESS_MAX_WORKERS = 4
+_PROCESS_MIN_ITEMS = 4
+_PROCESS_MIN_THREAD_SECONDS = 1.0
 
 
 def _cgroup_cpu_limit() -> int | None:
@@ -72,10 +85,118 @@ def _executor(capacity: int) -> ThreadPoolExecutor:
         return _EXECUTOR
 
 
+_PROCESS_EXECUTOR_LOCK = threading.Lock()
+_PROCESS_EXECUTOR: ProcessPoolExecutor | None = None
+_PROCESS_EXECUTOR_PID: int | None = None
+_PROCESS_EXECUTOR_CAPACITY = 0
+_PROCESS_STARTUP: tuple[Future[int], ...] = ()
+_PROCESS_BACKEND_DISABLED = False
+
+
+def _process_context() -> multiprocessing.context.BaseContext:
+    return multiprocessing.get_context("spawn")
+
+
+def _process_identity() -> int:
+    # Keep every submitted warmup occupied until the bounded pool is started.
+    time.sleep(0.25)
+    return os.getpid()
+
+
+def _submit_process_warmup(
+    executor: ProcessPoolExecutor, capacity: int
+) -> tuple[Future[int], ...]:
+    original_main = sys.modules.get("__main__")
+    sys.modules["__main__"] = ModuleType("__main__")
+    try:
+        return tuple(executor.submit(_process_identity) for _ in range(capacity))
+    finally:
+        if original_main is None:
+            del sys.modules["__main__"]
+        else:
+            sys.modules["__main__"] = original_main
+
+
+def _finish_process_warmup(futures: tuple[Future[int], ...], capacity: int) -> None:
+    if not futures:
+        return
+    worker_pids = {future.result() for future in futures}
+    if len(worker_pids) != capacity:
+        raise RuntimeError(
+            f"started {len(worker_pids)} process workers, expected {capacity}"
+        )
+
+
+def _start_process_executor(
+    capacity: int,
+) -> tuple[ProcessPoolExecutor, int, tuple[Future[int], ...]]:
+    global _PROCESS_EXECUTOR, _PROCESS_EXECUTOR_CAPACITY, _PROCESS_EXECUTOR_PID
+    global _PROCESS_STARTUP
+    process_capacity = min(_PROCESS_MAX_WORKERS, capacity)
+    pid = os.getpid()
+    with _PROCESS_EXECUTOR_LOCK:
+        if (
+            _PROCESS_EXECUTOR is None
+            or _PROCESS_EXECUTOR_PID != pid
+            or _PROCESS_EXECUTOR_CAPACITY < process_capacity
+        ):
+            previous = _PROCESS_EXECUTOR if _PROCESS_EXECUTOR_PID == pid else None
+            executor = ProcessPoolExecutor(
+                max_workers=process_capacity,
+                mp_context=_process_context(),
+            )
+            try:
+                startup = _submit_process_warmup(executor, process_capacity)
+            except BaseException:
+                executor.shutdown(wait=False, cancel_futures=True)
+                raise
+            _PROCESS_EXECUTOR = executor
+            _PROCESS_EXECUTOR_PID = pid
+            _PROCESS_EXECUTOR_CAPACITY = process_capacity
+            _PROCESS_STARTUP = startup
+            if previous is not None:
+                previous.shutdown(wait=False, cancel_futures=True)
+        return (
+            _PROCESS_EXECUTOR,
+            _PROCESS_EXECUTOR_CAPACITY,
+            _PROCESS_STARTUP,
+        )
+
+
+def _complete_process_warmup(
+    executor: ProcessPoolExecutor, startup: tuple[Future[int], ...]
+) -> None:
+    global _PROCESS_STARTUP
+    with _PROCESS_EXECUTOR_LOCK:
+        if _PROCESS_EXECUTOR is executor and _PROCESS_STARTUP is startup:
+            _PROCESS_STARTUP = ()
+
+
+def _process_executor(capacity: int) -> ProcessPoolExecutor:
+    executor, process_capacity, startup = _start_process_executor(capacity)
+    _finish_process_warmup(startup, process_capacity)
+    _complete_process_warmup(executor, startup)
+    return executor
+
+
+def _discard_process_executor() -> None:
+    global _PROCESS_EXECUTOR, _PROCESS_EXECUTOR_CAPACITY, _PROCESS_EXECUTOR_PID
+    global _PROCESS_STARTUP
+    with _PROCESS_EXECUTOR_LOCK:
+        previous = _PROCESS_EXECUTOR
+        _PROCESS_EXECUTOR = None
+        _PROCESS_EXECUTOR_PID = None
+        _PROCESS_EXECUTOR_CAPACITY = 0
+        _PROCESS_STARTUP = ()
+        if previous is not None:
+            previous.shutdown(wait=False, cancel_futures=True)
+
+
 @dataclass
 class _Measurement:
     units: int = 0
     seconds: float = 0
+    samples: int = 0
 
     @property
     def rate(self) -> float:
@@ -92,8 +213,20 @@ _TUNING_LOCK = threading.Lock()
 
 
 @lru_cache(maxsize=128)
-def _tuning_state(key: tuple[object, ...], initial_workers: int) -> _TuningState:
-    return _TuningState(initial_workers)
+def _tuning_state(key: tuple[object, ...]) -> _TuningState:
+    return _TuningState(4)
+
+
+@dataclass
+class _ProcessTuningState(_TuningState):
+    warmed: bool = False
+    candidate: bool = False
+    disabled: bool = False
+
+
+@lru_cache(maxsize=128)
+def _process_tuning_state(key: tuple[object, ...]) -> _ProcessTuningState:
+    return _ProcessTuningState(_PROCESS_MAX_WORKERS)
 
 
 def _size_bucket(size: int) -> int:
@@ -147,9 +280,8 @@ def _tuning_key(
 
 
 def _workers(key: tuple[object, ...], *, capacity: int, size: int) -> int:
-    initial = min(4, capacity, size)
     with _TUNING_LOCK:
-        state = _tuning_state(key, initial)
+        state = _tuning_state(key)
         return max(1, min(state.next_workers, capacity, size))
 
 
@@ -164,12 +296,12 @@ def _observe(
 ) -> None:
     if units <= 0 or elapsed <= 0:
         return
-    initial = min(4, capacity, size)
     with _TUNING_LOCK:
-        state = _tuning_state(key, initial)
+        state = _tuning_state(key)
         measurement = state.measurements.setdefault(workers, _Measurement())
         measurement.units += units
         measurement.seconds += elapsed
+        measurement.samples += 1
         limit = min(capacity, size)
 
         smaller = [value for value in state.measurements if value < workers]
@@ -196,9 +328,117 @@ def _observe(
         )
 
 
+def _process_workers(key: tuple[object, ...], *, capacity: int, size: int) -> int:
+    limit = min(_PROCESS_MAX_WORKERS, capacity, size)
+    with _TUNING_LOCK:
+        state = _process_tuning_state(key)
+        return max(1, min(state.next_workers, limit))
+
+
+def _observe_process(
+    key: tuple[object, ...],
+    *,
+    workers: int,
+    capacity: int,
+    size: int,
+    units: int,
+    elapsed: float,
+) -> None:
+    if units <= 0 or elapsed <= 0:
+        return
+    limit = min(_PROCESS_MAX_WORKERS, capacity, size)
+    with _TUNING_LOCK:
+        state = _process_tuning_state(key)
+        if not state.warmed:
+            # Spawning workers and loading their tokenizers is a one-time cost, not
+            # evidence about the steady-state worker width.
+            state.warmed = True
+            return
+        measurement = state.measurements.setdefault(workers, _Measurement())
+        measurement.units += units
+        measurement.seconds += elapsed
+        measurement.samples += 1
+
+        if measurement.samples < 2:
+            state.next_workers = workers
+            return
+
+        thread_state = _tuning_state(key)
+        if thread_state.measurements:
+            process_peak = max(value.rate for value in state.measurements.values())
+            thread_peak = max(
+                value.rate for value in thread_state.measurements.values()
+            )
+            if process_peak < thread_peak * 1.05:
+                state.disabled = True
+                return
+
+        probe = min(2, limit)
+        if workers > probe and probe not in state.measurements:
+            state.next_workers = probe
+            return
+
+        peak = max(value.rate for value in state.measurements.values())
+        efficient = min(
+            width
+            for width, value in state.measurements.items()
+            if value.rate >= peak * 0.95
+        )
+        state.next_workers = efficient
+
+
+def _consider_processes(key: tuple[object, ...], *, elapsed: float) -> None:
+    with _TUNING_LOCK:
+        state = _process_tuning_state(key)
+        thread_state = _tuning_state(key)
+        thread_samples = sum(
+            measurement.samples for measurement in thread_state.measurements.values()
+        )
+        if elapsed >= _PROCESS_MIN_THREAD_SECONDS and thread_samples >= 2:
+            state.candidate = True
+
+
+def _processes_enabled(key: tuple[object, ...]) -> bool:
+    with _TUNING_LOCK:
+        state = _process_tuning_state(key)
+        return state.candidate and not state.disabled
+
+
+def _disable_processes(
+    key: tuple[object, ...],
+    *,
+    reason: BaseException,
+) -> None:
+    with _TUNING_LOCK:
+        state = _process_tuning_state(key)
+        if state.disabled:
+            return
+        state.disabled = True
+    warnings.warn(
+        f"ART process tokenization is unavailable for this workload; using threads: "
+        f"{type(reason).__name__}: {reason}",
+        RuntimeWarning,
+        stacklevel=4,
+    )
+
+
+def _disable_process_backend(reason: BaseException) -> None:
+    global _PROCESS_BACKEND_DISABLED
+    with _PROCESS_EXECUTOR_LOCK:
+        if _PROCESS_BACKEND_DISABLED:
+            return
+        _PROCESS_BACKEND_DISABLED = True
+    warnings.warn(
+        f"ART process tokenization is unavailable; using threads: "
+        f"{type(reason).__name__}: {reason}",
+        RuntimeWarning,
+        stacklevel=4,
+    )
+
+
 async def _ordered_map(
-    function: Callable[[Trajectory], _ResultT],
-    values: Sequence[Trajectory],
+    function: Callable[[_ValueT], _ResultT],
+    values: Sequence[_ValueT],
     *,
     workers: int,
     capacity: int,
@@ -207,11 +447,183 @@ async def _ordered_map(
     executor = _executor(capacity)
     semaphore = asyncio.Semaphore(workers)
 
-    async def invoke(value: Trajectory) -> _ResultT:
+    async def invoke(value: _ValueT) -> _ResultT:
         async with semaphore:
             return await loop.run_in_executor(executor, function, value)
 
-    return list(await asyncio.gather(*(invoke(value) for value in values)))
+    return await _gather_cancel_on_error(invoke(value) for value in values)
+
+
+async def _gather_cancel_on_error(
+    awaitables: Iterable[Awaitable[_ResultT]],
+) -> list[_ResultT]:
+    tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
+    try:
+        return list(await asyncio.gather(*tasks))
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+
+@dataclass(frozen=True)
+class _ProcessOptions:
+    multi_history: bool
+    reconcile_text_equivalent_tokenizations: bool
+    model: str | None
+    base_model: str | None
+    chat_template: str | None
+    chat_template_kwargs: Mapping[str, object] | None
+
+
+class _ProcessTransferError(RuntimeError):
+    pass
+
+
+class _ProcessBackendError(RuntimeError):
+    pass
+
+
+def _tokenize_process_payload(payload: bytes) -> bytes:
+    try:
+        trajectory, options = cast(
+            tuple[Trajectory, _ProcessOptions], pickle.loads(payload)
+        )
+    except Exception as error:
+        raise _ProcessTransferError(
+            f"could not deserialize process input: {type(error).__name__}: {error}"
+        ) from None
+    tokenized = trajectory.tokenize(
+        multi_history=options.multi_history,
+        reconcile_text_equivalent_tokenizations=(
+            options.reconcile_text_equivalent_tokenizations
+        ),
+        model=options.model,
+        base_model=options.base_model,
+        tokenizer=None,
+        chat_template=options.chat_template,
+        chat_template_kwargs=options.chat_template_kwargs,
+    )
+    try:
+        return pickle.dumps(tokenized, protocol=pickle.HIGHEST_PROTOCOL)
+    except Exception as error:
+        raise _ProcessTransferError(
+            f"could not serialize {type(tokenized).__name__}: "
+            f"{type(error).__name__}: {error}"
+        ) from None
+
+
+def _process_payloads(
+    values: Sequence[Trajectory], options: _ProcessOptions
+) -> list[bytes]:
+    try:
+        with _without_pickle_string_interning():
+            return [
+                pickle.dumps((value, options), protocol=pickle.HIGHEST_PROTOCOL)
+                for value in values
+            ]
+    except Exception as error:
+        raise _ProcessTransferError(
+            f"could not serialize process input: {type(error).__name__}: {error}"
+        ) from None
+
+
+async def _ordered_process_map(
+    payloads: Sequence[bytes],
+    trajectories: Sequence[Trajectory],
+    *,
+    workers: int,
+    capacity: int,
+) -> list[TokenizedTrajectory | TokenizedMultiHistoryTrajectory]:
+    loop = asyncio.get_running_loop()
+    thread_executor = _executor(capacity)
+    try:
+        executor, process_capacity, startup = _start_process_executor(capacity)
+        await loop.run_in_executor(
+            thread_executor,
+            _finish_process_warmup,
+            startup,
+            process_capacity,
+        )
+        _complete_process_warmup(executor, startup)
+    except BrokenProcessPool:
+        raise
+    except (OSError, RuntimeError) as error:
+        raise _ProcessBackendError(
+            f"could not start process workers: {type(error).__name__}: {error}"
+        ) from None
+    semaphore = asyncio.Semaphore(workers)
+
+    async def invoke(
+        payload: bytes, trajectory: Trajectory
+    ) -> TokenizedTrajectory | TokenizedMultiHistoryTrajectory:
+        async with semaphore:
+            serialized = await loop.run_in_executor(
+                executor, _tokenize_process_payload, payload
+            )
+            return await loop.run_in_executor(
+                thread_executor,
+                _deserialize_process_result,
+                serialized,
+                trajectory,
+            )
+
+    return await _gather_cancel_on_error(
+        invoke(payload, trajectory)
+        for payload, trajectory in zip(payloads, trajectories, strict=True)
+    )
+
+
+def _supports_processes(
+    *, capacity: int, size: int, tokenizer: Tokenizer | None
+) -> bool:
+    if (
+        _PROCESS_BACKEND_DISABLED
+        or capacity < 2
+        or size < _PROCESS_MIN_ITEMS
+        or tokenizer is not None
+    ):
+        return False
+    if multiprocessing.current_process().daemon:
+        return False
+    return "spawn" in multiprocessing.get_all_start_methods()
+
+
+def _rebind_process_result(
+    result: TokenizedTrajectory | TokenizedMultiHistoryTrajectory,
+    trajectory: Trajectory,
+) -> None:
+    source_trajectory = result.trajectory
+    if isinstance(result, TokenizedTrajectory):
+        _rebind_history_sources(
+            result.history, trajectory, source_trajectory=source_trajectory
+        )
+    else:
+        for history in result.histories:
+            _rebind_history_sources(
+                history.history, trajectory, source_trajectory=source_trajectory
+            )
+    result.trajectory = trajectory
+
+
+def _deserialize_process_result(
+    payload: bytes, trajectory: Trajectory
+) -> TokenizedTrajectory | TokenizedMultiHistoryTrajectory:
+    try:
+        result = pickle.loads(payload)
+        if not isinstance(
+            result, (TokenizedTrajectory, TokenizedMultiHistoryTrajectory)
+        ):
+            raise TypeError(f"unexpected process result {type(result).__name__}")
+        _rebind_process_result(result, trajectory)
+        return result
+    except Exception as error:
+        if isinstance(error, _ProcessTransferError):
+            raise
+        raise _ProcessTransferError(
+            f"could not restore process output: {type(error).__name__}: {error}"
+        ) from None
 
 
 def _result_units(value: object) -> int:
@@ -269,6 +681,7 @@ async def transform(
         )
         return tokenized if operation == "tokenize" else tokenized.tensorize()
 
+    transformed: list[object]
     if leaves:
         capacity = _cpu_capacity()
         key = _tuning_key(
@@ -282,19 +695,84 @@ async def transform(
             chat_template=chat_template,
             capacity=capacity,
         )
-        workers = _workers(key, capacity=capacity, size=len(leaves))
-        started = time.perf_counter()
-        transformed = await _ordered_map(
-            convert, leaves, workers=workers, capacity=capacity
-        )
-        _observe(
-            key,
-            workers=workers,
-            capacity=capacity,
-            size=len(leaves),
-            units=sum(_result_units(value) for value in transformed),
-            elapsed=time.perf_counter() - started,
-        )
+        use_processes = _supports_processes(
+            capacity=capacity, size=len(leaves), tokenizer=tokenizer
+        ) and _processes_enabled(key)
+        if use_processes:
+            options = _ProcessOptions(
+                multi_history=multi_history,
+                reconcile_text_equivalent_tokenizations=(
+                    reconcile_text_equivalent_tokenizations
+                ),
+                model=model,
+                base_model=base_model,
+                chat_template=chat_template,
+                chat_template_kwargs=chat_template_kwargs,
+            )
+            try:
+                workers = _process_workers(key, capacity=capacity, size=len(leaves))
+                started = time.perf_counter()
+                payloads = await asyncio.get_running_loop().run_in_executor(
+                    _executor(capacity), _process_payloads, leaves, options
+                )
+                tokenized = await _ordered_process_map(
+                    payloads,
+                    leaves,
+                    workers=workers,
+                    capacity=capacity,
+                )
+                if operation == "tokenize":
+                    transformed = cast(list[object], tokenized)
+                else:
+                    transformed = cast(
+                        list[object],
+                        await _ordered_map(
+                            lambda result: result.tensorize(),
+                            tokenized,
+                            workers=workers,
+                            capacity=capacity,
+                        ),
+                    )
+                _observe_process(
+                    key,
+                    workers=workers,
+                    capacity=capacity,
+                    size=len(leaves),
+                    units=sum(_result_units(value) for value in transformed),
+                    elapsed=time.perf_counter() - started,
+                )
+            except (pickle.PickleError, _ProcessTransferError) as error:
+                _disable_processes(
+                    key,
+                    reason=error,
+                )
+                use_processes = False
+            except (BrokenProcessPool, _ProcessBackendError) as error:
+                _discard_process_executor()
+                _disable_process_backend(error)
+                use_processes = False
+        if not use_processes:
+            workers = _workers(key, capacity=capacity, size=len(leaves))
+            started = time.perf_counter()
+            transformed = await _ordered_map(
+                convert, leaves, workers=workers, capacity=capacity
+            )
+            elapsed = time.perf_counter() - started
+            _observe(
+                key,
+                workers=workers,
+                capacity=capacity,
+                size=len(leaves),
+                units=sum(_result_units(value) for value in transformed),
+                elapsed=elapsed,
+            )
+            if _supports_processes(
+                capacity=capacity, size=len(leaves), tokenizer=tokenizer
+            ):
+                _consider_processes(
+                    key,
+                    elapsed=elapsed,
+                )
     else:
         transformed = []
 

--- a/src/art/trajectories/_parallel.py
+++ b/src/art/trajectories/_parallel.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from functools import lru_cache
+import math
+import os
+from pathlib import Path
+import threading
+import time
+from typing import Any, Literal, TypeVar, cast
+
+from . import (
+    TokenizedTrajectoryGroup,
+    Tokenizer,
+    Trajectory,
+    TrajectoryGroup,
+)
+
+_ResultT = TypeVar("_ResultT")
+_InputKind = Literal["trajectory", "group"]
+_Operation = Literal["tokenize", "tensorize"]
+
+
+def _cgroup_cpu_limit() -> int | None:
+    try:
+        quota, period = Path("/sys/fs/cgroup/cpu.max").read_text().split()[:2]
+        if quota != "max":
+            return max(1, math.ceil(int(quota) / int(period)))
+    except (OSError, ValueError, ZeroDivisionError):
+        pass
+    try:
+        quota = int(Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read_text())
+        period = int(Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read_text())
+    except (OSError, ValueError):
+        return None
+    return max(1, math.ceil(quota / period)) if quota > 0 and period > 0 else None
+
+
+def _cpu_capacity() -> int:
+    candidates = [os.cpu_count() or 1]
+    try:
+        candidates.append(len(os.sched_getaffinity(0)))
+    except (AttributeError, OSError):
+        pass
+    if (limit := _cgroup_cpu_limit()) is not None:
+        candidates.append(limit)
+    return max(1, min(candidates))
+
+
+_EXECUTOR_LOCK = threading.Lock()
+_EXECUTOR: ThreadPoolExecutor | None = None
+_EXECUTOR_PID: int | None = None
+_EXECUTOR_CAPACITY = 0
+
+
+def _executor(capacity: int) -> ThreadPoolExecutor:
+    global _EXECUTOR, _EXECUTOR_CAPACITY, _EXECUTOR_PID
+    pid = os.getpid()
+    with _EXECUTOR_LOCK:
+        if _EXECUTOR is None or _EXECUTOR_PID != pid or _EXECUTOR_CAPACITY < capacity:
+            previous = _EXECUTOR if _EXECUTOR_PID == pid else None
+            _EXECUTOR = ThreadPoolExecutor(
+                max_workers=capacity, thread_name_prefix="art-tokenize"
+            )
+            _EXECUTOR_PID = pid
+            _EXECUTOR_CAPACITY = capacity
+            if previous is not None:
+                previous.shutdown(wait=False)
+        return _EXECUTOR
+
+
+@dataclass
+class _Measurement:
+    units: int = 0
+    seconds: float = 0
+
+    @property
+    def rate(self) -> float:
+        return self.units / self.seconds
+
+
+@dataclass
+class _TuningState:
+    next_workers: int
+    measurements: dict[int, _Measurement] = field(default_factory=dict)
+
+
+_TUNING_LOCK = threading.Lock()
+
+
+@lru_cache(maxsize=128)
+def _tuning_state(key: tuple[object, ...], initial_workers: int) -> _TuningState:
+    return _TuningState(initial_workers)
+
+
+def _size_bucket(size: int) -> int:
+    return 1 << max(0, (size - 1).bit_length())
+
+
+def _workload_bucket(values: Sequence[Trajectory]) -> int:
+    branches = sum(
+        len(value.exchanges.chat_completions)
+        + len(value.exchanges.completions)
+        + len(value.exchanges.responses)
+        + len(value.exchanges.messages)
+        + len(value.additional_histories)
+        + bool(value.messages_and_choices)
+        for value in values
+    )
+    return _size_bucket(max(1, math.ceil(branches / len(values))))
+
+
+def _tuning_key(
+    *,
+    operation: _Operation,
+    kind: _InputKind,
+    values: Sequence[Trajectory],
+    multi_history: bool,
+    tokenizer: Tokenizer | None,
+    model: str | None,
+    base_model: str | None,
+    chat_template: str | None,
+    capacity: int,
+) -> tuple[object, ...]:
+    if tokenizer is None:
+        tokenizer_key: tuple[object, ...] = ("automatic", base_model, model)
+    else:
+        tokenizer_type = type(tokenizer)
+        tokenizer_key = (
+            tokenizer_type.__module__,
+            tokenizer_type.__qualname__,
+            bool(getattr(tokenizer, "is_fast", False)),
+        )
+    return (
+        operation,
+        kind,
+        _size_bucket(len(values)),
+        _workload_bucket(values),
+        multi_history,
+        tokenizer_key,
+        chat_template is not None,
+        capacity,
+    )
+
+
+def _workers(key: tuple[object, ...], *, capacity: int, size: int) -> int:
+    initial = min(4, capacity, size)
+    with _TUNING_LOCK:
+        state = _tuning_state(key, initial)
+        return max(1, min(state.next_workers, capacity, size))
+
+
+def _observe(
+    key: tuple[object, ...],
+    *,
+    workers: int,
+    capacity: int,
+    size: int,
+    units: int,
+    elapsed: float,
+) -> None:
+    if units <= 0 or elapsed <= 0:
+        return
+    initial = min(4, capacity, size)
+    with _TUNING_LOCK:
+        state = _tuning_state(key, initial)
+        measurement = state.measurements.setdefault(workers, _Measurement())
+        measurement.units += units
+        measurement.seconds += elapsed
+        limit = min(capacity, size)
+
+        smaller = [value for value in state.measurements if value < workers]
+        if workers == max(state.measurements) and workers < limit:
+            previous = max(smaller) if smaller else None
+            if (
+                previous is None
+                or measurement.rate >= state.measurements[previous].rate * 1.05
+            ):
+                state.next_workers = min(limit, workers * 2)
+                return
+
+        peak = max(value.rate for value in state.measurements.values())
+        efficient = min(
+            workers
+            for workers, value in state.measurements.items()
+            if value.rate >= peak * 0.95
+        )
+        lower = max(1, math.ceil(efficient / 2))
+        state.next_workers = (
+            lower
+            if lower < efficient and lower not in state.measurements
+            else efficient
+        )
+
+
+async def _ordered_map(
+    function: Callable[[Trajectory], _ResultT],
+    values: Sequence[Trajectory],
+    *,
+    workers: int,
+    capacity: int,
+) -> list[_ResultT]:
+    loop = asyncio.get_running_loop()
+    executor = _executor(capacity)
+    semaphore = asyncio.Semaphore(workers)
+
+    async def invoke(value: Trajectory) -> _ResultT:
+        async with semaphore:
+            return await loop.run_in_executor(executor, function, value)
+
+    return list(await asyncio.gather(*(invoke(value) for value in values)))
+
+
+def _result_units(value: object) -> int:
+    if (tokens := getattr(value, "tokens", None)) is not None:
+        return len(tokens)
+    histories = getattr(value, "histories", None)
+    return sum(_result_units(history) for history in histories) if histories else 1
+
+
+def _materialize(
+    values: Iterable[Trajectory] | Iterable[TrajectoryGroup],
+) -> tuple[_InputKind | None, list[Trajectory] | list[TrajectoryGroup]]:
+    materialized = list(values)
+    if not materialized:
+        return None, []
+    if all(isinstance(value, Trajectory) for value in materialized):
+        return "trajectory", cast(list[Trajectory], materialized)
+    if all(isinstance(value, TrajectoryGroup) for value in materialized):
+        return "group", cast(list[TrajectoryGroup], materialized)
+    raise TypeError("items must contain only trajectories or only trajectory groups")
+
+
+async def transform(
+    values: Iterable[Trajectory] | Iterable[TrajectoryGroup],
+    *,
+    operation: _Operation,
+    multi_history: bool,
+    reconcile_text_equivalent_tokenizations: bool,
+    model: str | None,
+    base_model: str | None,
+    tokenizer: Tokenizer | None,
+    chat_template: str | None,
+    chat_template_kwargs: Mapping[str, object] | None,
+    device: Any = None,
+) -> list[object]:
+    kind, materialized = _materialize(values)
+    if kind is None:
+        return []
+    groups = cast(list[TrajectoryGroup], materialized) if kind == "group" else None
+    leaves = (
+        [trajectory for group in groups for trajectory in group.trajectories]
+        if groups is not None
+        else cast(list[Trajectory], materialized)
+    )
+
+    def convert(trajectory: Trajectory) -> object:
+        tokenized = trajectory.tokenize(
+            multi_history=multi_history,
+            reconcile_text_equivalent_tokenizations=reconcile_text_equivalent_tokenizations,
+            model=model,
+            base_model=base_model,
+            tokenizer=tokenizer,
+            chat_template=chat_template,
+            chat_template_kwargs=chat_template_kwargs,
+        )
+        return tokenized if operation == "tokenize" else tokenized.tensorize()
+
+    if leaves:
+        capacity = _cpu_capacity()
+        key = _tuning_key(
+            operation=operation,
+            kind=kind,
+            values=leaves,
+            multi_history=multi_history,
+            tokenizer=tokenizer,
+            model=model,
+            base_model=base_model,
+            chat_template=chat_template,
+            capacity=capacity,
+        )
+        workers = _workers(key, capacity=capacity, size=len(leaves))
+        started = time.perf_counter()
+        transformed = await _ordered_map(
+            convert, leaves, workers=workers, capacity=capacity
+        )
+        _observe(
+            key,
+            workers=workers,
+            capacity=capacity,
+            size=len(leaves),
+            units=sum(_result_units(value) for value in transformed),
+            elapsed=time.perf_counter() - started,
+        )
+    else:
+        transformed = []
+
+    if groups is not None:
+        if operation == "tokenize":
+            group_class: Any = TokenizedTrajectoryGroup
+        else:
+            from .tensors import TensorizedTrajectoryGroup
+
+            group_class = TensorizedTrajectoryGroup
+        grouped: list[object] = []
+        start = 0
+        for group in groups:
+            end = start + len(group.trajectories)
+            grouped.append(
+                group_class(trajectory_group=group, trajectories=transformed[start:end])
+            )
+            start = end
+        transformed = grouped
+
+    if device is not None:
+        for value in transformed:
+            cast(Any, value).to(device)
+    return transformed

--- a/src/art/trajectories/_serialization.py
+++ b/src/art/trajectories/_serialization.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from contextlib import contextmanager
 from dataclasses import fields, is_dataclass
+import threading
 from typing import Any, Literal, SupportsIndex, cast
 
 from openai.types.chat import ChatCompletion
@@ -13,6 +15,17 @@ from pydantic.main import IncEx
 from ..openai import ART_MOE_ROUTING_METADATA_KEY
 
 type _StringPool = dict[str, str]
+_PICKLE_STATE = threading.local()
+
+
+@contextmanager
+def _without_pickle_string_interning():
+    previous = getattr(_PICKLE_STATE, "skip_string_interning", False)
+    _PICKLE_STATE.skip_string_interning = True
+    try:
+        yield
+    finally:
+        _PICKLE_STATE.skip_string_interning = previous
 
 
 class _StringInterningModel(BaseModel):
@@ -24,7 +37,9 @@ class _StringInterningModel(BaseModel):
     __slots__ = ("_art_pickle_strings_interned",)
 
     def __reduce_ex__(self, protocol: SupportsIndex, /) -> str | tuple[Any, ...]:
-        if not getattr(self, "_art_pickle_strings_interned", False):
+        if not getattr(_PICKLE_STATE, "skip_string_interning", False) and not getattr(
+            self, "_art_pickle_strings_interned", False
+        ):
             _intern_strings(self)
         return super().__reduce_ex__(protocol)
 
@@ -217,7 +232,12 @@ def validate_history(value: object) -> object:
     return model.model_validate(data)
 
 
-def _rebind_history_sources(history: object, trajectory: object | None = None) -> None:
+def _rebind_history_sources(
+    history: object,
+    trajectory: object | None = None,
+    *,
+    source_trajectory: object | None = None,
+) -> None:
     """Restore history sidecars to canonical exchange objects after validation."""
 
     from . import (
@@ -234,18 +254,32 @@ def _rebind_history_sources(history: object, trajectory: object | None = None) -
         ResponsesExchange,
         MessagesExchange,
     )
-    canonical = (
-        [
-            *trajectory.exchanges.chat_completions,
-            *trajectory.exchanges.completions,
-            *trajectory.exchanges.responses,
-            *trajectory.exchanges.messages,
+
+    def exchanges(value: object) -> list[object]:
+        if not isinstance(value, Trajectory):
+            return []
+        return [
+            *value.exchanges.chat_completions,
+            *value.exchanges.completions,
+            *value.exchanges.responses,
+            *value.exchanges.messages,
         ]
-        if isinstance(trajectory, Trajectory)
-        else []
-    )
+
+    canonical = exchanges(trajectory)
     fixed = trajectory is not None
-    identities = {id(exchange): exchange for exchange in canonical}
+    if source_trajectory is None:
+        identities = {id(exchange): exchange for exchange in canonical}
+    else:
+        sources = exchanges(source_trajectory)
+        if len(sources) != len(canonical) or any(
+            type(source) is not type(target)
+            for source, target in zip(sources, canonical, strict=True)
+        ):
+            raise ValueError("Source trajectory exchange structure has changed")
+        identities = {
+            id(source): target
+            for source, target in zip(sources, canonical, strict=True)
+        }
 
     def visit(value: object) -> None:
         if isinstance(value, BaseModel) or is_dataclass(value):
@@ -258,7 +292,9 @@ def _rebind_history_sources(history: object, trajectory: object | None = None) -
             )
             for name, item in items:
                 if isinstance(item, exchange_types):
-                    if id(item) in identities:
+                    if (replacement := identities.get(id(item))) is not None:
+                        if replacement is not item:
+                            object.__setattr__(value, name, replacement)
                         continue
                     matches = [
                         exchange

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -11,6 +11,7 @@ from hashlib import sha256
 import json
 import math
 import re
+import threading
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, cast
 import warnings
 
@@ -61,6 +62,7 @@ if TYPE_CHECKING:
 
 _TOKEN_ID = re.compile(r"token_id:(\d+)$")
 _WARNED_PREFIX_RETOKENIZATION = False
+_TOKENIZER_LOAD_LOCK = threading.Lock()
 
 
 @dataclass
@@ -1495,7 +1497,11 @@ def _cached_tokenizer(base_model: str, revision: str | None) -> Tokenizer:
 
 
 def _load_tokenizer(config: _TokenizerConfig) -> Tokenizer:
-    return _cached_tokenizer(config.base_model, config.revision)
+    # functools.lru_cache permits duplicate concurrent calls for the same miss.
+    # Collection tokenization runs in parallel, so serialize this rare load path
+    # while leaving all tokenizer use concurrent.
+    with _TOKENIZER_LOAD_LOCK:
+        return _cached_tokenizer(config.base_model, config.revision)
 
 
 def _ids(value: object) -> list[int]:

--- a/tests/unit/trajectories/test_capture.py
+++ b/tests/unit/trajectories/test_capture.py
@@ -48,6 +48,8 @@ def test_root_trajectory_exports_are_minimal() -> None:
         "trajectory_group",
         "current_trajectory",
         "no_capture",
+        "tensorize",
+        "tokenize",
     }
 
     assert set(art.__all__) & set(art.trajectories.__all__) == expected

--- a/tests/unit/trajectories/test_parallel_tokenize.py
+++ b/tests/unit/trajectories/test_parallel_tokenize.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+import concurrent.futures
+from functools import lru_cache
+import math
+import threading
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+import art
+import art.trajectories as tr
+from art.trajectories import _parallel, _tokenize
+
+_CPU_CAPACITY = _parallel._cpu_capacity
+
+
+def _tokenized(trajectory: art.Trajectory) -> tr.TokenizedTrajectory:
+    index = int(trajectory.metadata["index"])
+    return tr.TokenizedTrajectory(
+        history=tr.LegacyHistory(messages_and_choices=[]),
+        model="policy",
+        tokens=[index, index + 1],
+        logprobs=[math.nan, -0.25],
+        flags=[tr.TokenFlag.EXACT, tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED],
+        trajectory=trajectory,
+    )
+
+
+def _tokenized_multi(trajectory: art.Trajectory) -> tr.TokenizedMultiHistoryTrajectory:
+    return tr.TokenizedMultiHistoryTrajectory(trajectory=trajectory, histories=[])
+
+
+@pytest.fixture(autouse=True)
+def _reset_tuning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_parallel, "_cpu_capacity", lambda: 4)
+    with _parallel._TUNING_LOCK:
+        _parallel._tuning_state.cache_clear()
+
+
+def _patch_tokenize(
+    monkeypatch: pytest.MonkeyPatch,
+    function: Callable[
+        [art.Trajectory, dict[str, object]],
+        tr.TokenizedTrajectory | tr.TokenizedMultiHistoryTrajectory,
+    ],
+) -> None:
+    def tokenize(
+        self: art.Trajectory, **kwargs: object
+    ) -> tr.TokenizedTrajectory | tr.TokenizedMultiHistoryTrajectory:
+        return function(self, kwargs)
+
+    monkeypatch.setattr(art.Trajectory, "tokenize", tokenize)
+
+
+async def test_tokenize_preserves_order_and_parallelizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock = threading.Lock()
+    active = 0
+    maximum = 0
+    threads: set[str] = set()
+    received: list[dict[str, object]] = []
+
+    def tokenize(
+        trajectory: art.Trajectory, kwargs: dict[str, object]
+    ) -> tr.TokenizedTrajectory:
+        nonlocal active, maximum
+        with lock:
+            active += 1
+            maximum = max(maximum, active)
+            threads.add(threading.current_thread().name)
+            received.append(kwargs)
+        time.sleep(0.02 * (4 - int(trajectory.metadata["index"])))
+        with lock:
+            active -= 1
+        return _tokenized(trajectory)
+
+    _patch_tokenize(monkeypatch, tokenize)
+    trajectories = [art.Trajectory(metadata={"index": index}) for index in range(4)]
+    tokenizer = cast(Any, object())
+
+    result = await art.tokenize(
+        (trajectory for trajectory in trajectories),
+        multi_history=False,
+        reconcile_text_equivalent_tokenizations=True,
+        model="policy",
+        base_model="base",
+        tokenizer=tokenizer,
+        chat_template="template",
+        chat_template_kwargs={"enable_thinking": True},
+    )
+
+    assert [value.trajectory for value in result] == trajectories
+    assert maximum == 4
+    assert all(name.startswith("art-tokenize") for name in threads)
+    assert all(
+        kwargs
+        == {
+            "multi_history": False,
+            "reconcile_text_equivalent_tokenizations": True,
+            "model": "policy",
+            "base_model": "base",
+            "tokenizer": tokenizer,
+            "chat_template": "template",
+            "chat_template_kwargs": {"enable_thinking": True},
+        }
+        for kwargs in received
+    )
+
+
+async def test_tokenize_groups_flattens_and_reconstructs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_tokenize(monkeypatch, lambda trajectory, _: _tokenized(trajectory))
+    trajectories = [art.Trajectory(metadata={"index": index}) for index in range(3)]
+    groups = [
+        art.TrajectoryGroup(
+            trajectories[:2], metadata={"name": "first"}, metrics={"score": 1}
+        ),
+        art.TrajectoryGroup(trajectories[2:], metadata={"name": "second"}),
+        art.TrajectoryGroup(metadata={"name": "empty"}),
+    ]
+
+    result = await art.tokenize(groups)
+
+    assert [value.trajectory_group for value in result] == groups
+    assert [
+        [trajectory.trajectory for trajectory in value.trajectories] for value in result
+    ] == [trajectories[:2], trajectories[2:], []]
+    assert result[0].metadata is groups[0].metadata
+    assert result[0].metrics is groups[0].metrics
+
+
+async def test_multi_history_group_structure_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trajectory = art.Trajectory(metadata={"index": 0})
+    _patch_tokenize(monkeypatch, lambda trajectory, _: _tokenized_multi(trajectory))
+    group = art.TrajectoryGroup([trajectory], metadata={"name": "multi"})
+
+    tokenized = await art.tokenize([group], multi_history=True)
+    tensorized = await art.tensorize([group], multi_history=True)
+
+    assert tokenized[0].trajectory_group is group
+    assert tokenized[0].trajectories[0].trajectory is trajectory
+    assert tensorized[0].trajectory_group is group
+    assert tensorized[0].trajectories[0].trajectory is trajectory
+
+
+async def test_empty_and_mixed_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_tokenize(monkeypatch, lambda trajectory, _: _tokenized(trajectory))
+
+    assert await art.tokenize([]) == []
+    assert await art.tensorize([]) == []
+    empty_tensorized_groups = await art.tensorize([art.TrajectoryGroup()], device="cpu")
+    assert len(empty_tensorized_groups) == 1
+    assert empty_tensorized_groups[0].trajectories == []
+    with pytest.raises(TypeError, match="only trajectories or only trajectory groups"):
+        await art.tokenize(  # ty: ignore[no-matching-overload]
+            cast(
+                Any,
+                [
+                    art.Trajectory(metadata={"index": 0}),
+                    art.TrajectoryGroup(),
+                ],
+            )
+        )
+
+
+async def test_failure_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    def tokenize(
+        trajectory: art.Trajectory, _: dict[str, object]
+    ) -> tr.TokenizedTrajectory:
+        index = int(trajectory.metadata["index"])
+        if index == 1:
+            time.sleep(0.04)
+            raise RuntimeError("one")
+        time.sleep(0.02)
+        return _tokenized(trajectory)
+
+    _patch_tokenize(monkeypatch, tokenize)
+    trajectories = [art.Trajectory(metadata={"index": index}) for index in range(4)]
+
+    with pytest.raises(RuntimeError, match="one"):
+        await art.tokenize(trajectories)
+
+
+async def test_tensorize_preserves_sources_and_moves_after_parallel_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch = pytest.importorskip("torch")
+    _patch_tokenize(monkeypatch, lambda trajectory, _: _tokenized(trajectory))
+    trajectories = [art.Trajectory(metadata={"index": index}) for index in range(3)]
+
+    result = await art.tensorize(trajectories, device="cpu")
+    grouped = await art.tensorize(
+        [art.TrajectoryGroup(trajectories)], device=torch.device("cpu")
+    )
+
+    assert [value.trajectory for value in result] == trajectories
+    assert all(value.tokens.device.type == "cpu" for value in result)
+    assert grouped[0].trajectory_group.trajectories == trajectories
+    assert [value.trajectory for value in grouped[0].trajectories] == trajectories
+
+
+def test_tuner_probes_and_retains_the_best_rate() -> None:
+    key = ("test",)
+    assert _parallel._workers(key, capacity=16, size=16) == 4
+
+    _parallel._observe(key, workers=4, capacity=16, size=16, units=400, elapsed=1)
+    assert _parallel._workers(key, capacity=16, size=16) == 8
+    _parallel._observe(key, workers=8, capacity=16, size=16, units=600, elapsed=1)
+    assert _parallel._workers(key, capacity=16, size=16) == 16
+    _parallel._observe(key, workers=16, capacity=16, size=16, units=500, elapsed=1)
+    assert _parallel._workers(key, capacity=16, size=16) == 8
+
+
+def test_tuner_probes_down_and_uses_smallest_near_peak_pool() -> None:
+    key = ("small-pool",)
+    assert _parallel._workers(key, capacity=16, size=16) == 4
+
+    _parallel._observe(key, workers=4, capacity=16, size=16, units=400, elapsed=1)
+    assert _parallel._workers(key, capacity=16, size=16) == 8
+    _parallel._observe(key, workers=8, capacity=16, size=16, units=390, elapsed=1)
+    assert _parallel._workers(key, capacity=16, size=16) == 2
+
+    _parallel._observe(key, workers=2, capacity=16, size=16, units=385, elapsed=1)
+    assert _parallel._workers(key, capacity=16, size=16) == 1
+    _parallel._observe(key, workers=1, capacity=16, size=16, units=300, elapsed=1)
+    assert _parallel._workers(key, capacity=16, size=16) == 2
+
+
+def test_tuner_probes_intermediate_worker_count_for_odd_input_size() -> None:
+    key = ("odd-sized",)
+    assert _parallel._workers(key, capacity=16, size=3) == 3
+
+    _parallel._observe(key, workers=3, capacity=16, size=3, units=300, elapsed=1)
+
+    assert _parallel._workers(key, capacity=16, size=3) == 2
+
+
+def test_workload_bucket_uses_average_history_branches() -> None:
+    trajectories = [
+        art.Trajectory(
+            additional_histories=[
+                tr.LegacyHistory(messages_and_choices=[]) for _ in range(count)
+            ]
+        )
+        for count in (1, 4, 7)
+    ]
+
+    assert _parallel._workload_bucket(trajectories) == 4
+
+
+def test_cpu_capacity_honors_affinity_and_cgroup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_parallel.os, "cpu_count", lambda: 32)
+    monkeypatch.setattr(_parallel.os, "sched_getaffinity", lambda _: set(range(16)))
+    monkeypatch.setattr(_parallel, "_cgroup_cpu_limit", lambda: 6)
+
+    assert _CPU_CAPACITY() == 6
+
+
+def test_automatic_tokenizer_loading_is_single_flight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock = threading.Lock()
+    active = 0
+    maximum = 0
+    calls = 0
+    tokenizer = cast(Any, object())
+
+    @lru_cache(maxsize=1)
+    def load(_: str, __: str | None) -> Any:
+        nonlocal active, calls, maximum
+        with lock:
+            calls += 1
+            active += 1
+            maximum = max(maximum, active)
+        time.sleep(0.01)
+        with lock:
+            active -= 1
+        return tokenizer
+
+    monkeypatch.setattr(_tokenize, "_cached_tokenizer", load)
+    config = _tokenize._TokenizerConfig("model")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(executor.map(_tokenize._load_tokenizer, [config] * 4))
+
+    assert results == [tokenizer] * 4
+    assert calls == 1
+    assert maximum == 1
+
+
+def test_root_and_trajectory_exports_are_identical() -> None:
+    assert art.tokenize is tr.tokenize
+    assert art.tensorize is tr.tensorize
+
+
+if TYPE_CHECKING:
+
+    async def _overloads_typecheck(
+        trajectories: list[art.Trajectory], groups: list[art.TrajectoryGroup]
+    ) -> None:
+        tokenized: list[tr.TokenizedTrajectory] = await art.tokenize(trajectories)
+        tokenized_multi: list[tr.TokenizedMultiHistoryTrajectory] = await art.tokenize(
+            trajectories, multi_history=True
+        )
+        tokenized_groups: list[
+            tr.TokenizedTrajectoryGroup[tr.TokenizedTrajectory]
+        ] = await art.tokenize(groups)
+        tokenized_multi_groups: list[
+            tr.TokenizedTrajectoryGroup[tr.TokenizedMultiHistoryTrajectory]
+        ] = await art.tokenize(groups, multi_history=True)
+        tensorized: list[tr.TensorizedTrajectory] = await art.tensorize(trajectories)
+        tensorized_multi: list[
+            tr.TensorizedMultiHistoryTrajectory
+        ] = await art.tensorize(trajectories, multi_history=True)
+        tensorized_groups: list[
+            tr.TensorizedTrajectoryGroup[tr.TensorizedTrajectory]
+        ] = await art.tensorize(groups)
+        tensorized_multi_groups: list[
+            tr.TensorizedTrajectoryGroup[tr.TensorizedMultiHistoryTrajectory]
+        ] = await art.tensorize(groups, multi_history=True)
+        _ = (
+            tokenized,
+            tokenized_multi,
+            tokenized_groups,
+            tokenized_multi_groups,
+            tensorized,
+            tensorized_multi,
+            tensorized_groups,
+            tensorized_multi_groups,
+        )

--- a/tests/unit/trajectories/test_parallel_tokenize.py
+++ b/tests/unit/trajectories/test_parallel_tokenize.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import concurrent.futures
+from datetime import UTC, datetime, timedelta
 from functools import lru_cache
 import math
+import os
+from pathlib import Path
+import pickle
+import subprocess
+import sys
+import textwrap
 import threading
 import time
 from typing import TYPE_CHECKING, Any, cast
 
+from openai.types.chat import ChatCompletion
 import pytest
 
 import art
@@ -15,6 +23,7 @@ import art.trajectories as tr
 from art.trajectories import _parallel, _tokenize
 
 _CPU_CAPACITY = _parallel._cpu_capacity
+_SUPPORTS_PROCESSES = _parallel._supports_processes
 
 
 def _tokenized(trajectory: art.Trajectory) -> tr.TokenizedTrajectory:
@@ -33,11 +42,72 @@ def _tokenized_multi(trajectory: art.Trajectory) -> tr.TokenizedMultiHistoryTraj
     return tr.TokenizedMultiHistoryTrajectory(trajectory=trajectory, histories=[])
 
 
+def _chat_completion(index: int) -> ChatCompletion:
+    token = index + 2
+    return ChatCompletion.model_validate(
+        {
+            "id": f"chat-{index}",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "test/model",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "answer"},
+                    "prompt_token_ids": [1],
+                    "token_ids": [token],
+                    "logprobs": {
+                        "content": [
+                            {
+                                "token": f"token_id:{token}",
+                                "logprob": -0.2,
+                                "bytes": [],
+                                "top_logprobs": [],
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+    )
+
+
+def _legacy_trajectory(index: int) -> art.Trajectory:
+    response = _chat_completion(index)
+    return art.Trajectory(
+        messages_and_choices=[response.choices[0]], metadata={"index": index}
+    )
+
+
+def _exchange_trajectory(index: int) -> art.Trajectory:
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    return art.Trajectory(
+        exchanges=tr.TrajectoryExchanges(
+            chat_completions=[
+                tr.ChatCompletionsExchange(
+                    request=tr.ChatCompletionsRequest(
+                        model="test/model",
+                        messages=[{"role": "user", "content": "question"}],
+                    ),
+                    response=_chat_completion(index),
+                    start_time=start,
+                    end_time=start + timedelta(milliseconds=1),
+                )
+            ]
+        ),
+        metadata={"index": index},
+    )
+
+
 @pytest.fixture(autouse=True)
 def _reset_tuning(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_parallel, "_cpu_capacity", lambda: 4)
+    monkeypatch.setattr(_parallel, "_supports_processes", lambda **_: False)
+    monkeypatch.setattr(_parallel, "_PROCESS_BACKEND_DISABLED", False)
     with _parallel._TUNING_LOCK:
         _parallel._tuning_state.cache_clear()
+        _parallel._process_tuning_state.cache_clear()
 
 
 def _patch_tokenize(
@@ -242,6 +312,323 @@ def test_tuner_probes_intermediate_worker_count_for_odd_input_size() -> None:
     assert _parallel._workers(key, capacity=16, size=3) == 2
 
 
+def test_process_tuner_ignores_cold_start_and_compares_two_with_four() -> None:
+    key = ("process",)
+    assert _parallel._process_workers(key, capacity=16, size=16) == 4
+
+    _parallel._observe_process(
+        key, workers=4, capacity=16, size=16, units=100, elapsed=10
+    )
+    assert _parallel._process_workers(key, capacity=16, size=16) == 4
+
+    _parallel._observe_process(
+        key, workers=4, capacity=16, size=16, units=400, elapsed=1
+    )
+    assert _parallel._process_workers(key, capacity=16, size=16) == 4
+    _parallel._observe_process(
+        key, workers=4, capacity=16, size=16, units=400, elapsed=1
+    )
+    assert _parallel._process_workers(key, capacity=16, size=16) == 2
+
+    _parallel._observe_process(
+        key, workers=2, capacity=16, size=16, units=390, elapsed=1
+    )
+    assert _parallel._process_workers(key, capacity=16, size=16) == 2
+    _parallel._observe_process(
+        key, workers=2, capacity=16, size=16, units=390, elapsed=1
+    )
+    assert _parallel._process_workers(key, capacity=16, size=16) == 2
+
+
+def test_process_tuner_returns_to_four_when_two_is_slower() -> None:
+    key = ("process-slower",)
+    _parallel._observe_process(
+        key, workers=4, capacity=16, size=16, units=100, elapsed=10
+    )
+    _parallel._observe_process(
+        key, workers=4, capacity=16, size=16, units=400, elapsed=1
+    )
+    _parallel._observe_process(
+        key, workers=4, capacity=16, size=16, units=400, elapsed=1
+    )
+    _parallel._observe_process(
+        key, workers=2, capacity=16, size=16, units=300, elapsed=1
+    )
+    _parallel._observe_process(
+        key, workers=2, capacity=16, size=16, units=300, elapsed=1
+    )
+
+    assert _parallel._process_workers(key, capacity=16, size=16) == 4
+
+
+def test_process_backend_is_considered_only_after_slow_thread_work() -> None:
+    fast_key = ("fast-thread",)
+    slow_key = ("slow-thread",)
+    for key in (fast_key, slow_key):
+        _parallel._observe(key, workers=4, capacity=16, size=16, units=100, elapsed=2)
+        _parallel._observe(key, workers=4, capacity=16, size=16, units=100, elapsed=2)
+
+    _parallel._consider_processes(fast_key, elapsed=0.1)
+    _parallel._consider_processes(slow_key, elapsed=2.0)
+
+    assert not _parallel._processes_enabled(fast_key)
+    assert _parallel._processes_enabled(slow_key)
+
+
+def test_process_backend_returns_to_threads_when_warm_rate_is_not_better() -> None:
+    key = ("threads-win",)
+    _parallel._observe(key, workers=4, capacity=16, size=16, units=400, elapsed=1)
+    _parallel._observe(key, workers=4, capacity=16, size=16, units=400, elapsed=1)
+    _parallel._consider_processes(key, elapsed=1)
+    _parallel._observe_process(
+        key, workers=4, capacity=16, size=16, units=100, elapsed=10
+    )
+    _parallel._observe_process(
+        key, workers=4, capacity=16, size=16, units=300, elapsed=1
+    )
+    _parallel._observe_process(
+        key, workers=4, capacity=16, size=16, units=300, elapsed=1
+    )
+
+    assert not _parallel._processes_enabled(key)
+
+
+def test_process_context_does_not_spawn_through_user_main() -> None:
+    assert _parallel._process_context().get_start_method() == "spawn"
+
+
+def test_process_context_does_not_reexecute_unguarded_script(
+    tmp_path: Path,
+) -> None:
+    script = tmp_path / "unguarded.py"
+    marker = tmp_path / "executions"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+            from art.trajectories._parallel import _discard_process_executor, _process_executor
+
+            marker = Path({str(marker)!r})
+            with marker.open("a") as output:
+                output.write("run\\n")
+            pool = _process_executor(2)
+            assert list(pool.map(abs, [-1, -2])) == [1, 2]
+            _discard_process_executor()
+            """
+        )
+    )
+
+    subprocess.run([sys.executable, str(script)], check=True, cwd=Path.cwd())
+
+    assert marker.read_text() == "run\n"
+
+
+def test_child_deserialization_failure_is_a_transfer_error() -> None:
+    with pytest.raises(_parallel._ProcessTransferError, match="process input"):
+        _parallel._tokenize_process_payload(b"not a pickle")
+
+
+def test_process_input_pickle_does_not_mutate_or_mark_caller_trajectory() -> None:
+    trajectory = _exchange_trajectory(0)
+    request_keys = list(trajectory.exchanges.chat_completions[0].request)
+    options = _parallel._ProcessOptions(
+        multi_history=False,
+        reconcile_text_equivalent_tokenizations=False,
+        model=None,
+        base_model=None,
+        chat_template=None,
+        chat_template_kwargs=None,
+    )
+
+    payloads = _parallel._process_payloads([trajectory], options)
+
+    assert payloads
+    assert list(trajectory.exchanges.chat_completions[0].request) == request_keys
+    assert not getattr(trajectory, "_art_pickle_strings_interned", False)
+
+
+def test_broken_pool_disables_processes_for_the_interpreter() -> None:
+    with pytest.warns(RuntimeWarning, match="using threads"):
+        _parallel._disable_process_backend(_parallel.BrokenProcessPool("worker exited"))
+
+    assert not _SUPPORTS_PROCESSES(capacity=4, size=4, tokenizer=None)
+
+
+async def test_process_results_rebind_to_original_trajectories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_parallel, "_supports_processes", lambda **_: True)
+    monkeypatch.setattr(_parallel, "_processes_enabled", lambda *_, **__: True)
+
+    async def process_map(
+        payloads: list[bytes],
+        trajectories: list[art.Trajectory],
+        *,
+        workers: int,
+        capacity: int,
+    ) -> list[tr.TokenizedTrajectory]:
+        del workers, capacity
+        copies = [
+            cast(tuple[art.Trajectory, object], pickle.loads(payload))[0]
+            for payload in payloads
+        ]
+        return [
+            cast(
+                tr.TokenizedTrajectory,
+                _parallel._deserialize_process_result(
+                    pickle.dumps(_tokenized(copied)), trajectory
+                ),
+            )
+            for copied, trajectory in zip(copies, trajectories, strict=True)
+        ]
+
+    monkeypatch.setattr(_parallel, "_ordered_process_map", process_map)
+    trajectories = [art.Trajectory(metadata={"index": index}) for index in range(4)]
+
+    result = await art.tokenize(trajectories)
+
+    assert [value.trajectory for value in result] == trajectories
+    assert all(
+        value.trajectory is trajectory
+        for value, trajectory in zip(result, trajectories, strict=True)
+    )
+
+
+def test_process_rebind_uses_exchange_position_not_deep_equality() -> None:
+    trajectory = _exchange_trajectory(0)
+    copied = cast(art.Trajectory, pickle.loads(pickle.dumps(trajectory)))
+    tokenized = copied.tokenize()
+    trajectory.exchanges.chat_completions[0].request["temperature"] = math.nan
+
+    _parallel._rebind_process_result(tokenized, trajectory)
+
+    source = cast(tr.ChatCompletionsHistory, tokenized.history).message_sources[-1]
+    assert source is not None
+    assert source.exchange is trajectory.exchanges.chat_completions[0]
+    assert tokenized.trajectory is trajectory
+
+
+async def test_process_tensorization_runs_in_parent_thread_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("torch")
+    monkeypatch.setattr(_parallel, "_supports_processes", lambda **_: True)
+    monkeypatch.setattr(_parallel, "_processes_enabled", lambda *_, **__: True)
+    parent_pid = os.getpid()
+    tensorize_processes: list[int] = []
+    tensorize_threads: list[str] = []
+    original_tensorize = tr.TokenizedTrajectory.tensorize
+
+    async def process_map(
+        payloads: list[bytes],
+        trajectories: list[art.Trajectory],
+        *,
+        workers: int,
+        capacity: int,
+    ) -> list[tr.TokenizedTrajectory]:
+        del workers, capacity
+        copies = [
+            cast(tuple[art.Trajectory, object], pickle.loads(payload))[0]
+            for payload in payloads
+        ]
+        return [
+            cast(
+                tr.TokenizedTrajectory,
+                _parallel._deserialize_process_result(
+                    pickle.dumps(_tokenized(copied)), trajectory
+                ),
+            )
+            for copied, trajectory in zip(copies, trajectories, strict=True)
+        ]
+
+    def tensorize(
+        self: tr.TokenizedTrajectory, *, device: object = None
+    ) -> tr.TensorizedTrajectory:
+        tensorize_processes.append(os.getpid())
+        tensorize_threads.append(threading.current_thread().name)
+        return original_tensorize(self, device=cast(Any, device))
+
+    monkeypatch.setattr(_parallel, "_ordered_process_map", process_map)
+    monkeypatch.setattr(tr.TokenizedTrajectory, "tensorize", tensorize)
+    trajectories = [art.Trajectory(metadata={"index": index}) for index in range(4)]
+
+    result = await art.tensorize(trajectories, device="cpu")
+
+    assert tensorize_processes == [parent_pid] * 4
+    assert all(name.startswith("art-tokenize") for name in tensorize_threads)
+    assert all(value.tokens.device.type == "cpu" for value in result)
+
+
+async def test_unpickleable_process_input_warns_once_and_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_parallel, "_supports_processes", lambda **_: True)
+
+    def processes_enabled(key: tuple[object, ...]) -> bool:
+        return not _parallel._process_tuning_state(key).disabled
+
+    monkeypatch.setattr(_parallel, "_processes_enabled", processes_enabled)
+    _patch_tokenize(monkeypatch, lambda trajectory, _: _tokenized(trajectory))
+    attempts = 0
+
+    def fail_payloads(*_: object) -> list[bytes]:
+        nonlocal attempts
+        attempts += 1
+        raise _parallel._ProcessTransferError("not pickleable")
+
+    monkeypatch.setattr(_parallel, "_process_payloads", fail_payloads)
+    trajectories = [art.Trajectory(metadata={"index": index}) for index in range(4)]
+
+    with pytest.warns(RuntimeWarning, match="using threads"):
+        first = await art.tokenize(trajectories)
+    second = await art.tokenize(trajectories)
+
+    assert attempts == 1
+    assert [value.trajectory for value in first] == trajectories
+    assert [value.trajectory for value in second] == trajectories
+
+
+async def test_process_tokenization_errors_are_not_retried_in_threads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_parallel, "_supports_processes", lambda **_: True)
+    monkeypatch.setattr(_parallel, "_processes_enabled", lambda *_, **__: True)
+
+    async def process_map(*_: object, **__: object) -> list[tr.TokenizedTrajectory]:
+        raise ValueError("invalid trajectory")
+
+    monkeypatch.setattr(_parallel, "_ordered_process_map", process_map)
+    trajectories = [art.Trajectory(metadata={"index": index}) for index in range(4)]
+
+    with pytest.raises(ValueError, match="invalid trajectory"):
+        await art.tokenize(trajectories)
+
+
+async def test_spawn_process_pool_tokenizes_serialized_trajectories() -> None:
+    trajectories = [_legacy_trajectory(index) for index in range(4)]
+    options = _parallel._ProcessOptions(
+        multi_history=False,
+        reconcile_text_equivalent_tokenizations=False,
+        model="test/model",
+        base_model=None,
+        chat_template=None,
+        chat_template_kwargs=None,
+    )
+
+    try:
+        result = await _parallel._ordered_process_map(
+            _parallel._process_payloads(trajectories, options),
+            trajectories,
+            workers=2,
+            capacity=2,
+        )
+    finally:
+        _parallel._discard_process_executor()
+
+    tokenized = cast(list[tr.TokenizedTrajectory], result)
+    assert [value.tokens for value in tokenized] == [[1, 2], [1, 3], [1, 4], [1, 5]]
+
+
 def test_workload_bucket_uses_average_history_branches() -> None:
     trajectories = [
         art.Trajectory(
@@ -263,6 +650,13 @@ def test_cpu_capacity_honors_affinity_and_cgroup(
     monkeypatch.setattr(_parallel, "_cgroup_cpu_limit", lambda: 6)
 
     assert _CPU_CAPACITY() == 6
+
+
+def test_process_backend_requires_capacity_batch_and_automatic_tokenizer() -> None:
+    assert _SUPPORTS_PROCESSES(capacity=4, size=4, tokenizer=None)
+    assert not _SUPPORTS_PROCESSES(capacity=1, size=4, tokenizer=None)
+    assert not _SUPPORTS_PROCESSES(capacity=4, size=3, tokenizer=None)
+    assert not _SUPPORTS_PROCESSES(capacity=4, size=4, tokenizer=cast(Any, object()))
 
 
 def test_automatic_tokenizer_loading_is_single_flight(


### PR DESCRIPTION
## Summary

- add typed async `art.tokenize(...)` and `art.tensorize(...)` collection helpers for homogeneous iterables of trajectories or trajectory groups
- preserve input order, group boundaries, canonical source objects, metadata, and metrics while moving CPU tokenization/tensorization off the asyncio driver thread
- automatically use threads for small/custom-tokenizer work and qualify a reusable process pool for expensive, serializable automatic-tokenizer workloads
- adapt both backend and worker width from inclusive observed throughput without exposing tuning parameters
- serialize cold tokenizer cache misses so parallel collection work cannot instantiate the same tokenizer multiple times in one process

`tensorize(..., device=...)` tokenizes in the selected CPU pool, constructs tensors in parent-process worker threads, and performs device placement only after collection. Existing instance methods are unchanged.

## Automatic execution policy

- capacity respects CPU affinity, cgroup quota, and host CPU count
- explicit/custom tokenizers and batches smaller than four stay on threads
- a workload becomes a process candidate only after two thread observations and a thread call lasting at least one second
- process workers use a safely prestarted `spawn` pool capped at four; unguarded user scripts are not re-executed
- cold process/tokenizer initialization is excluded from steady-state width selection
- four and two process workers each receive two warm observations; ART keeps the smallest width within 5% of peak
- if warm processes do not beat the measured thread rate by at least 5%, that workload returns to threads
- input/output transfer, provenance rebinding, and CPU tensor construction are included in process timing
- serialization or environment failures fall back to threads; genuine tokenization errors and cancellation still propagate

Process results are rebound positionally to the caller's original mutable trajectory and exchange graph. Process IPC disables ART's mutating pre-pickle string-interning for that transfer only; ordinary durable serialization retains its existing behavior.

## Profiling

The workload was 16 real Bonnie trajectories transformed through the 047 Dynamics path, producing 211,798 Qwen3.5 tokens. IPC was approximately 0.96 MB in and 4.8 MB out per batch.

On the final public API implementation:

| phase | elapsed | tokens/s |
|---|---:|---:|
| first thread baseline | 13.40s | 15.8k |
| warm thread baseline | 10.75s | 19.7k |
| cold process startup/tokenizer load | 23.94s | 8.8k |
| four processes, warm | 4.31–4.35s | 48.7–49.2k |
| two-process probe | 7.06s | 30.0k |
| settled four-process width | 4.33–4.40s | 48.1–48.9k |

The conservative qualification/exploration cost amortizes after roughly nine representative batches; steady-state tokenization/tensorization is about 2.5x faster than threads. Earlier disposable SkyPilot Modal profiles across 4–16 effective CPUs found the same four-process optimum and showed regression at eight workers. All temporary clusters were torn down.

## Validation

- `uv run prek run --all-files`
- 438 trajectory/history/tokenization/tensorization tests
- real `spawn` execution and an intentionally unguarded-script subprocess regression
- public end-to-end adaptive benchmark with exact source-identity checks on every iteration
- Claude Fable 5.1 open-ended design and implementation review, followed by two remediation reviews: no remaining blocker or P1 findings
