### PR TITLE
Make tensorized device transfers functional

### DIFF
--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -1107,7 +1107,7 @@ class TrainerRank:
         # TP explicitly. Known limitation: the cold static memory estimate
         # ignores sharding (conservative).
         self.runtime: TrainingRuntime = runtime
-        self.device = next(runtime.model[0].parameters()).device
+        self.device: torch.device = next(runtime.model[0].parameters()).device
         self._param_dtype_size = _dtype_size(next(runtime.model[0].parameters()).dtype)
         try:
             metadata_model = _language_model(runtime.model[0])

--- a/src/art/trajectories/_compact.py
+++ b/src/art/trajectories/_compact.py
@@ -175,7 +175,7 @@ def _validate_value(
         else:
             result = _validate_group(value, model)
         if device is not None:
-            move = getattr(result, "to", None)
+            move = getattr(result, "to_", None)
             if not callable(move):
                 raise AssertionError("Tensorized compact value has no device mover")
             move(device)

--- a/src/art/trajectories/_parallel.py
+++ b/src/art/trajectories/_parallel.py
@@ -795,5 +795,5 @@ async def transform(
 
     if device is not None:
         for value in transformed:
-            cast(Any, value).to(device)
+            cast(Any, value).to_(device)
     return transformed

--- a/src/art/trajectories/tensors.py
+++ b/src/art/trajectories/tensors.py
@@ -118,12 +118,20 @@ class TensorizedHistory(_StringInterningModel):
         return self
 
     def to(self, device: torch.device | str) -> Self:
-        """Move owned tensors to ``device`` in place and return this view."""
+        """Return a copy with independently owned tensors on ``device``."""
+
+        result = self.model_copy()
+        result.tokens = self.tokens.to(device=device, copy=True)
+        result.logprobs = self.logprobs.to(device=device, copy=True)
+        result.flags = self.flags.to(device=device, copy=True)
+        return result
+
+    def to_(self, device: torch.device | str) -> None:
+        """Move owned tensors to ``device`` in place."""
 
         self.tokens = self.tokens.to(device=device)
         self.logprobs = self.logprobs.to(device=device)
         self.flags = self.flags.to(device=device)
-        return self
 
     def compact_dump(self) -> CompactTrajectoryPayload:
         from ._compact import dump
@@ -201,9 +209,13 @@ class TensorizedMultiHistoryTrajectory(_StringInterningModel):
         return self
 
     def to(self, device: torch.device | str) -> Self:
+        return self.model_copy(
+            update={"histories": [history.to(device) for history in self.histories]}
+        )
+
+    def to_(self, device: torch.device | str) -> None:
         for history in self.histories:
-            history.to(device)
-        return self
+            history.to_(device)
 
     def first_occurrence_masks(
         self, *, where: TokenFlag | None = None
@@ -290,12 +302,21 @@ class TensorizedTrajectoryGroup(_StringInterningModel, Generic[TensorizedTraject
         return self
 
     def to(self, device: torch.device | str) -> Self:
+        trajectories: list[TensorizedTrajectoryT] = []
         for trajectory in self.trajectories:
             if isinstance(trajectory, TensorizedTrajectory):
-                trajectory.to(device)
+                moved = trajectory.to(device)
             else:
-                trajectory.to(device)
-        return self
+                moved = trajectory.to(device)
+            trajectories.append(cast(TensorizedTrajectoryT, moved))
+        return self.model_copy(update={"trajectories": trajectories})
+
+    def to_(self, device: torch.device | str) -> None:
+        for trajectory in self.trajectories:
+            if isinstance(trajectory, TensorizedTrajectory):
+                trajectory.to_(device)
+            else:
+                trajectory.to_(device)
 
     def compact_dump(self) -> CompactTrajectoryPayload:
         from ._compact import dump

--- a/tests/unit/trajectories/test_tensorized_models.py
+++ b/tests/unit/trajectories/test_tensorized_models.py
@@ -133,7 +133,7 @@ def test_missing_torch_reports_tensor_extra() -> None:
     assert "openpipe-art[tensors]" in result.stderr
 
 
-def test_history_tensorize_uses_canonical_tensors_and_moves_in_place() -> None:
+def test_history_tensorize_uses_canonical_tensors_and_device_copy_semantics() -> None:
     value = _tokenized_history().tensorize()
 
     assert isinstance(value, tr.TensorizedHistory)
@@ -142,7 +142,16 @@ def test_history_tensorize_uses_canonical_tensors_and_moves_in_place() -> None:
     assert value.flags.dtype is torch.int32
     assert value.tokens.device.type == "cpu"
     assert value.tokens.is_contiguous()
-    assert value.to("cpu") is value
+    copied = value.to("cpu")
+    assert copied is not value
+    assert copied.history is value.history
+    assert copied.tokens.data_ptr() != value.tokens.data_ptr()
+    assert copied.logprobs.data_ptr() != value.logprobs.data_ptr()
+    assert copied.flags.data_ptr() != value.flags.data_ptr()
+    assert torch.equal(copied.tokens, value.tokens)
+    assert torch.allclose(copied.logprobs, value.logprobs, equal_nan=True)
+    assert torch.equal(copied.flags, value.flags)
+    assert value.to_("cpu") is None
     assert "tokenized" not in type(value).model_fields
 
 
@@ -316,7 +325,25 @@ def test_tensorized_trajectory_multi_history_and_group_compact_round_trips() -> 
         restored_group.trajectories[0].trajectory
         is (restored_group.trajectory_group.trajectories[0])
     )
-    assert restored_group.to("cpu") is restored_group
+    copied_multi = restored_multi.to("cpu")
+    assert copied_multi is not restored_multi
+    assert copied_multi.trajectory is restored_multi.trajectory
+    assert copied_multi.histories[0] is not restored_multi.histories[0]
+    assert (
+        copied_multi.histories[0].tokens.data_ptr()
+        != restored_multi.histories[0].tokens.data_ptr()
+    )
+    assert restored_multi.to_("cpu") is None
+
+    copied_group = restored_group.to("cpu")
+    assert copied_group is not restored_group
+    assert copied_group.trajectory_group is restored_group.trajectory_group
+    assert copied_group.trajectories[0] is not restored_group.trajectories[0]
+    assert (
+        copied_group.trajectories[0].tokens.data_ptr()
+        != restored_group.trajectories[0].tokens.data_ptr()
+    )
+    assert restored_group.to_("cpu") is None
 
 
 def test_tensorized_pickle_retains_sources_without_tokenized_intermediate() -> None:


### PR DESCRIPTION
## Summary
- make tensorized trajectory `to(device)` methods return independent device copies without mutating their inputs
- add explicit in-place `to_(device) -> None` methods across histories, multi-history trajectories, and groups
- retain allocation-efficient in-place movement in ART internal tensorization and compact-loading paths
- explicitly type `TrainerRank.device` as `torch.device` for Pyright consumers

Source trajectory/history metadata remains shared; owned token, logprob, and flag tensors are copied.

## Validation
- `uv run pytest -q tests/unit/trajectories` (443 passed)
- targeted `uv run ty check` for changed modules/tests
- `uvx basedpyright experiments/047-adversarial-dynamics.py` (0 errors; unrelated existing warnings remain)
- Ruff lint and format checks

The repository-wide `ty` invocation still reports its existing diagnostics across dev scripts and optional vLLM integrations; the changed files are clean.