### PR TITLE
Add output provenance and first-occurrence masks

### DIFF
--- a/src/art/preprocessing/tokenize.py
+++ b/src/art/preprocessing/tokenize.py
@@ -25,6 +25,7 @@ from ..trajectories import (
     TokenFlag,
     Trajectory,
     TrajectoryGroup,
+    _FirstOccurrenceTrie,
     get_messages,
 )
 from ..trajectories._selection import ModelSelector, resolve_training_model
@@ -757,9 +758,7 @@ def tokenize_trajectory_groups(
             if trajectory.exchanges:
                 from ..trajectories._tokenize import (
                     _as_tokenizer,
-                    _first_introduction_mask,
                     _require_causal_predecessor,
-                    _SampledSourceKey,
                     _tokenize_trajectory_with_trace,
                 )
 
@@ -782,7 +781,7 @@ def tokenize_trajectory_groups(
                         "local tokenization or chat-template rendering was required."
                     )
                 trajectory_results = []
-                seen_source_keys: set[_SampledSourceKey] = set()
+                occurrences = _FirstOccurrenceTrie()
                 for exchange_result, trace in zip(
                     exchange_results.histories, traces, strict=True
                 ):
@@ -790,9 +789,12 @@ def tokenize_trajectory_groups(
                         _max_sequence_length is not None
                         and len(exchange_result.tokens) > _max_sequence_length
                     ):
-                        preview_seen = set(seen_source_keys)
-                        would_train = _first_introduction_mask(
-                            trace.source_keys, preview_seen
+                        would_train = occurrences.mask(
+                            exchange_result.model,
+                            exchange_result.tokens,
+                            exchange_result.flags,
+                            where=TokenFlag.SAMPLED,
+                            claim=False,
                         )
                         if any(would_train):
                             trajectory_results.append(
@@ -814,8 +816,11 @@ def tokenize_trajectory_groups(
                                 )
                             )
                         continue
-                    trainable = _first_introduction_mask(
-                        trace.source_keys, seen_source_keys
+                    trainable = occurrences.mask(
+                        exchange_result.model,
+                        exchange_result.tokens,
+                        exchange_result.flags,
+                        where=TokenFlag.SAMPLED,
                     )
                     _require_causal_predecessor(trainable)
                     if not any(trainable):

--- a/src/art/tinker_native/data.py
+++ b/src/art/tinker_native/data.py
@@ -15,6 +15,7 @@ from ..trajectories import (
     TokenizedHistory,
     Trajectory,
     TrajectoryGroup,
+    _FirstOccurrenceTrie,
     get_messages,
 )
 from ..trajectories._selection import ModelSelector, resolve_training_model
@@ -164,26 +165,24 @@ def trajectory_groups_to_datums(
             continue
         for trajectory, advantage in zip(group.trajectories, advantages):
             if trajectory.exchanges:
-                from ..trajectories._tokenize import (
-                    _as_tokenizer,
-                    _first_introduction_mask,
-                    _SampledSourceKey,
-                    _tokenize_trajectory_with_trace,
-                )
+                from ..trajectories._tokenize import _as_tokenizer
 
                 selected_model = resolve_training_model(trajectory, model)
-                tokenized, traces = _tokenize_trajectory_with_trace(
-                    trajectory,
+                tokenized = trajectory.tokenize(
+                    multi_history=True,
                     model=selected_model,
                     base_model=base_model,
                     tokenizer=_as_tokenizer(tokenizer)
                     if tokenizer is not None
                     else None,
                 )
-                seen_source_keys: set[_SampledSourceKey] = set()
-                for history, trace in zip(tokenized.histories, traces, strict=True):
-                    trainable = _first_introduction_mask(
-                        trace.source_keys, seen_source_keys
+                occurrences = _FirstOccurrenceTrie()
+                for history in tokenized.histories:
+                    trainable = occurrences.mask(
+                        history.model,
+                        history.tokens,
+                        history.flags,
+                        where=TokenFlag.SAMPLED,
                     )
                     datum = _tokenized_trajectory_to_datum(
                         history, advantage, trainable=trainable

--- a/src/art/trajectories/__init__.py
+++ b/src/art/trajectories/__init__.py
@@ -149,16 +149,22 @@ class Tokenizer(Protocol):
 
 
 class TokenFlag(IntFlag):
-    """Independent facts about a token; members may be combined."""
+    """Independent facts about a token; members may be combined.
+
+    ``ASSISTANT`` is structural and may include request context. ``OUTPUT`` is
+    reconstructed response provenance; ``SAMPLED`` is authoritative server output.
+    """
 
     # The ID came from inference metadata rather than client-side tokenization.
     EXACT = 1 << 0
-    # The exact token ID belongs to a model-sampled response rather than its prompt.
+    # The server returned this exact output token ID (implies EXACT | OUTPUT).
     SAMPLED = 1 << 1
-    # The token is in a rendered assistant continuation and may be inexact.
+    # The token occupies a rendered assistant-role region and may be inexact.
     ASSISTANT = 1 << 2
     # The token belongs to a generation-terminating token or sequence.
     STOP = 1 << 3
+    # Best-effort provenance that the token came from a concrete response.
+    OUTPUT = 1 << 4
 
 
 class ChatCompletionsRequest(TypedDict, total=False, extra_items=Any):
@@ -1091,13 +1097,22 @@ class TokenizedHistory(_StringInterningModel):
     def validate_tokenwise_lengths(self) -> TokenizedHistory:
         if not (len(self.tokens) == len(self.logprobs) == len(self.flags)):
             raise ValueError("Tokenized history fields differ in length")
-        if any(
-            flag & TokenFlag.SAMPLED and not flag & TokenFlag.EXACT
-            for flag in self.flags
-        ):
-            raise ValueError(
-                "SAMPLED tokens must also be EXACT; regenerate this tokenization"
-            )
+        needs_output = False
+        for flag in self.flags:
+            if not flag & TokenFlag.SAMPLED:
+                continue
+            if not flag & TokenFlag.EXACT:
+                raise ValueError(
+                    "SAMPLED tokens must also be EXACT; regenerate this tokenization"
+                )
+            needs_output |= not bool(flag & TokenFlag.OUTPUT)
+        # Serialized tokenizations predating OUTPUT remain valid: SAMPLED is
+        # authoritative output provenance and therefore implies OUTPUT.
+        if needs_output:
+            self.flags = [
+                flag | TokenFlag.OUTPUT if flag & TokenFlag.SAMPLED else flag
+                for flag in self.flags
+            ]
         return self
 
     def tensorize(
@@ -1205,6 +1220,13 @@ class TokenizedMultiHistoryTrajectory(_StringInterningModel):
         self, *, device: torch.device | str | None = None
     ) -> TensorizedMultiHistoryTrajectory:
         return _load_tensors().tensorize_multi_history_trajectory(self, device=device)
+
+    def first_occurrence_masks(
+        self, *, where: TokenFlag | None = None
+    ) -> list[list[bool]]:
+        """Select the first eligible occurrence of each model-visible prefix."""
+
+        return first_occurrence_masks(self.histories, where=where)
 
 
 TokenizedTrajectoryT = TypeVar(
@@ -1584,6 +1606,92 @@ async def tensorize(
     )
 
 
+class _TokenPrefixNode:
+    __slots__ = ("children", "claimed")
+
+    def __init__(self) -> None:
+        self.children: dict[int, _TokenPrefixNode] = {}
+        self.claimed = False
+
+
+class _FirstOccurrenceTrie:
+    """Track claimed token-prefix edges independently for each model."""
+
+    def __init__(self) -> None:
+        self._roots: dict[str, _TokenPrefixNode] = {}
+
+    def mask(
+        self,
+        model: str,
+        tokens: Iterable[int],
+        flags: Iterable[int | TokenFlag],
+        *,
+        where: TokenFlag | None = None,
+        claim: bool = True,
+    ) -> list[bool]:
+        node = self._roots.setdefault(model, _TokenPrefixNode())
+        result: list[bool] = []
+        sentinel = int(where) if where is not None else None
+        for token, flag in zip(tokens, flags, strict=True):
+            node = node.children.setdefault(int(token), _TokenPrefixNode())
+            eligible = sentinel is None or bool(int(flag) & sentinel)
+            first = eligible and not node.claimed
+            result.append(first)
+            if first and claim:
+                node.claimed = True
+        return result
+
+
+@overload
+def first_occurrence_masks(
+    histories: Iterable[TokenizedHistory],
+    *,
+    where: TokenFlag | None = None,
+) -> list[list[bool]]: ...
+
+
+@overload
+def first_occurrence_masks(
+    histories: Iterable[TensorizedHistory],
+    *,
+    where: TokenFlag | None = None,
+) -> list[torch.Tensor]: ...
+
+
+def first_occurrence_masks(
+    histories: Iterable[TokenizedHistory] | Iterable[TensorizedHistory],
+    *,
+    where: TokenFlag | None = None,
+) -> list[list[bool]] | list[torch.Tensor]:
+    """Return first-occurrence masks for complete model-visible token prefixes.
+
+    ``where=None`` selects every unique position. A flag selects and deduplicates
+    only positions carrying any requested bit; ineligible positions do not claim
+    their prefix for a later history. ``ASSISTANT`` is structural and can include
+    request context; use ``OUTPUT`` for reconstructed response tokens or
+    ``SAMPLED`` when authoritative server output IDs are required.
+    """
+
+    values = list(histories)
+    if not values:
+        return []
+    if all(isinstance(history, TokenizedHistory) for history in values):
+        trie = _FirstOccurrenceTrie()
+        return [
+            trie.mask(
+                history.model,
+                history.tokens,
+                history.flags,
+                where=where,
+            )
+            for history in cast(list[TokenizedHistory], values)
+        ]
+    tensors = _load_tensors()
+    if all(isinstance(history, tensors.TensorizedHistory) for history in values):
+        return tensors.first_occurrence_masks(cast(Any, values), where=where)
+    raise TypeError("histories must be uniformly tokenized or tensorized")
+
+
 def get_messages(messages_and_choices: MessagesAndChoices) -> Messages:
     from ._compat import messages_from_legacy_history
 
@@ -1673,5 +1781,6 @@ __all__ = [
     "trajectory_group",
     "tokenize",
     "tensorize",
+    "first_occurrence_masks",
     "get_messages",
 ]

--- a/src/art/trajectories/__init__.py
+++ b/src/art/trajectories/__init__.py
@@ -1629,15 +1629,33 @@ class _FirstOccurrenceTrie:
         where: TokenFlag | None = None,
         claim: bool = True,
     ) -> list[bool]:
-        node = self._roots.setdefault(model, _TokenPrefixNode())
         result: list[bool] = []
         sentinel = int(where) if where is not None else None
+        if not claim:
+            node = self._roots.get(model)
+            missing = node is None
+            for token, flag in zip(tokens, flags, strict=True):
+                if not missing:
+                    assert node is not None
+                    child = node.children.get(int(token))
+                    missing = child is None
+                    if child is not None:
+                        node = child
+                eligible = sentinel is None or bool(int(flag) & sentinel)
+                if missing:
+                    result.append(eligible)
+                else:
+                    assert node is not None
+                    result.append(eligible and not node.claimed)
+            return result
+
+        node = self._roots.setdefault(model, _TokenPrefixNode())
         for token, flag in zip(tokens, flags, strict=True):
             node = node.children.setdefault(int(token), _TokenPrefixNode())
             eligible = sentinel is None or bool(int(flag) & sentinel)
             first = eligible and not node.claimed
             result.append(first)
-            if first and claim:
+            if first:
                 node.claimed = True
         return result
 

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from bisect import bisect_left
 import codecs
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
@@ -12,7 +12,7 @@ import json
 import math
 import re
 import threading
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 import warnings
 
 from anthropic.types import Message, MessageParam, TextBlock
@@ -522,8 +522,10 @@ def _prove_exact_sampled_assistant_span(
     return start, end
 
 
-def _rendered_flag(assistant: bool, stop: bool) -> TokenFlag:
+def _rendered_flag(assistant: bool, output: bool, stop: bool) -> TokenFlag:
     flag = TokenFlag.ASSISTANT if assistant else TokenFlag(0)
+    if output:
+        flag |= TokenFlag.OUTPUT
     return flag | TokenFlag.STOP if stop else flag
 
 
@@ -577,6 +579,51 @@ def _synthetic_length_stop_mask(
     return mask
 
 
+def _response_output_mask(
+    messages: Sequence[Mapping[str, object]],
+    sources: Sequence[object | None],
+    assistant_mask: Sequence[bool],
+) -> list[bool]:
+    """Mark assistant spans backed by concrete exchange responses."""
+
+    assistant_sources = [
+        source
+        for message, source in zip(messages, sources, strict=True)
+        if message.get("role") == "assistant"
+    ]
+    spans: list[tuple[int, int]] = []
+    start = 0
+    while start < len(assistant_mask):
+        if not assistant_mask[start]:
+            start += 1
+            continue
+        end = start + 1
+        while end < len(assistant_mask) and assistant_mask[end]:
+            end += 1
+        spans.append((start, end))
+        start = end
+    result = [False] * len(assistant_mask)
+    if len(spans) != len(assistant_sources):
+        # Some minimal/custom templates concatenate adjacent assistant items.
+        # That loses the boundary between those items, but attribution remains
+        # unambiguous when every merged item has the same provenance class.
+        output_sources = [
+            source is not None and _source_is_sampled(source)
+            for source in assistant_sources
+        ]
+        if output_sources and all(output_sources):
+            return list(assistant_mask)
+        if not any(output_sources):
+            return result
+        raise ValueError(
+            "Could not uniquely attribute rendered assistant spans to source turns"
+        )
+    for source, (start, end) in zip(assistant_sources, spans, strict=True):
+        if source is not None and _source_is_sampled(source):
+            result[start:end] = [True] * (end - start)
+    return result
+
+
 @dataclass(frozen=True)
 class _SampledOutput:
     text: str | None
@@ -612,19 +659,6 @@ class _HistoryTokenizationTrace:
                 )
             if source_key is not None and source_key not in self.sources:
                 raise AssertionError("Tokenization trace source key is unresolved")
-
-
-_SourceKeyT = TypeVar("_SourceKeyT", bound=Hashable)
-
-
-def _first_introduction_mask(
-    source_keys: Sequence[_SourceKeyT | None],
-    seen: set[_SourceKeyT],
-) -> list[bool]:
-    keys = {key for key in source_keys if key is not None}
-    new_keys = keys - seen
-    seen.update(keys)
-    return [key in new_keys if key is not None else False for key in source_keys]
 
 
 def _require_causal_predecessor(trainable: Sequence[bool]) -> None:
@@ -2241,7 +2275,12 @@ def _legacy_tokenize(
             completion_logprobs = [math.nan] * len(completion)
         logprobs.extend(completion_logprobs)
         flags.extend(
-            [TokenFlag.EXACT | TokenFlag.SAMPLED | TokenFlag.ASSISTANT]
+            [
+                TokenFlag.EXACT
+                | TokenFlag.SAMPLED
+                | TokenFlag.ASSISTANT
+                | TokenFlag.OUTPUT
+            ]
             * len(completion)
         )
         if item.finish_reason in {"stop", "tool_calls", "function_call"}:
@@ -2511,8 +2550,9 @@ def _tokenize_exchange_trajectory(
             if isinstance(exchange, CompletionsExchange)
             else TokenFlag.ASSISTANT
         )
+        completion_flag |= TokenFlag.OUTPUT
         if completion_is_exact:
-            completion_flag |= TokenFlag.EXACT | TokenFlag.SAMPLED
+            completion_flag |= TokenFlag.EXACT | TokenFlag.SAMPLED | TokenFlag.OUTPUT
         flags.extend([completion_flag] * len(completion))
         if completion_is_exact:
             source_key = _exchange_sampled_source_key(exchange)
@@ -3475,7 +3515,13 @@ def _tokenize_exact_responses_history(
         token_ids.extend(output)
         logprobs.extend(output_logprobs)
         flags.extend(
-            [TokenFlag.EXACT | TokenFlag.SAMPLED | TokenFlag.ASSISTANT] * len(output)
+            [
+                TokenFlag.EXACT
+                | TokenFlag.SAMPLED
+                | TokenFlag.ASSISTANT
+                | TokenFlag.OUTPUT
+            ]
+            * len(output)
         )
         source = next(
             (
@@ -3979,7 +4025,12 @@ def _tokenize_exact_projected_chat_history(
     flags = [
         *([TokenFlag.EXACT] * len(final_prompt)),
         *(
-            [TokenFlag.EXACT | TokenFlag.SAMPLED | TokenFlag.ASSISTANT]
+            [
+                TokenFlag.EXACT
+                | TokenFlag.SAMPLED
+                | TokenFlag.ASSISTANT
+                | TokenFlag.OUTPUT
+            ]
             * len(final_output)
         ),
         *terminal_flags,
@@ -4029,7 +4080,7 @@ def _tokenize_exact_projected_chat_history(
         if final_prompt[start:end] != retained_ids:
             return None
         flags[start:end] = [
-            TokenFlag.EXACT | TokenFlag.SAMPLED | TokenFlag.ASSISTANT
+            TokenFlag.EXACT | TokenFlag.SAMPLED | TokenFlag.ASSISTANT | TokenFlag.OUTPUT
         ] * len(retained_ids)
         logprobs[start:end] = retained_logprobs
         source_key = _sampled_source_key(source)
@@ -4635,8 +4686,16 @@ def _tokenize_chat_view(
         canonical_assistant_mask,
         canonical_stop_mask,
     )
+    canonical_output_mask = _response_output_mask(
+        messages,
+        history.message_sources,
+        canonical_assistant_mask,
+    )
     assistant_mask = _translate_token_mask(
         canonical_rendered, rendered, canonical_assistant_mask
+    )
+    output_mask = _translate_token_mask(
+        canonical_rendered, rendered, canonical_output_mask
     )
     stop_mask = _translate_token_mask(canonical_rendered, rendered, canonical_stop_mask)
     length_stop_mask = _translate_token_mask(
@@ -5645,9 +5704,14 @@ def _tokenize_chat_view(
         token_ids.extend(rendered[cursor:start])
         logprobs.extend([math.nan] * (start - cursor))
         flags.extend(
-            _rendered_flag(assistant and not length_stop, stop)
-            for assistant, stop, length_stop in zip(
+            _rendered_flag(
+                assistant and not length_stop,
+                output and not length_stop,
+                stop,
+            )
+            for assistant, output, stop, length_stop in zip(
                 assistant_mask[cursor:start],
+                output_mask[cursor:start],
                 stop_mask[cursor:start],
                 length_stop_mask[cursor:start],
                 strict=True,
@@ -5670,6 +5734,7 @@ def _tokenize_chat_view(
                 TokenFlag.EXACT
                 | TokenFlag.SAMPLED
                 | TokenFlag.ASSISTANT
+                | TokenFlag.OUTPUT
                 | (TokenFlag.STOP if stop else TokenFlag(0))
                 for stop in replacement_stop_mask
             )
@@ -5683,7 +5748,11 @@ def _tokenize_chat_view(
                 else [math.nan] * len(replacement)
             )
             flags.extend(
-                _rendered_flag(not length_stop, stop)
+                _rendered_flag(
+                    not length_stop,
+                    not length_stop,
+                    stop,
+                )
                 for stop, length_stop in zip(
                     replacement_stop_mask,
                     replacement_length_stop_mask,
@@ -5695,9 +5764,14 @@ def _tokenize_chat_view(
     token_ids.extend(rendered[cursor:])
     logprobs.extend([math.nan] * (len(rendered) - cursor))
     flags.extend(
-        _rendered_flag(assistant and not length_stop, stop)
-        for assistant, stop, length_stop in zip(
+        _rendered_flag(
+            assistant and not length_stop,
+            output and not length_stop,
+            stop,
+        )
+        for assistant, output, stop, length_stop in zip(
             assistant_mask[cursor:],
+            output_mask[cursor:],
             stop_mask[cursor:],
             length_stop_mask[cursor:],
             strict=True,
@@ -5769,7 +5843,9 @@ def _tokenize_completions_token_history(
     for start, end in history.sampled_spans:
         if start < 0 or end <= start or end > len(history.prompt):
             raise ValueError("Completions sampled spans are out of bounds")
-        flags[start:end] = [TokenFlag.EXACT | TokenFlag.SAMPLED] * (end - start)
+        flags[start:end] = [TokenFlag.EXACT | TokenFlag.SAMPLED | TokenFlag.OUTPUT] * (
+            end - start
+        )
     for span in history.prompt_sources:
         if span.source is None:
             continue
@@ -5975,6 +6051,8 @@ def _tokenize_completions_string_history(
             )
             logprobs.extend(visible or [math.nan] * len(ids))
         flag = TokenFlag.EXACT if exact is not None else TokenFlag(0)
+        if is_sampled:
+            flag |= TokenFlag.OUTPUT
         if is_sampled and exact is not None:
             flag |= TokenFlag.SAMPLED
         flags.extend([flag] * len(ids))

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -583,8 +583,36 @@ def _response_output_mask(
     messages: Sequence[Mapping[str, object]],
     sources: Sequence[object | None],
     assistant_mask: Sequence[bool],
+    message_bounds: Sequence[tuple[int, int]] | None = None,
 ) -> list[bool]:
     """Mark assistant spans backed by concrete exchange responses."""
+
+    result = [False] * len(assistant_mask)
+    if message_bounds is not None:
+        if len(message_bounds) != len(messages):
+            raise ValueError("Message bounds differ in length from messages")
+        for message, source, (start, end) in zip(
+            messages, sources, message_bounds, strict=True
+        ):
+            if (
+                message.get("role") == "assistant"
+                and source is not None
+                and _source_is_sampled(source)
+            ):
+                result[start:end] = [True] * (end - start)
+        # A direct content render can gain one template-owned role stop above.
+        # Attribute that tail to the final assistant response without merging
+        # adjacent assistant messages with different provenance.
+        if messages and messages[-1].get("role") == "assistant":
+            start = message_bounds[-1][1]
+            source = sources[-1]
+            if (
+                source is not None
+                and _source_is_sampled(source)
+                and all(assistant_mask[start:])
+            ):
+                result[start:] = [True] * (len(result) - start)
+        return result
 
     assistant_sources = [
         source
@@ -602,7 +630,6 @@ def _response_output_mask(
             end += 1
         spans.append((start, end))
         start = end
-    result = [False] * len(assistant_mask)
     if len(spans) != len(assistant_sources):
         # Some minimal/custom templates concatenate adjacent assistant items.
         # That loses the boundary between those items, but attribution remains
@@ -4690,6 +4717,7 @@ def _tokenize_chat_view(
         messages,
         history.message_sources,
         canonical_assistant_mask,
+        direct_bounds or None,
     )
     assistant_mask = _translate_token_mask(
         canonical_rendered, rendered, canonical_assistant_mask

--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -599,7 +599,7 @@ def _response_output_mask(
                 and source is not None
                 and _source_is_sampled(source)
             ):
-                result[start:end] = [True] * (end - start)
+                result[start:end] = assistant_mask[start:end]
         # A direct content render can gain one template-owned role stop above.
         # Attribute that tail to the final assistant response without merging
         # adjacent assistant messages with different provenance.
@@ -2579,7 +2579,7 @@ def _tokenize_exchange_trajectory(
         )
         completion_flag |= TokenFlag.OUTPUT
         if completion_is_exact:
-            completion_flag |= TokenFlag.EXACT | TokenFlag.SAMPLED | TokenFlag.OUTPUT
+            completion_flag |= TokenFlag.EXACT | TokenFlag.SAMPLED
         flags.extend([completion_flag] * len(completion))
         if completion_is_exact:
             source_key = _exchange_sampled_source_key(exchange)

--- a/src/art/trajectories/tensors.py
+++ b/src/art/trajectories/tensors.py
@@ -24,6 +24,7 @@ from . import (
     Trajectory,
     TrajectoryGroup,
     TrajectoryHistory,
+    _FirstOccurrenceTrie,
     _StringInterningModel,
 )
 from ._serialization import (
@@ -106,6 +107,9 @@ class TensorizedHistory(_StringInterningModel):
         if not (len(self.tokens) == len(self.logprobs) == len(self.flags)):
             raise ValueError("Tensorized history fields differ in length")
         sampled = self.flags.bitwise_and(int(TokenFlag.SAMPLED)).bool()
+        self.flags = self.flags.bitwise_or(
+            sampled.to(self.flags.dtype) * int(TokenFlag.OUTPUT)
+        )
         exact = self.flags.bitwise_and(int(TokenFlag.EXACT)).bool()
         if bool((sampled & ~exact).any().item()):
             raise ValueError(
@@ -201,10 +205,37 @@ class TensorizedMultiHistoryTrajectory(_StringInterningModel):
             history.to(device)
         return self
 
+    def first_occurrence_masks(
+        self, *, where: TokenFlag | None = None
+    ) -> list[torch.Tensor]:
+        """Select the first eligible occurrence of each model-visible prefix."""
+
+        return first_occurrence_masks(self.histories, where=where)
+
     def compact_dump(self) -> CompactTrajectoryPayload:
         from ._compact import dump
 
         return dump(self)
+
+
+def first_occurrence_masks(
+    histories: list[TensorizedHistory],
+    *,
+    where: TokenFlag | None = None,
+) -> list[torch.Tensor]:
+    """Tensor implementation using one bulk device transfer per source tensor."""
+
+    trie = _FirstOccurrenceTrie()
+    result: list[torch.Tensor] = []
+    for history in histories:
+        tokens, flags = (
+            torch.stack((history.tokens, history.flags)).detach().cpu().tolist()
+        )
+        mask = trie.mask(history.model, tokens, flags, where=where)
+        result.append(
+            torch.tensor(mask, dtype=torch.bool, device=history.tokens.device)
+        )
+    return result
 
 
 TensorizedTrajectoryT = TypeVar(

--- a/tests/unit/test_exchange_training_model_selection.py
+++ b/tests/unit/test_exchange_training_model_selection.py
@@ -18,7 +18,7 @@ from art import TrainableModel
 from art.dev.model import InternalModelConfig
 from art.local import LocalBackend
 from art.openai import ART_MOE_ROUTING_METADATA_KEY
-from art.preprocessing.moe_routing import MoeRouteSegments
+from art.preprocessing.moe_routing import MoeRouteArray
 from art.preprocessing.tokenize import (
     TokenizedResult,
     _chat_choice_trace,
@@ -42,7 +42,6 @@ from art.trajectories._selection import (
     resolve_training_model,
 )
 from art.trajectories._tokenize import (
-    _first_introduction_mask,
     _HistoryTokenizationTrace,
 )
 
@@ -255,36 +254,6 @@ def _versioned_group() -> art.TrajectoryGroup:
 
 class _Tokenizer:
     name_or_path = "base/model"
-
-
-def test_first_introduction_mask_trains_repeated_sources_once_across_histories() -> (
-    None
-):
-    seen: set[str] = set()
-    assert _first_introduction_mask([None, "a", "a"], seen) == [
-        False,
-        True,
-        True,
-    ]
-    assert _first_introduction_mask([None, "a", "a", None, "b"], seen) == [
-        False,
-        False,
-        False,
-        False,
-        True,
-    ]
-    assert _first_introduction_mask(
-        [None, "a", "a", None, "b", None, "c", "c"], seen
-    ) == [
-        False,
-        False,
-        False,
-        False,
-        False,
-        False,
-        True,
-        True,
-    ]
 
 
 def test_preprocessing_requires_model_selection() -> None:
@@ -819,20 +788,17 @@ def test_preprocessing_preserves_moe_routes_for_reasoning_stripped_suffix() -> N
     assert len(initial) == 2
     assert len(stripped) == 2
     assert all(result.choice_offsets == [1] for result in initial)
-    assert all(result.choice_offsets == [5] for result in stripped)
+    assert all(result.choice_offsets == [1, 5] for result in stripped)
     assert all(result.assistant_mask == [0, 1, 1, 1, 1] for result in initial)
-    assert all(result.assistant_mask == [0, 0, 0, 0, 0, 1, 1] for result in stripped)
-    assert all(result.weight == pytest.approx(1 / 6) for result in results)
+    assert all(result.assistant_mask == [0, 1, 1, 1, 0, 1, 1] for result in stripped)
+    assert all(result.weight == pytest.approx(1 / 9) for result in results)
     expected_routes = np.asarray(
         [[[10]], [[1010]], [[1020]], [[90]], [[40]], [[50]], [[60]]],
         dtype=np.uint16,
     )
     for result in stripped:
-        assert isinstance(result.moe_routed_experts, MoeRouteSegments)
-        assert np.array_equal(
-            np.concatenate(result.moe_routed_experts.segments),
-            expected_routes,
-        )
+        assert isinstance(result.moe_routed_experts, MoeRouteArray)
+        assert np.array_equal(result.moe_routed_experts, expected_routes)
 
     datums = trajectory_groups_to_datums(
         [group],
@@ -844,7 +810,7 @@ def test_preprocessing_preserves_moe_routes_for_reasoning_stripped_suffix() -> N
     )
     masks = [datum.loss_fn_inputs["mask"].to_torch().tolist() for datum in datums]
     assert masks.count([1, 1, 1, 1]) == 2
-    assert masks.count([0, 0, 0, 0, 1, 1]) == 2
+    assert masks.count([1, 1, 1, 0, 1, 1]) == 2
 
 
 def test_ambiguous_non_moe_suffix_falls_back_to_sampled_spans() -> None:
@@ -868,9 +834,9 @@ def test_ambiguous_non_moe_suffix_falls_back_to_sampled_spans() -> None:
             [1, 11, 2, 11],
             [
                 tr.TokenFlag.EXACT,
-                tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+                tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT,
                 tr.TokenFlag.EXACT,
-                tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+                tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT,
             ],
         )
         is None
@@ -902,10 +868,10 @@ def test_chat_choice_trace_anchors_retained_suffix_at_its_prompt_boundary() -> N
         [1, 8, 9, 7, 8],
         [
             tr.TokenFlag.EXACT,
-            tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+            tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT,
             tr.TokenFlag.EXACT,
-            tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
-            tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+            tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT,
+            tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT,
         ],
     )
 
@@ -946,7 +912,7 @@ def test_chat_choice_trace_does_bounded_work_for_a_retained_suffix() -> None:
     token_ids = CountingList([1, 7, *([0] * 510)])
     flags = [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT,
         *([tr.TokenFlag.EXACT] * 510),
     ]
 

--- a/tests/unit/test_exchange_training_model_selection.py
+++ b/tests/unit/test_exchange_training_model_selection.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
-from typing import SupportsIndex, cast, overload
+from typing import Any, SupportsIndex, cast, overload
 from unittest.mock import patch
 
 import numpy as np
@@ -339,14 +339,24 @@ def test_training_tokenizes_each_exchange_trajectory_once(
     )
     assert calls == len(group.trajectories)
 
-    calls = 0
+    public_calls = 0
+    original_public = art.Trajectory.tokenize
+
+    def counted_public(
+        self: art.Trajectory, *args: Any, **kwargs: Any
+    ) -> TokenizedMultiHistoryTrajectory:
+        nonlocal public_calls
+        public_calls += 1
+        return cast(TokenizedMultiHistoryTrajectory, original_public(self, *args, **kwargs))
+
+    monkeypatch.setattr(art.Trajectory, "tokenize", counted_public)
     trajectory_groups_to_datums(
         [group],
         renderer=None,
         tokenizer=None,
         model="policy",
     )
-    assert calls == len(group.trajectories)
+    assert public_calls == len(group.trajectories)
 
 
 def test_overlength_history_does_not_claim_sources_from_fitting_history() -> None:

--- a/tests/unit/test_exchange_training_model_selection.py
+++ b/tests/unit/test_exchange_training_model_selection.py
@@ -347,7 +347,9 @@ def test_training_tokenizes_each_exchange_trajectory_once(
     ) -> TokenizedMultiHistoryTrajectory:
         nonlocal public_calls
         public_calls += 1
-        return cast(TokenizedMultiHistoryTrajectory, original_public(self, *args, **kwargs))
+        return cast(
+            TokenizedMultiHistoryTrajectory, original_public(self, *args, **kwargs)
+        )
 
     monkeypatch.setattr(art.Trajectory, "tokenize", counted_public)
     trajectory_groups_to_datums(
@@ -798,6 +800,8 @@ def test_preprocessing_preserves_moe_routes_for_reasoning_stripped_suffix() -> N
     assert len(initial) == 2
     assert len(stripped) == 2
     assert all(result.choice_offsets == [1] for result in initial)
+    # The retained response has a different complete visible prefix after its
+    # reasoning is stripped, so it is independently eligible in this history.
     assert all(result.choice_offsets == [1, 5] for result in stripped)
     assert all(result.assistant_mask == [0, 1, 1, 1, 1] for result in initial)
     assert all(result.assistant_mask == [0, 1, 1, 1, 0, 1, 1] for result in stripped)

--- a/tests/unit/test_tau_bench_client.py
+++ b/tests/unit/test_tau_bench_client.py
@@ -956,9 +956,15 @@ async def test_rollout_captures_two_turn_tool_exchange_with_exact_tokens() -> No
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.EXACT
+        | tr.TokenFlag.SAMPLED
+        | tr.TokenFlag.ASSISTANT
+        | tr.TokenFlag.OUTPUT,
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.EXACT
+        | tr.TokenFlag.SAMPLED
+        | tr.TokenFlag.ASSISTANT
+        | tr.TokenFlag.OUTPUT,
     ]
 
 

--- a/tests/unit/trajectories/test_compact_serialization.py
+++ b/tests/unit/trajectories/test_compact_serialization.py
@@ -638,7 +638,7 @@ def test_tokenized_compact_round_trip_all_protocol_source_shapes() -> None:
             logprobs=[float("nan"), -0.1],
             flags=[
                 tr.TokenFlag.EXACT,
-                tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+                tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT,
             ],
         )
 

--- a/tests/unit/trajectories/test_history.py
+++ b/tests/unit/trajectories/test_history.py
@@ -706,7 +706,7 @@ def test_history_accepts_user_authored_messages_with_none_source() -> None:
     tokenized = history.tokenize(tokenizer=Tokenizer())
 
     assert tokenized.tokens == [10, 20, 30]
-    assert tokenized.flags[1] == tr.TokenFlag.ASSISTANT
+    assert tokenized.flags[1] == tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT
 
 
 def test_protocol_histories_convert_to_chat_and_history_rejects_ambiguity() -> None:
@@ -1901,7 +1901,10 @@ def test_anthropic_exact_regeneration_preserves_sampled_source() -> None:
     assert tokenized.tokens == [1, 101, 3, 5]
     assert tokenized.logprobs[1] == -101.0
     assert tokenized.flags[1] == (
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT
+        tr.TokenFlag.EXACT
+        | tr.TokenFlag.SAMPLED
+        | tr.TokenFlag.ASSISTANT
+        | tr.TokenFlag.OUTPUT
     )
 
 

--- a/tests/unit/trajectories/test_parallel_tokenize.py
+++ b/tests/unit/trajectories/test_parallel_tokenize.py
@@ -33,7 +33,10 @@ def _tokenized(trajectory: art.Trajectory) -> tr.TokenizedTrajectory:
         model="policy",
         tokens=[index, index + 1],
         logprobs=[math.nan, -0.25],
-        flags=[tr.TokenFlag.EXACT, tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED],
+        flags=[
+            tr.TokenFlag.EXACT,
+            tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT,
+        ],
         trajectory=trajectory,
     )
 

--- a/tests/unit/trajectories/test_tensorized_models.py
+++ b/tests/unit/trajectories/test_tensorized_models.py
@@ -24,7 +24,10 @@ def _tokenized_history() -> tr.TokenizedHistory:
         logprobs=[math.nan, -0.25],
         flags=[
             tr.TokenFlag.EXACT,
-            tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.STOP,
+            tr.TokenFlag.EXACT
+            | tr.TokenFlag.SAMPLED
+            | tr.TokenFlag.OUTPUT
+            | tr.TokenFlag.STOP,
         ],
     )
 
@@ -34,6 +37,7 @@ def test_tensorized_history_rejects_sampled_without_exact() -> None:
     assert not hasattr(tr.TensorizedHistory, "sampled_mask")
     assert not hasattr(tr.TensorizedHistory, "assistant_mask")
     assert not hasattr(tr.TensorizedHistory, "stop_mask")
+    assert not hasattr(tr.TensorizedHistory, "output_mask")
     with pytest.raises(ValueError, match="SAMPLED tokens must also be EXACT"):
         tr.TensorizedHistory(
             history=tr.LegacyHistory(messages_and_choices=[]),
@@ -42,6 +46,16 @@ def test_tensorized_history_rejects_sampled_without_exact() -> None:
             logprobs=[math.nan],
             flags=[tr.TokenFlag.SAMPLED],
         )
+    legacy = tr.TensorizedHistory(
+        history=tr.LegacyHistory(messages_and_choices=[]),
+        model="policy",
+        tokens=[1],
+        logprobs=[-0.1],
+        flags=[tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED],
+    )
+    assert legacy.flags.tolist() == [
+        int(tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT)
+    ]
 
 
 def _trajectory() -> art.Trajectory:

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -40,6 +40,9 @@ from art.trajectories import (
     TrajectoryExchanges,
 )
 
+_SAMPLED_OUTPUT = tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT
+_SAMPLED_ASSISTANT_OUTPUT = _SAMPLED_OUTPUT | tr.TokenFlag.ASSISTANT
+
 
 def _chat_exchange(
     prompt: list[int],
@@ -376,12 +379,7 @@ def test_exact_sampled_eos_is_stop_when_tokenizer_identifies_it() -> None:
         exchanges=TrajectoryExchanges(chat_completions=[exchange])
     ).tokenize(tokenizer=_StopTokenizer())
 
-    assert tokenized.flags[-1] == (
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP
-    )
+    assert tokenized.flags[-1] == (_SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP)
 
 
 def test_exact_sampled_tool_stop_is_stop_when_tokenizer_identifies_it() -> None:
@@ -402,12 +400,7 @@ def test_exact_sampled_tool_stop_is_stop_when_tokenizer_identifies_it() -> None:
         exchanges=TrajectoryExchanges(chat_completions=[exchange])
     ).tokenize(tokenizer=_StopTokenizer())
 
-    assert tokenized.flags[-1] == (
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP
-    )
+    assert tokenized.flags[-1] == (_SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP)
 
 
 def test_length_stop_keeps_sampled_content_and_adds_synthetic_stop() -> None:
@@ -421,7 +414,7 @@ def test_length_stop_keeps_sampled_content_and_adds_synthetic_stop() -> None:
     assert tokenized.tokens == [1, 2, 9]
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
         tr.TokenFlag.STOP,
     ]
 
@@ -443,9 +436,10 @@ def test_inexact_length_stop_is_not_attributed_to_the_assistant() -> None:
     assert tokenized.tokens == [1, 2, 9]
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
         tr.TokenFlag.STOP,
     ]
+    assert not tokenized.flags[-1] & tr.TokenFlag.OUTPUT
 
 
 def test_length_stop_without_a_template_terminator_does_not_raise() -> None:
@@ -500,7 +494,7 @@ def test_terminal_length_with_sampled_eos_still_adds_synthetic_stop() -> None:
 
     assert tokenized.tokens == [1, 2, 9, 9]
     assert tokenized.flags[-2:] == [
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
         tr.TokenFlag.STOP,
     ]
 
@@ -531,7 +525,7 @@ def test_terminal_length_stays_synthetic_after_an_earlier_length_stop() -> None:
 
     assert tokenized.tokens == [1, 2, 9, 3, 4, 9, 9]
     assert tokenized.flags[-2:] == [
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
         tr.TokenFlag.STOP,
     ]
 
@@ -937,9 +931,7 @@ def test_integer_stop_reason_marks_raw_completions_without_assistant() -> None:
         exchanges=TrajectoryExchanges(completions=[exchange])
     ).tokenize(tokenizer=_StopTokenizer())
 
-    assert tokenized.flags[-1] == (
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.STOP
-    )
+    assert tokenized.flags[-1] == (_SAMPLED_OUTPUT | tr.TokenFlag.STOP)
 
 
 def test_stop_string_marks_only_its_exact_terminal_sequence() -> None:
@@ -972,12 +964,7 @@ def test_metadata_only_final_token_is_preserved_as_sampled_stop() -> None:
     ).tokenize()
 
     assert tokenized.tokens == [1, 9]
-    assert tokenized.flags[-1] == (
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP
-    )
+    assert tokenized.flags[-1] == (_SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP)
 
 
 def test_empty_output_materializes_a_synthetic_stop() -> None:
@@ -991,7 +978,7 @@ def test_empty_output_materializes_a_synthetic_stop() -> None:
     assert tokenized.tokens == [1, 9]
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.ASSISTANT | tr.TokenFlag.STOP,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT | tr.TokenFlag.STOP,
     ]
 
 
@@ -1277,12 +1264,7 @@ def test_messages_sampled_stop_and_length_stop_provenance() -> None:
         .tokenize(tokenizer=_StopTokenizer())
     )
 
-    assert sampled.flags[-1] == (
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP
-    )
+    assert sampled.flags[-1] == (_SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP)
     assert synthetic.tokens == [1, 2, 9]
     assert synthetic.flags[-1] == tr.TokenFlag.STOP
 
@@ -1407,12 +1389,7 @@ def test_responses_sampled_stop_and_length_stop_provenance() -> None:
         .tokenize(tokenizer=_StopTokenizer())
     )
 
-    assert sampled.flags[-1] == (
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP
-    )
+    assert sampled.flags[-1] == (_SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP)
     assert synthetic.tokens == [1, 2, 9]
     assert synthetic.flags[-1] == tr.TokenFlag.STOP
 
@@ -1540,7 +1517,10 @@ def test_responses_length_status_applies_only_to_the_terminal_generation() -> No
     ]
     assert len(stops) == 2
     assert tokenized.flags[stops[0]] == (
-        tr.TokenFlag.EXACT | tr.TokenFlag.ASSISTANT | tr.TokenFlag.STOP
+        tr.TokenFlag.EXACT
+        | tr.TokenFlag.ASSISTANT
+        | tr.TokenFlag.OUTPUT
+        | tr.TokenFlag.STOP
     )
     assert tokenized.flags[stops[1]] == tr.TokenFlag.STOP
 
@@ -1575,9 +1555,9 @@ def test_exact_tokens_form_one_append_only_history_without_tokenizer(
     assert tokenized.tokens == [1, 2, 3, 4]
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
     assert math.isnan(tokenized.logprobs[0])
     assert tokenized.logprobs[1] == -0.2
@@ -1605,11 +1585,8 @@ def test_gpt_oss_exact_provenance_is_black_box() -> None:
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        _SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP,
     ]
 
 
@@ -1661,7 +1638,7 @@ def test_messages_exact_prompt_and_output_do_not_load_a_tokenizer(
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
 
 
@@ -1762,9 +1739,7 @@ def test_converted_anthropic_system_history_preserves_exact_assistant_evidence(
 
     assert tokenized.tokens == [10, 11, 12]
     assert tokenized.logprobs[-1] == pytest.approx(-0.12)
-    assert tokenized.flags[-1] == (
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT
-    )
+    assert tokenized.flags[-1] == (_SAMPLED_ASSISTANT_OUTPUT)
 
 
 def test_converted_anthropic_system_source_rejects_sampled_response_mutation() -> None:
@@ -1812,9 +1787,7 @@ def test_converted_responses_history_tokenizes_without_native_chat_exchange(
 
     assert tokenized.tokens == [10, 11, 12]
     assert tokenized.logprobs[-1] == pytest.approx(-0.1)
-    assert tokenized.flags[-1] == (
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT
-    )
+    assert tokenized.flags[-1] == (_SAMPLED_ASSISTANT_OUTPUT)
 
 
 def test_malformed_explicit_exact_token_metadata_fails_closed() -> None:
@@ -1904,7 +1877,7 @@ def test_completions_echo_preserves_prompt_logprobs_without_sampling_them() -> N
     assert tokenized.logprobs == [-0.1, -0.2]
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+        _SAMPLED_OUTPUT,
     ]
 
 
@@ -1942,8 +1915,8 @@ def test_completions_echo_does_not_strip_repeated_prompt_token_from_completion()
     assert tokenized.tokens == [1, 1, 2]
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+        _SAMPLED_OUTPUT,
+        _SAMPLED_OUTPUT,
     ]
     assert math.isnan(tokenized.logprobs[0])
     assert tokenized.logprobs[1:] == [-0.2, -0.3]
@@ -1970,8 +1943,8 @@ def test_completions_echo_strips_prompt_from_proven_combined_token_carrier() -> 
     assert tokenized.logprobs[1:] == pytest.approx([-0.2, -0.3])
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+        _SAMPLED_OUTPUT,
+        _SAMPLED_OUTPUT,
     ]
 
 
@@ -1995,7 +1968,7 @@ def test_completions_echo_strips_prompt_from_proven_textual_carrier() -> None:
     assert tokenized.logprobs == pytest.approx([-0.1, -0.2])
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+        _SAMPLED_OUTPUT,
     ]
 
 
@@ -2019,8 +1992,8 @@ def test_completions_echo_prefers_full_logprob_carrier_to_id_prefix_heuristic() 
     assert tokenized.logprobs == [-0.1, -0.2, -0.3]
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+        _SAMPLED_OUTPUT,
+        _SAMPLED_OUTPUT,
     ]
 
 
@@ -2056,7 +2029,7 @@ def test_completions_echo_without_prompt_ids_falls_back_without_sampling_prompt(
     assert tokenized.tokens == [1, 2]
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag(0),
+        tr.TokenFlag.OUTPUT,
     ]
     assert all(math.isnan(logprob) for logprob in tokenized.logprobs)
 
@@ -2142,7 +2115,7 @@ def test_mutated_completions_token_prompt_drops_stale_exact_evidence() -> None:
     assert tokenized.tokens == [99, 2]
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+        _SAMPLED_OUTPUT,
     ]
 
 
@@ -2237,7 +2210,7 @@ def test_completions_string_history_preserves_textual_logprobs() -> None:
 
     assert tokenized.tokens == [1, 2]
     assert tokenized.logprobs[1] == -0.8
-    assert tokenized.flags[1] == tr.TokenFlag(0)
+    assert tokenized.flags[1] == tr.TokenFlag.OUTPUT
 
 
 def test_mutated_completions_string_prompt_retokens_without_stale_exact() -> None:
@@ -2320,11 +2293,11 @@ def test_batched_completions_map_each_choice_to_its_prompt() -> None:
     assert [history.flags for history in tokenized.histories] == [
         [
             tr.TokenFlag.EXACT,
-            tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+            _SAMPLED_OUTPUT,
         ],
         [
             tr.TokenFlag.EXACT,
-            tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+            _SAMPLED_OUTPUT,
         ],
     ]
 
@@ -2409,7 +2382,7 @@ def test_randomized_completions_projection_preserves_every_choice_once() -> None
             history.flags
             == [
                 tr.TokenFlag.EXACT,
-                tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED,
+                _SAMPLED_OUTPUT,
             ]
             for history in tokenized.histories
         )
@@ -2933,7 +2906,7 @@ def test_fallback_uses_template_overrides_and_nan_logprobs(
     assert loaded_base_models == ["base/model"]
     assert result.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
     assert math.isnan(result.logprobs[1])
     assert tokenizer.calls
@@ -3260,12 +3233,12 @@ def test_reasoning_stripped_messages_history_preserves_exact_tokens(
     assert tokenized.logprobs[-2] == pytest.approx(-10.0)
     assert tokenized.logprobs[-1] == pytest.approx(-20.1)
     assert tokenized.flags[1:3] == [
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
     assert tokenized.flags[-2:] == [
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
 
 
@@ -3459,9 +3432,9 @@ def test_chat_exact_hidden_suffix_preserves_rendered_trailing_scaffold() -> None
     assert tokenized.flags == [
         tr.TokenFlag(0),
         tr.TokenFlag(0),
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
 
 
@@ -3582,9 +3555,9 @@ def test_chat_fallback_anchors_sampled_text_away_from_equal_user_text() -> None:
     assert tokenized.tokens == [1, 2, 2, 3]
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
         tr.TokenFlag(0),
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
     assert tokenized.logprobs[1] == -0.1
     assert math.isnan(tokenized.logprobs[2])
@@ -3661,9 +3634,9 @@ def test_chat_view_preserves_two_turn_textual_logprobs_without_exact_ids() -> No
     assert tokenized.logprobs[3] == pytest.approx(-0.5)
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
         tr.TokenFlag(0),
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
 
 
@@ -3725,9 +3698,9 @@ def test_chat_view_uses_later_exact_prompt_when_first_is_missing() -> None:
     assert tokenized.logprobs[-1] == pytest.approx(-0.5)
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
 
 
@@ -3854,7 +3827,7 @@ def test_empty_chat_prompt_ids_are_missing_evidence(
     assert tokenized.tokens == [10, 2]
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
 
 
@@ -3902,7 +3875,7 @@ def test_missing_completion_renders_only_missing_region_when_prompt_is_exact(
     assert tokenized.logprobs[1] == -0.5
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
 
 
@@ -4157,9 +4130,9 @@ def test_cross_exchange_responses_reasoning_split_uses_later_prompt_backbone() -
     assert tokenized.histories[1].logprobs[3] == -0.1
     assert tokenized.histories[1].flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
 
 
@@ -4225,8 +4198,8 @@ def test_responses_aggregates_complete_exact_pairs_across_content_blocks(
     assert result.tokens == [10, 11, 12]
     assert result.logprobs[1:] == [-0.1, -0.2]
     assert result.flags[1:] == [
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
 
 
@@ -4514,9 +4487,9 @@ def test_responses_token_generations_preserve_every_generation() -> None:
     assert tokenized.logprobs[3] == -0.4
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
 
 
@@ -4633,9 +4606,7 @@ def test_responses_split_preserves_unchanged_prior_generation_provenance() -> No
     tokenized = final.tokenize()
 
     assert tokenized.tokens == [1, 2, 3, 500, 5, 6]
-    assert tokenized.flags[1] == (
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT
-    )
+    assert tokenized.flags[1] == (_SAMPLED_ASSISTANT_OUTPUT)
     assert tokenized.logprobs[1] == -0.2
     assert tokenized.flags[3] == tr.TokenFlag.EXACT
     assert math.isnan(tokenized.logprobs[3])
@@ -4727,10 +4698,7 @@ def test_responses_terminal_generation_without_output_items_is_tokenized() -> No
     assert tokenized.logprobs[1] == pytest.approx(-0.2)
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP,
+        _SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP,
     ]
     assert history.as_chat_completions_history().messages[-1] == {
         "role": "assistant",
@@ -4774,10 +4742,7 @@ def test_responses_terminal_generation_without_output_items_survives_rerender() 
     assert tokenized.logprobs[1] == pytest.approx(-0.2)
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP,
+        _SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP,
     ]
 
 
@@ -4910,9 +4875,9 @@ def test_structured_tool_arguments_remain_in_sampled_region_without_exact_tokens
         exact_prompt
     )
     assistant = slice(len(exact_prompt), None)
-    assert tokenized.flags[assistant] == [tr.TokenFlag.ASSISTANT] * (
-        len(sampled_tokens) + 1
-    )
+    assert tokenized.flags[assistant] == [
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT
+    ] * (len(sampled_tokens) + 1)
     assert all(math.isnan(value) for value in tokenized.logprobs[assistant])
 
 
@@ -4951,7 +4916,7 @@ def test_reasoning_probe_failure_does_not_override_authoritative_render() -> Non
     tokenized = history.tokenize(tokenizer=Tokenizer())
 
     assert tokenized.tokens == [1, 20, 30]
-    assert tokenized.flags[1:] == [tr.TokenFlag.ASSISTANT] * 2
+    assert tokenized.flags[1:] == [tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT] * 2
 
 
 @pytest.mark.parametrize("arguments", ("not-json", "[]"))
@@ -5364,9 +5329,7 @@ def test_template_change_rerenders_scaffold_but_preserves_sampled_output() -> No
 
     assert tokenized.tokens == [10, 2, 30]
     assert tokenized.logprobs[1] == -0.2
-    assert tokenized.flags[1] == (
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT
-    )
+    assert tokenized.flags[1] == (_SAMPLED_ASSISTANT_OUTPUT)
 
 
 def test_template_change_preserves_complete_exact_sampled_suffix() -> None:
@@ -5397,9 +5360,9 @@ def test_template_change_preserves_complete_exact_sampled_suffix() -> None:
     assert tokenized.logprobs[1:3] == pytest.approx([-0.2, -0.3])
     assert math.isnan(tokenized.logprobs[3])
     assert tokenized.flags[1:] == [
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
 
 
@@ -5504,7 +5467,7 @@ def test_responses_generation_evidence_is_atomic_and_partial_edits_do_not_replay
     partial = history.tokenize(tokenizer=Tokenizer(), chat_template="custom")
     assert partial.tokens == [1, 30, 9]
     assert 2 not in partial.tokens
-    assert partial.flags[1] == tr.TokenFlag.ASSISTANT
+    assert partial.flags[1] == tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT
     assert math.isnan(partial.logprobs[1])
 
 
@@ -5639,9 +5602,9 @@ def test_responses_chat_rerender_preserves_equal_length_generation_evidence() ->
     assert tokenized.logprobs[1::2] == pytest.approx([-0.2, -0.4])
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
         tr.TokenFlag(0),
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
 
 
@@ -5707,9 +5670,7 @@ def test_responses_chat_output_indices_reuse_one_complete_generation() -> None:
 
     assert tokenized.tokens == [1, 2]
     assert tokenized.logprobs[-1] == pytest.approx(-0.1)
-    assert tokenized.flags[-1] == (
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT
-    )
+    assert tokenized.flags[-1] == (_SAMPLED_ASSISTANT_OUTPUT)
 
 
 def test_responses_chat_output_indices_are_bounds_checked() -> None:
@@ -5809,8 +5770,8 @@ def test_responses_multi_output_generation_is_rendered_without_duplicate_evidenc
     assert all(math.isnan(value) for value in tokenized.logprobs)
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
 
 
@@ -5862,8 +5823,8 @@ def test_responses_multi_output_chat_conversion_preserves_item_logprobs() -> Non
     assert tokenized.logprobs[1:] == [-0.1, -0.2]
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
 
 
@@ -5911,8 +5872,8 @@ def test_mutable_chat_history_is_authoritative_and_does_not_replay_removed_turns
     assert 20 not in tokenized.tokens
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
 
 
@@ -5958,9 +5919,8 @@ def test_request_assistant_messages_are_marked_assistant_not_sampled() -> None:
     assert tokenized.tokens == [5, 20, 6, 30, 7, 40, 8]
     assert not tokenized.flags[1] & tr.TokenFlag.SAMPLED
     assert tokenized.flags[1] & tr.TokenFlag.ASSISTANT
-    assert tokenized.flags[5] == (
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT
-    )
+    assert not tokenized.flags[1] & tr.TokenFlag.OUTPUT
+    assert tokenized.flags[5] == (_SAMPLED_ASSISTANT_OUTPUT)
 
 
 def test_rerender_constrains_exact_output_to_its_message_region() -> None:
@@ -5996,7 +5956,7 @@ def test_rerender_constrains_exact_output_to_its_message_region() -> None:
     assert tokenized.flags == [
         tr.TokenFlag(0),
         tr.TokenFlag(0),
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
     assert math.isnan(tokenized.logprobs[0])
     assert tokenized.logprobs[2] == -0.7
@@ -6056,9 +6016,7 @@ def test_rerender_does_not_bind_unique_exact_id_outside_sampled_message() -> Non
 
     assert tokenized.tokens == [42, 7, 99, 7]
     assert not tokenized.flags[1] & tr.TokenFlag.SAMPLED
-    assert tokenized.flags[-1] == (
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT
-    )
+    assert tokenized.flags[-1] == (_SAMPLED_ASSISTANT_OUTPUT)
     assert math.isnan(tokenized.logprobs[1])
     assert tokenized.logprobs[-1] == -0.7
 
@@ -6121,11 +6079,8 @@ def test_rerender_does_not_duplicate_sampled_trailing_eos() -> None:
     assert tokenized.tokens == [1, 99, 7, 2]
     assert tokenized.tokens.count(2) == 1
     assert tokenized.flags[-2:] == [
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        _SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP,
     ]
     assert tokenized.logprobs[-2:] == [-0.7, -0.2]
 
@@ -6210,10 +6165,7 @@ def test_reasoning_stripped_chat_histories_tokenize_authoritative_views() -> Non
     assert tokenized.histories[1].flags[1] & tr.TokenFlag.EXACT
     assert tokenized.histories[1].logprobs[1:3] == [-10.1, -10.2]
     assert tokenized.histories[1].flags[3] == (
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP
+        _SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP
     )
     assert tokenized.histories[1].logprobs[3] == -0.9
     assert 2 not in tokenized.histories[1].tokens
@@ -6379,8 +6331,8 @@ def test_reasoning_stripped_tool_call_keeps_exact_evidence_for_strict_training(
     assert second_history.tokens == [1, 7, 8, 4, 5]
     assert second_history.logprobs[1:3] == [-0.7, -0.8]
     assert second_history.flags[1:3] == [
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
 
     preprocessing = list(
@@ -6529,7 +6481,7 @@ def test_rerender_marks_tool_call_only_generated_region_sampled() -> None:
     tokenized = history.tokenize(tokenizer=Tokenizer())
 
     assert tokenized.tokens == [1, 10, 20, 25, 30, 31, 26]
-    assert tokenized.flags[2:] == [tr.TokenFlag.ASSISTANT] * 5
+    assert tokenized.flags[2:] == [tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT] * 5
     assert all(math.isnan(value) for value in tokenized.logprobs[2:])
     assert not tokenized.flags[0] & tr.TokenFlag.SAMPLED
 
@@ -6589,7 +6541,7 @@ def test_tool_call_probe_handles_contextual_tokenization(
     tokenized = history.tokenize(tokenizer=Tokenizer())
 
     assert tokenized.tokens == [1, 10, 20, 25, 30, 26]
-    assert tokenized.flags[2:] == [tr.TokenFlag.ASSISTANT] * 4
+    assert tokenized.flags[2:] == [tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT] * 4
     assert all(math.isnan(value) for value in tokenized.logprobs[2:])
 
 
@@ -6668,10 +6620,10 @@ def test_rerender_proves_each_reasoning_and_content_part_separately() -> None:
     assert tokenized.flags == [
         tr.TokenFlag(0),
         tr.TokenFlag(0),
-        tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
     assert tokenized.logprobs[4] == -0.7
 
@@ -6786,12 +6738,7 @@ def test_empty_sampled_message_inserts_exact_control_token() -> None:
 
     assert tokenized.tokens == [1, 99, 2, 9]
     assert tokenized.logprobs[2] == -0.2
-    assert tokenized.flags[2] == (
-        tr.TokenFlag.EXACT
-        | tr.TokenFlag.SAMPLED
-        | tr.TokenFlag.ASSISTANT
-        | tr.TokenFlag.STOP
-    )
+    assert tokenized.flags[2] == (_SAMPLED_ASSISTANT_OUTPUT | tr.TokenFlag.STOP)
 
 
 def test_renderer_ignored_refusal_is_appended_for_tokenization() -> None:
@@ -6872,7 +6819,7 @@ def test_renderer_ignored_refusal_is_appended_for_tokenization() -> None:
 
     assert tokenized.tokens == [1, 4, 5]
     assert tokenized.logprobs[1:] == [-0.4, -0.5]
-    assert tokenized.flags[1:] == [tr.TokenFlag.ASSISTANT] * 2
+    assert tokenized.flags[1:] == [tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT] * 2
 
 
 def test_renderer_reasoning_content_alias_preserves_reasoning() -> None:
@@ -6914,8 +6861,8 @@ def test_renderer_reasoning_content_alias_preserves_reasoning() -> None:
     assert tokenized.tokens == [1, 2, 3]
     assert tokenized.flags == [
         tr.TokenFlag(0),
-        tr.TokenFlag.ASSISTANT,
-        tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
+        tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT,
     ]
 
 
@@ -7018,7 +6965,7 @@ def test_trimmed_render_preserves_authoritative_textual_logprob_tokens() -> None
 
     assert tokenized.tokens == [1, 1118, 2222, 220]
     assert tokenized.logprobs[1:] == [-0.4, -0.45, -0.5]
-    assert tokenized.flags[1:] == [tr.TokenFlag.ASSISTANT] * 3
+    assert tokenized.flags[1:] == [tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT] * 3
 
 
 def test_textual_logprobs_reconstruct_split_utf8_bytes() -> None:
@@ -7228,9 +7175,9 @@ def test_trimmed_whitespace_output_inserts_authoritative_logprob_token(
         9,
     ]
     assert tokenized.logprobs[1] == -0.5
-    assert tokenized.flags[1] == tr.TokenFlag.ASSISTANT
+    assert tokenized.flags[1] == tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT
     if adjacent_scaffold:
-        assert tokenized.flags[2] == tr.TokenFlag.ASSISTANT
+        assert tokenized.flags[2] == tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT
 
 
 def _repeated_text_rerender_history(
@@ -7469,7 +7416,7 @@ def test_responses_external_context_requires_or_uses_exact_prompt_tokens() -> No
     assert tokenized.flags == [
         tr.TokenFlag.EXACT,
         tr.TokenFlag.EXACT,
-        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.ASSISTANT,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
 
 
@@ -7585,10 +7532,7 @@ def test_private_trace_keys_do_not_collide_for_repeated_empty_response_ids() -> 
 
 
 def test_responses_fallback_trace_does_not_retrain_echoed_output_items() -> None:
-    from art.trajectories._tokenize import (
-        _first_introduction_mask,
-        _tokenize_trajectory_with_trace,
-    )
+    from art.trajectories._tokenize import _tokenize_trajectory_with_trace
 
     def output(item_id: str, text: str) -> ResponseOutputMessageParam:
         return {
@@ -7677,11 +7621,12 @@ def test_responses_fallback_trace_does_not_retrain_echoed_output_items() -> None
     )
 
     assert len(tokenized.histories) == len(traces) == 2
-    seen: set[object] = set()
     trained_first_response = 0
     first_response_indices: set[int] = set()
-    for trace in traces:
-        trainable = _first_introduction_mask(trace.source_keys, seen)
+    trainable_masks = tr.first_occurrence_masks(
+        tokenized.histories, where=tr.TokenFlag.SAMPLED
+    )
+    for trace, trainable in zip(traces, trainable_masks, strict=True):
         for selected, key in zip(trainable, trace.source_keys, strict=True):
             if key is not None and key.response_id == first_response.id:
                 first_response_indices.add(key.index)

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -465,6 +465,59 @@ def test_length_stop_without_a_template_terminator_does_not_raise() -> None:
     assert not any(flag & tr.TokenFlag.STOP for flag in tokenized.flags)
 
 
+def test_adjacent_seeded_and_response_assistant_output_are_distinguished() -> None:
+    response = ChatCompletion.model_validate(
+        {
+            "id": "chat-adjacent-assistant",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "test/model",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "answer"},
+                }
+            ],
+        }
+    )
+    exchange = ChatCompletionsExchange(
+        request=ChatCompletionsRequest(
+            model="test/model",
+            messages=[{"role": "assistant", "content": "seed"}],
+        ),
+        response=response,
+        start_time=datetime(2026, 1, 1),
+        end_time=datetime(2026, 1, 1) + timedelta(milliseconds=1),
+    )
+
+    class Tokenizer:
+        def __call__(self, text: str, **kwargs: object) -> list[int]:
+            del kwargs
+            return [ord(character) for character in text]
+
+        def apply_chat_template(
+            self, messages: list[dict[str, Any]], **kwargs: object
+        ) -> list[int]:
+            del kwargs
+            return [
+                ord(character)
+                for message in messages
+                for character in cast(str, message.get("content") or "")
+            ]
+
+    tokenized = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[exchange])
+    ).tokenize(tokenizer=Tokenizer())
+
+    seed_length = len("seed")
+    assert all(flag == tr.TokenFlag.ASSISTANT for flag in tokenized.flags[:seed_length])
+    assert all(
+        flag == tr.TokenFlag.ASSISTANT | tr.TokenFlag.OUTPUT
+        for flag in tokenized.flags[seed_length:]
+    )
+
+
 def test_length_stop_mapping_allows_another_assistant_without_a_stop() -> None:
     first = _chat_exchange([1], [2])
     second = _chat_exchange([1, 2, 3], [4], offset=1)

--- a/tests/unit/trajectories/test_tokenized_models.py
+++ b/tests/unit/trajectories/test_tokenized_models.py
@@ -126,6 +126,17 @@ def test_first_occurrence_masks_partition_models_and_accept_generators() -> None
     assert not hasattr(art, "first_occurrence_masks")
 
 
+def test_first_occurrence_preview_does_not_mutate_trie() -> None:
+    trie = tr._FirstOccurrenceTrie()
+
+    assert trie.mask("model", [1, 2], [0, 0], claim=False) == [True, True]
+    assert trie._roots == {}
+    assert trie.mask("model", [1], [0]) == [True]
+    root = trie._roots["model"]
+    assert trie.mask("model", [1, 2, 3], [0, 0, 0], claim=False) == [False, True, True]
+    assert 2 not in root.children[1].children
+
+
 def test_tensorized_first_occurrence_masks_match_tokenized() -> None:
     histories = [
         _tokenized([1, 2], [tr.TokenFlag(0), tr.TokenFlag.OUTPUT]),

--- a/tests/unit/trajectories/test_tokenized_models.py
+++ b/tests/unit/trajectories/test_tokenized_models.py
@@ -1,7 +1,9 @@
 import math
 import pickle
+from typing import Any, cast
 
 import pytest
+import torch
 
 import art
 import art.trajectories as tr
@@ -18,7 +20,8 @@ def _history() -> tr.TokenizedHistory:
             tr.TokenFlag.EXACT
             | tr.TokenFlag.SAMPLED
             | tr.TokenFlag.ASSISTANT
-            | tr.TokenFlag.STOP,
+            | tr.TokenFlag.STOP
+            | tr.TokenFlag.OUTPUT,
         ],
     )
 
@@ -28,10 +31,12 @@ def test_token_provenance_flag_values_and_invariant() -> None:
     assert tr.TokenFlag.SAMPLED == 2
     assert tr.TokenFlag.ASSISTANT == 4
     assert tr.TokenFlag.STOP == 8
+    assert tr.TokenFlag.OUTPUT == 16
     assert not hasattr(tr.TokenizedHistory, "exact_mask")
     assert not hasattr(tr.TokenizedHistory, "sampled_mask")
     assert not hasattr(tr.TokenizedHistory, "assistant_mask")
     assert not hasattr(tr.TokenizedHistory, "stop_mask")
+    assert not hasattr(tr.TokenizedHistory, "output_mask")
 
     with pytest.raises(ValueError, match="SAMPLED tokens must also be EXACT"):
         tr.TokenizedHistory(
@@ -50,6 +55,104 @@ def test_token_provenance_flag_values_and_invariant() -> None:
         flags=[tr.TokenFlag.ASSISTANT],
     )
     assert value.flags == [tr.TokenFlag.ASSISTANT]
+
+    legacy = tr.TokenizedHistory(
+        history=tr.LegacyHistory(messages_and_choices=[]),
+        model="policy",
+        tokens=[1],
+        logprobs=[-0.1],
+        flags=[tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED],
+    )
+    assert legacy.flags == [
+        tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED | tr.TokenFlag.OUTPUT
+    ]
+
+
+def _tokenized(
+    tokens: list[int], flags: list[tr.TokenFlag], *, model: str = "policy"
+) -> tr.TokenizedHistory:
+    return tr.TokenizedHistory(
+        history=tr.LegacyHistory(messages_and_choices=[]),
+        model=model,
+        tokens=tokens,
+        logprobs=[math.nan] * len(tokens),
+        flags=flags,
+    )
+
+
+def test_first_occurrence_masks_use_complete_prefixes_and_eligibility() -> None:
+    output = tr.TokenFlag.OUTPUT
+    histories = [
+        _tokenized([1, 2, 9], [tr.TokenFlag(0), output, output]),
+        _tokenized([1, 2, 9], [tr.TokenFlag(0), output, output]),
+        _tokenized([1, 3, 9], [tr.TokenFlag(0), output, output]),
+    ]
+
+    assert tr.first_occurrence_masks(histories) == [
+        [True, True, True],
+        [False, False, False],
+        [False, True, True],
+    ]
+    assert tr.first_occurrence_masks(histories, where=output) == [
+        [False, True, True],
+        [False, False, False],
+        [False, True, True],
+    ]
+
+    unsampled = _tokenized([1, 2], [tr.TokenFlag(0), output])
+    sampled = _tokenized(
+        [1, 2],
+        [tr.TokenFlag(0), tr.TokenFlag.EXACT | tr.TokenFlag.SAMPLED],
+    )
+    assert tr.first_occurrence_masks(
+        [unsampled, sampled], where=tr.TokenFlag.SAMPLED
+    ) == [[False, False], [False, True]]
+
+
+def test_first_occurrence_masks_partition_models_and_accept_generators() -> None:
+    histories = (
+        _tokenized([1, 2], [tr.TokenFlag(0)] * 2, model=model)
+        for model in ("one", "two")
+    )
+    assert tr.first_occurrence_masks(histories) == [[True, True], [True, True]]
+    assert tr.first_occurrence_masks([], where=tr.TokenFlag.OUTPUT) == []
+    assert tr.first_occurrence_masks(
+        [_tokenized([1], [tr.TokenFlag.OUTPUT])], where=tr.TokenFlag(0)
+    ) == [[False]]
+    assert tr.first_occurrence_masks(
+        [_tokenized([1, 2], [tr.TokenFlag.OUTPUT, tr.TokenFlag.STOP])],
+        where=tr.TokenFlag.OUTPUT | tr.TokenFlag.STOP,
+    ) == [[True, True]]
+    assert not hasattr(art, "first_occurrence_masks")
+
+
+def test_tensorized_first_occurrence_masks_match_tokenized() -> None:
+    histories = [
+        _tokenized([1, 2], [tr.TokenFlag(0), tr.TokenFlag.OUTPUT]),
+        _tokenized([1, 2], [tr.TokenFlag(0), tr.TokenFlag.OUTPUT]),
+    ]
+    tensors = [history.tensorize() for history in histories]
+    expected = tr.first_occurrence_masks(histories, where=tr.TokenFlag.OUTPUT)
+    actual = tr.first_occurrence_masks(tensors, where=tr.TokenFlag.OUTPUT)
+    source = art.Trajectory()
+    tokenized_multi = tr.TokenizedMultiHistoryTrajectory(
+        trajectory=source, histories=histories
+    )
+    tensorized_multi = tokenized_multi.tensorize()
+
+    assert [mask.tolist() for mask in actual] == expected
+    assert tokenized_multi.first_occurrence_masks(where=tr.TokenFlag.OUTPUT) == expected
+    assert [
+        mask.tolist()
+        for mask in tensorized_multi.first_occurrence_masks(where=tr.TokenFlag.OUTPUT)
+    ] == expected
+    assert all(mask.dtype is torch.bool for mask in actual)
+    assert all(
+        mask.device == history.tokens.device
+        for mask, history in zip(actual, tensors, strict=True)
+    )
+    with pytest.raises(TypeError, match="uniformly tokenized or tensorized"):
+        tr.first_occurrence_masks(cast(Any, [histories[0], tensors[0]]))
 
 
 def _assert_history_round_trip(


### PR DESCRIPTION
## Summary

- add `TokenFlag.OUTPUT` as reconstructed response provenance while retaining `ASSISTANT` as structural role metadata
- add model-partitioned, complete-prefix `first_occurrence_masks()` for tokenized and tensorized multi-history trajectories
- reuse first-occurrence masking in ART preprocessing and Tinker to deduplicate shared sampled prefixes
- attribute output provenance across Chat Completions, Messages, Responses, and Completions, including stop and length-stop semantics
- normalize legacy `SAMPLED` flags to include `OUTPUT`

## Semantics

- `SAMPLED` implies `EXACT | OUTPUT`
- `where=None` selects the first occurrence of every token prefix
- flag filters use any-bit matching, are already intersected into the returned mask, and ineligible positions do not claim a prefix
- deduplication is scoped by model and full model-visible token prefix
- equal prefixes collapse even when they came from distinct response objects; the earliest eligible occurrence owns the edge
- the same response rendered under different model-visible prefixes remains independently eligible by design; recorded source logprobs still describe the original sampled context, so consumers requiring an exact behavior-policy likelihood must account for context-changing projections
- ambiguous mixed-provenance template transformations fail rather than guessing OUTPUT ownership

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- targeted `uv run ty check ...`
- 431 changed-area trajectory/preprocessing/Tinker tests
- 1,107 runnable unit tests (33 skipped; 5 collection errors require unavailable optional Megatron/Unsloth dependencies)
- independent Codex and Claude Fable reviews; all reproducible correctness and performance findings addressed