### PR TITLE
Accept standard tokenizer implementations

### DIFF
--- a/src/art/trajectories/__init__.py
+++ b/src/art/trajectories/__init__.py
@@ -139,17 +139,12 @@ class CompactTrajectoryPayload(TypedDict):
 class Tokenizer(Protocol):
     """Minimal tokenizer surface used by trajectory tokenization."""
 
-    def __call__(self, text: str, *, add_special_tokens: bool = False) -> object: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> object: ...
 
     def apply_chat_template(
         self,
-        messages: list[dict[str, Any]],
-        *,
-        tools: object,
-        tokenize: bool,
-        add_generation_prompt: bool,
-        chat_template: str | None = None,
-        **kwargs: object,
+        *args: Any,
+        **kwargs: Any,
     ) -> object: ...
 
 

--- a/tests/unit/trajectories/test_parallel_tokenize.py
+++ b/tests/unit/trajectories/test_parallel_tokenize.py
@@ -696,9 +696,12 @@ def test_root_and_trajectory_exports_are_identical() -> None:
 
 
 if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
 
     async def _overloads_typecheck(
-        trajectories: list[art.Trajectory], groups: list[art.TrajectoryGroup]
+        trajectories: list[art.Trajectory],
+        groups: list[art.TrajectoryGroup],
+        tokenizer: PreTrainedTokenizerBase,
     ) -> None:
         tokenized: list[tr.TokenizedTrajectory] = await art.tokenize(trajectories)
         tokenized_multi: list[tr.TokenizedMultiHistoryTrajectory] = await art.tokenize(
@@ -720,6 +723,9 @@ if TYPE_CHECKING:
         tensorized_multi_groups: list[
             tr.TensorizedTrajectoryGroup[tr.TensorizedMultiHistoryTrajectory]
         ] = await art.tensorize(groups, multi_history=True)
+        with_transformers_tokenizer: list[
+            tr.TensorizedTrajectory
+        ] = await art.tensorize(trajectories, tokenizer=tokenizer)
         _ = (
             tokenized,
             tokenized_multi,
@@ -729,4 +735,5 @@ if TYPE_CHECKING:
             tensorized_multi,
             tensorized_groups,
             tensorized_multi_groups,
+            with_transformers_tokenizer,
         )


### PR DESCRIPTION
## Summary
- loosen the structural tokenizer protocol so overloaded third-party tokenizers such as `transformers.PreTrainedTokenizerBase` satisfy it
- regression-check the public `art.tensorize` overload with a Transformers tokenizer

This is a typing-only compatibility follow-up to #833; runtime calls and adaptive execution are unchanged.

## Validation
- `29 passed` in `tests/unit/trajectories/test_parallel_tokenize.py`
- Ruff check/format pass
- `ty` passes for the ART files
- the exact Caladan 047 `await art.tensorize(batch.items, base_model=base_model, tokenizer=tokenizer)` consumer passes `ty`