### PR TITLE
fix: use restricted SkyPilot workload identity in TrainerRank CI

### DIFF
--- a/.github/workflows/trainer-rank-gpu.yml
+++ b/.github/workflows/trainer-rank-gpu.yml
@@ -112,6 +112,21 @@ jobs:
           chmod 600 "${HOME}/.kube/config"
           kubectl --context cks-wb3 get nodes >/dev/null
 
+      - name: Configure SkyPilot workload identity
+        run: |
+          mkdir -p "${HOME}/.sky"
+          cat > "${HOME}/.sky/config.yaml" <<'YAML'
+          # Use the pre-provisioned least-privilege service account instead of
+          # allowing SkyPilot to create its broadly privileged legacy RBAC.
+          allowed_clouds:
+            - kubernetes
+          kubernetes:
+            allowed_contexts:
+              - cks-wb3
+            remote_identity:
+              cks-wb3: skypilot-workload
+          YAML
+
       - name: Run TrainerRank GPU validation
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- configure the TrainerRank GPU workflow to use the pre-provisioned skypilot-workload service account on cks-wb3
- restrict SkyPilot to the intended Kubernetes context
- prevent the standalone CI client from recreating SkyPilot legacy wildcard RBAC

## Validation

- parsed the updated workflow as YAML
- verified the generated SkyPilot configuration selects skypilot-workload for cks-wb3
- ran git diff --check

The 2x H200 workflow was not triggered from this draft PR.