### PR TITLE
Add per-checkpoint TrainerRank optimizer settings

### DIFF
--- a/src/art/trainer_rank/__init__.py
+++ b/src/art/trainer_rank/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Literal, TypeVar, cast, overload
 
 import torch
@@ -336,12 +336,19 @@ class TrainerRank(_impl.TrainerRank):
     def optim_step(
         self,
         *,
-        params: AdamParams,
-        scale_grads: float = 1.0,
+        params: AdamParams | Mapping[str, AdamParams],
+        scale_grads: float | Mapping[str, float] = 1.0,
         checkpoints: Sequence[str] | None = None,
         on_live_graphs: Literal["allow", "error"] = "allow",
     ) -> dict[str, float]:
         """Step checkpoint slots that have accumulated gradients.
+
+        A mapping assigns independent optimizer parameters to each checkpoint;
+        ``scale_grads`` may likewise map checkpoints to gradient scales. Mapping
+        keys select the checkpoints when ``checkpoints`` is omitted, and all
+        explicitly supplied checkpoint sets must match. Each checkpoint's gradient
+        norm is clipped independently. If any selected norm is nonfinite, no
+        selected checkpoint is updated.
 
         By default, caller-retained forward graphs do not block the step. ART does
         not detach or free those graphs, and backward through one after the step is

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -2431,8 +2431,8 @@ class TrainerRank:
     def optim_step(
         self,
         *,
-        params: AdamParams,
-        scale_grads: float = 1.0,
+        params: AdamParams | Mapping[str, AdamParams],
+        scale_grads: float | Mapping[str, float] = 1.0,
         checkpoints: Sequence[str] | None = None,
         on_live_graphs: Literal["allow", "error"] = "allow",
     ) -> dict[str, float]:
@@ -2441,7 +2441,73 @@ class TrainerRank:
                 "on_live_graphs must be either 'allow' or 'error', got "
                 f"{on_live_graphs!r}"
             )
-        selected_checkpoints = self._selected_dynamic_checkpoints(checkpoints)
+        params_by_checkpoint = dict(params) if isinstance(params, Mapping) else None
+        if params_by_checkpoint is not None:
+            if not params_by_checkpoint:
+                raise ValueError("params mapping must select at least one checkpoint")
+            if any(not isinstance(name, str) for name in params_by_checkpoint):
+                raise TypeError("params keys must be checkpoint names")
+            if any(
+                not isinstance(value, AdamParams)
+                for value in params_by_checkpoint.values()
+            ):
+                raise TypeError("params values must be AdamParams")
+        elif not isinstance(params, AdamParams):
+            raise TypeError(
+                "params must be AdamParams or a mapping of checkpoint names"
+            )
+        if isinstance(scale_grads, Mapping):
+            raw_scales = cast(Mapping[object, object], scale_grads)
+            if not raw_scales:
+                raise ValueError(
+                    "scale_grads mapping must select at least one checkpoint"
+                )
+            if any(not isinstance(name, str) for name in raw_scales):
+                raise TypeError("scale_grads keys must be checkpoint names")
+            try:
+                scales_by_checkpoint = {
+                    cast(str, name): float(cast(Any, value))
+                    for name, value in raw_scales.items()
+                }
+            except (TypeError, ValueError) as error:
+                raise TypeError("scale_grads values must be floats") from error
+            scale_grads_value = None
+        else:
+            scales_by_checkpoint = None
+            scale_grads_value = float(scale_grads)
+        configured = [
+            tuple(value)
+            for value in (params_by_checkpoint, scales_by_checkpoint)
+            if value is not None
+        ]
+        if checkpoints is not None:
+            configured.append(tuple(dict.fromkeys(checkpoints)))
+        if configured and any(set(names) != set(configured[0]) for names in configured):
+            raise ValueError(
+                "params, scale_grads, and checkpoints must select the same "
+                "checkpoint names"
+            )
+        checkpoint_selection = (
+            checkpoints
+            if checkpoints is not None
+            else sorted(configured[0])
+            if configured
+            else None
+        )
+        self._guard_optim_step_configuration(
+            checkpoint_selection, params, on_live_graphs
+        )
+        selected_checkpoints = self._selected_dynamic_checkpoints(checkpoint_selection)
+        params_by_checkpoint = (
+            params_by_checkpoint
+            if params_by_checkpoint is not None
+            else dict.fromkeys(selected_checkpoints, cast(AdamParams, params))
+        )
+        scales_by_checkpoint = (
+            scales_by_checkpoint
+            if scales_by_checkpoint is not None
+            else dict.fromkeys(selected_checkpoints, cast(float, scale_grads_value))
+        )
         if on_live_graphs == "error":
             self._guard_checkpoints_can_step(selected_checkpoints)
         with _telemetry_phase(
@@ -2450,8 +2516,55 @@ class TrainerRank:
         ):
             return self._dynamic_optim_step(
                 selected_checkpoints,
-                params=params,
-                scale_grads=scale_grads,
+                params=params_by_checkpoint,
+                scale_grads=scales_by_checkpoint,
+            )
+
+    def _guard_optim_step_configuration(
+        self,
+        checkpoints: Sequence[str] | None,
+        params: AdamParams | Mapping[str, AdamParams],
+        on_live_graphs: Literal["allow", "error"],
+    ) -> None:
+        if not (dist.is_available() and dist.is_initialized()):
+            return
+
+        def adam_values(
+            value: AdamParams,
+        ) -> tuple[float, float, float, float, float]:
+            return (
+                value.learning_rate,
+                value.beta1,
+                value.beta2,
+                value.weight_decay,
+                value.grad_clip_norm,
+            )
+
+        config_values = (
+            tuple(
+                (name, *adam_values(value))
+                for name, value in sorted(
+                    cast(Mapping[str, AdamParams], params).items()
+                )
+            )
+            if isinstance(params, Mapping)
+            else adam_values(params)
+        )
+        digest = hashlib.sha256(
+            repr(
+                (
+                    None if checkpoints is None else tuple(checkpoints),
+                    config_values,
+                    on_live_graphs,
+                )
+            ).encode()
+        ).digest()
+        local = torch.tensor(tuple(digest), device=self.device, dtype=torch.uint8)
+        gathered = [torch.empty_like(local) for _ in range(dist.get_world_size())]
+        dist.all_gather(gathered, local)
+        if any(not torch.equal(value, local) for value in gathered):
+            raise TrainerRankSlotStateError(
+                "Optimizer checkpoint selection or AdamParams differ across ranks"
             )
 
     def _load_checkpoint_slot(
@@ -2724,8 +2837,8 @@ class TrainerRank:
         self,
         checkpoint_names: Sequence[str],
         *,
-        params: AdamParams,
-        scale_grads: float,
+        params: Mapping[str, AdamParams],
+        scale_grads: Mapping[str, float],
     ) -> dict[str, float]:
         self.runtime.model_support_handler.zero_internal_padding_grads(
             self.runtime.model
@@ -2735,32 +2848,76 @@ class TrainerRank:
             slot_params = self._checkpoint_slots[name].params
             step_flags = self._dynamic_param_step_flags(slot_params)
             slot_grads = self._reduce_dynamic_grads(
-                slot_params, scale_grads=scale_grads
+                slot_params, scale_grads=scale_grads[name]
             )
             selected.append((name, slot_params, slot_grads, step_flags))
 
-        all_params = tuple(
-            param for _, slot_params, _, _ in selected for param in slot_params
+        grad_norms = dict(
+            zip(
+                checkpoint_names,
+                _distributed_grad_norms(
+                    [(model_params, grads) for _, model_params, grads, _ in selected]
+                ),
+                strict=True,
+            )
         )
-        all_grads = tuple(
-            grad for _, _, slot_grads, _ in selected for grad in slot_grads
-        )
-        grad_norm = _distributed_grad_norm(all_params, all_grads)
-        if not torch.isfinite(torch.tensor(grad_norm)):
-            self.zero_grad()
-            return {
-                "learning_rate": float(params.learning_rate),
-                "grad_norm": float(grad_norm),
-                "update_successful": 0.0,
-                "num_zeros_in_grad": 0.0,
+        grad_norm = math.sqrt(sum(value**2 for value in grad_norms.values()))
+        metrics = {
+            "grad_norm": float(grad_norm),
+            "update_successful": float(math.isfinite(grad_norm)),
+            "num_zeros_in_grad": 0.0,
+        }
+        for name in checkpoint_names:
+            metrics[f"learning_rate/{name}"] = float(params[name].learning_rate)
+            metrics[f"grad_norm/{name}"] = float(grad_norms[name])
+        learning_rates = {params[name].learning_rate for name in checkpoint_names}
+        if len(learning_rates) == 1:
+            metrics["learning_rate"] = float(params[checkpoint_names[0]].learning_rate)
+        if not math.isfinite(grad_norm):
+            for name in checkpoint_names:
+                for param in self._checkpoint_slots[name].params:
+                    param.grad = None
+                self._prune_slot_graphs(self._slot_ref(name))
+            return metrics
+        previous = {
+            name: (
+                slot.optimizer,
+                None
+                if slot.optimizer is None
+                else [
+                    {key: group[key] for key in ("lr", "betas", "weight_decay")}
+                    for group in slot.optimizer.optimizer.param_groups
+                ],
+            )
+            for name in checkpoint_names
+            for slot in (self._checkpoint_slots[name],)
+        }
+        try:
+            dynamics = {
+                name: self._dynamic_optimizer(name, params[name])
+                for name in checkpoint_names
             }
-        clip = (
-            min(1.0, params.grad_clip_norm / (grad_norm + 1.0e-6))
-            if params.grad_clip_norm > 0.0
-            else 1.0
-        )
+        except BaseException:
+            for name, (optimizer, groups) in previous.items():
+                self._checkpoint_slots[name].optimizer = optimizer
+                if optimizer is not None and groups is not None:
+                    for group, values in zip(
+                        optimizer.optimizer.param_groups, groups, strict=True
+                    ):
+                        group.update(values)
+            raise
         for name, model_params, grads, step_flags in selected:
-            dynamic = self._dynamic_optimizer(name, params)
+            checkpoint_params = params[name]
+            checkpoint_grad_norm = grad_norms[name]
+            clip = (
+                min(
+                    1.0,
+                    checkpoint_params.grad_clip_norm / (checkpoint_grad_norm + 1.0e-6),
+                )
+                if checkpoint_params.grad_clip_norm > 0.0
+                else 1.0
+            )
+            dynamic = dynamics[name]
             for master, grad, should_step in zip(
                 dynamic.master_params, grads, step_flags, strict=True
             ):
@@ -2775,12 +2932,7 @@ class TrainerRank:
                     model.grad = None
             self._prune_slot_graphs(self._slot_ref(name))
             self._checkpoint_slots[name].revision += 1
-        return {
-            "learning_rate": float(params.learning_rate),
-            "grad_norm": float(grad_norm),
-            "update_successful": 1.0,
-            "num_zeros_in_grad": 0.0,
-        }
+        return metrics
 
     def _dynamic_param_step_flags(
         self, params: Sequence[torch.nn.Parameter]
@@ -5006,20 +5158,26 @@ def _distributed_grad_norm(
     params: Sequence[torch.nn.Parameter],
     grads: Sequence[torch.Tensor],
 ) -> float:
-    if len(params) != len(grads):
+    return _distributed_grad_norms([(params, grads)])[0]
+
+
+def _distributed_grad_norms(
+    groups: Sequence[tuple[Sequence[torch.nn.Parameter], Sequence[torch.Tensor]]],
+) -> tuple[float, ...]:
+    if any(len(params) != len(grads) for params, grads in groups):
         raise ValueError("params and grads must have matching lengths")
-    included = [
-        grad
-        for param, grad in zip(params, grads, strict=True)
-        if _include_in_distributed_grad_norm(param)
-    ]
-    device = grads[0].device if grads else torch.device("cpu")
-    squared = torch.zeros((), device=device, dtype=torch.float32)
-    for grad in included:
-        squared.add_(grad.float().square().sum())
+    device = next(
+        (grad.device for _params, grads in groups for grad in grads),
+        torch.device("cpu"),
+    )
+    squared = torch.zeros(len(groups), device=device, dtype=torch.float32)
+    for index, (params, grads) in enumerate(groups):
+        for param, grad in zip(params, grads, strict=True):
+            if _include_in_distributed_grad_norm(param):
+                squared[index].add_(grad.float().square().sum())
     if dist.is_available() and dist.is_initialized():
         dist.all_reduce(squared, op=dist.ReduceOp.SUM)
-    return float(torch.sqrt(squared).item())
+    return tuple(torch.sqrt(squared).tolist())
 
 
 def _include_in_distributed_grad_norm(param: torch.nn.Parameter) -> bool:

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -2470,6 +2470,269 @@ def test_optim_step_implicitly_steps_only_slots_with_grads(
     torch.testing.assert_close(untouched, before_untouched)
 
 
+def test_optim_step_accepts_per_checkpoint_params_and_scales(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    scales: dict[str, float] = {}
+    names: dict[int, str] = {}
+    for name in ("policy", "adversary", "unselected"):
+        param = torch.nn.Parameter(torch.ones(1))
+        param.grad = torch.ones_like(param)
+        trainer._checkpoint_slots[name] = _CheckpointSlot(params=(param,))
+        names[id(param)] = name
+
+    def reduce_grads(
+        params: tuple[torch.nn.Parameter, ...], *, scale_grads: float
+    ) -> tuple[torch.Tensor, ...]:
+        name = names[id(params[0])]
+        scales[name] = scale_grads
+        assert all(param.grad is not None for param in params)
+        return tuple(
+            cast(torch.Tensor, param.grad).float().mul(scale_grads) for param in params
+        )
+
+    monkeypatch.setattr(trainer, "_reduce_dynamic_grads", reduce_grads)
+    metrics = trainer.optim_step(
+        params={
+            "policy": AdamParams(
+                learning_rate=1e-2, weight_decay=0.0, grad_clip_norm=0.0
+            ),
+            "adversary": AdamParams(
+                learning_rate=2e-2, weight_decay=0.0, grad_clip_norm=0.0
+            ),
+        },
+        scale_grads={"policy": 0.5, "adversary": 0.25},
+    )
+
+    assert scales == {"adversary": 0.25, "policy": 0.5}
+    assert trainer._checkpoint_slots["unselected"].optimizer is None
+    for name, learning_rate in (("policy", 1e-2), ("adversary", 2e-2)):
+        optimizer = trainer._checkpoint_slots[name].optimizer
+        assert optimizer is not None
+        assert optimizer.optimizer.param_groups[0]["lr"] == learning_rate
+        assert metrics[f"learning_rate/{name}"] == learning_rate
+    assert "learning_rate" not in metrics
+
+
+@pytest.mark.parametrize("mapped", (False, True))
+def test_optim_step_clips_per_checkpoint(
+    monkeypatch: pytest.MonkeyPatch, mapped: bool
+) -> None:
+    trainer = TrainerRank(_runtime())
+    stepped: dict[str, torch.Tensor] = {}
+    dynamics: dict[str, object] = {}
+
+    class RecordingOptimizer:
+        def __init__(self, name: str, master: torch.nn.Parameter) -> None:
+            self.name = name
+            self.master = master
+
+        def step(self) -> None:
+            assert self.master.grad is not None
+            stepped[self.name] = self.master.grad.detach().clone()
+
+        def zero_grad(self, *, set_to_none: bool = False) -> None:
+            del set_to_none
+            self.master.grad = None
+
+    for name, grad in (("policy", 3.0), ("adversary", 4.0)):
+        param = torch.nn.Parameter(torch.ones(1))
+        param.grad = torch.full_like(param, grad)
+        trainer._checkpoint_slots[name] = _CheckpointSlot(params=(param,))
+        master = torch.nn.Parameter(param.detach().float().clone())
+        dynamics[name] = SimpleNamespace(
+            master_params=(master,), optimizer=RecordingOptimizer(name, master)
+        )
+
+    monkeypatch.setattr(
+        trainer,
+        "_reduce_dynamic_grads",
+        lambda params, **_kwargs: tuple(param.grad.float() for param in params),
+    )
+    monkeypatch.setattr(
+        trainer, "_dynamic_optimizer", lambda name, _params: dynamics[name]
+    )
+    monkeypatch.setattr(trainer, "_prune_slot_graphs", lambda *_args: None)
+
+    adam = AdamParams(learning_rate=1e-2, grad_clip_norm=1.0)
+    params = (
+        {
+            "policy": adam,
+            "adversary": AdamParams(learning_rate=1e-2, grad_clip_norm=2.0),
+        }
+        if mapped
+        else adam
+    )
+    metrics = trainer.optim_step(
+        params=params,
+        checkpoints=None if mapped else ["policy", "adversary"],
+    )
+
+    torch.testing.assert_close(stepped["policy"], torch.ones(1))
+    torch.testing.assert_close(
+        stepped["adversary"], torch.full((1,), 2.0 if mapped else 1.0)
+    )
+    assert metrics["grad_norm"] == pytest.approx(5.0)
+    assert metrics["learning_rate"] == 1e-2
+    assert metrics["grad_norm/policy"] == pytest.approx(3.0)
+    assert metrics["grad_norm/adversary"] == pytest.approx(4.0)
+
+
+def test_optim_step_checks_all_checkpoint_grads_before_stepping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    for name, grad in (
+        ("policy", 1.0),
+        ("adversary", float("nan")),
+        ("unselected", 1.0),
+    ):
+        param = torch.nn.Parameter(torch.ones(1))
+        param.grad = torch.full_like(param, grad)
+        trainer._checkpoint_slots[name] = _CheckpointSlot(params=(param,))
+    monkeypatch.setattr(
+        trainer,
+        "_reduce_dynamic_grads",
+        lambda params, **_kwargs: tuple(param.grad.float() for param in params),
+    )
+    monkeypatch.setattr(
+        trainer,
+        "_dynamic_optimizer",
+        lambda *_args: pytest.fail("optimizer initialized before finite preflight"),
+    )
+
+    metrics = trainer.optim_step(
+        params={
+            name: AdamParams(learning_rate=1e-2) for name in ("policy", "adversary")
+        }
+    )
+
+    assert metrics["update_successful"] == 0.0
+    assert all(slot.revision == 0 for slot in trainer._checkpoint_slots.values())
+    assert all(
+        param.grad is None
+        for name, slot in trainer._checkpoint_slots.items()
+        if name != "unselected"
+        for param in slot.params
+    )
+    assert trainer._checkpoint_slots["unselected"].params[0].grad is not None
+
+
+def test_optim_step_requires_matching_checkpoint_configuration() -> None:
+    trainer = TrainerRank(_runtime())
+
+    with pytest.raises(ValueError, match="same checkpoint names"):
+        trainer.optim_step(
+            params={"policy": AdamParams(learning_rate=1e-3)},
+            scale_grads={"adversary": 1.0},
+        )
+    with pytest.raises(ValueError, match="same checkpoint names"):
+        trainer.optim_step(
+            params={"policy": AdamParams(learning_rate=1e-3)},
+            checkpoints=["adversary"],
+        )
+
+
+def test_optim_step_mapping_rejects_unready_checkpoints() -> None:
+    trainer = TrainerRank(_runtime())
+    trainer._checkpoint_slots["student"] = _CheckpointSlot(
+        params=(torch.nn.Parameter(torch.ones(1)),)
+    )
+
+    with pytest.raises(TrainerRankSlotStateError, match="no gradients"):
+        trainer.optim_step(params={"student": AdamParams(learning_rate=1e-3)})
+    with pytest.raises(TrainerRankSlotStateError, match="unloaded checkpoint"):
+        trainer.optim_step(params={"missing": AdamParams(learning_rate=1e-3)})
+
+
+@pytest.mark.parametrize("mapped", ("params", "scale_grads"))
+def test_optim_step_allows_either_configuration_to_be_mapped(
+    monkeypatch: pytest.MonkeyPatch, mapped: str
+) -> None:
+    trainer = TrainerRank(_runtime())
+    param = torch.nn.Parameter(torch.ones(1))
+    param.grad = torch.ones_like(param)
+    trainer._checkpoint_slots["student"] = _CheckpointSlot(params=(param,))
+    monkeypatch.setattr(
+        trainer,
+        "_reduce_dynamic_grads",
+        lambda params, **_kwargs: tuple(param.grad.float() for param in params),
+    )
+    adam = AdamParams(learning_rate=1e-3, weight_decay=0.0)
+
+    trainer.optim_step(
+        params={"student": adam} if mapped == "params" else adam,
+        scale_grads={"student": 0.5} if mapped == "scale_grads" else 0.5,
+    )
+
+    assert trainer._checkpoint_slots["student"].revision == 1
+
+
+def test_optim_step_prepares_all_optimizers_before_first_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    stepped = False
+    for name in ("a", "b"):
+        param = torch.nn.Parameter(torch.ones(1))
+        param.grad = torch.ones_like(param)
+        trainer._checkpoint_slots[name] = _CheckpointSlot(params=(param,))
+    monkeypatch.setattr(
+        trainer,
+        "_reduce_dynamic_grads",
+        lambda params, **_kwargs: tuple(param.grad.float() for param in params),
+    )
+
+    class RecordingOptimizer:
+        def step(self) -> None:
+            nonlocal stepped
+            stepped = True
+
+        def zero_grad(self, *, set_to_none: bool = False) -> None:
+            del set_to_none
+
+    dynamic = SimpleNamespace(
+        master_params=(torch.nn.Parameter(torch.ones(1)),),
+        optimizer=RecordingOptimizer(),
+    )
+
+    def optimizer(name: str, _params: AdamParams) -> object:
+        if name == "b":
+            raise RuntimeError("invalid optimizer state")
+        return dynamic
+
+    monkeypatch.setattr(trainer, "_dynamic_optimizer", optimizer)
+    with pytest.raises(RuntimeError, match="invalid optimizer state"):
+        trainer.optim_step(
+            params={name: AdamParams(learning_rate=1e-3) for name in ("a", "b")}
+        )
+
+    assert not stepped
+    assert all(slot.revision == 0 for slot in trainer._checkpoint_slots.values())
+    assert all(slot.optimizer is None for slot in trainer._checkpoint_slots.values())
+
+
+def test_optim_step_configuration_must_match_across_ranks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    monkeypatch.setattr(dist, "is_available", lambda: True)
+    monkeypatch.setattr(dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(dist, "get_world_size", lambda _group=None: 2)
+
+    def gather(outputs: list[torch.Tensor], value: torch.Tensor) -> None:
+        outputs[0].copy_(value)
+        outputs[1].zero_()
+
+    monkeypatch.setattr(dist, "all_gather", gather)
+
+    with pytest.raises(TrainerRankSlotStateError, match="differ across ranks"):
+        trainer._guard_optim_step_configuration(
+            ["student"], AdamParams(learning_rate=1e-3), "allow"
+        )
+
+
 def test_optim_step_implicitly_ignores_resident_forward_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- allow `TrainerRank.optim_step()` to accept checkpoint-keyed `AdamParams` and gradient-scale mappings
- select mapped checkpoints atomically, validate optimizer configuration across ranks, and norm/clip each checkpoint independently
- preflight nonfinite gradients before updating any selected checkpoint while preserving unselected gradients
- report aggregate and per-checkpoint optimizer metrics and preserve checkpoint-owned optimizer state

## Validation

- `uv run --frozen ruff check .`
- `uv run --frozen ty check src tests`
- `uv lock --check`
- `uv run --frozen --extra tensors --with safetensors pytest -q tests/unit/test_trainer_rank_validation.py tests/unit/test_trainer_rank_custom_tensors.py` (170 passed, 17 skipped)
- two-pass design and correctness review with Claude Fable 5.1; final verdict: no merge-blocking defects
