### PR TITLE
Allow exact terminal length truncations without a rendered tail

### DIFF
--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -4019,9 +4019,9 @@ def _tokenize_exact_projected_chat_history(
         if final_stop_reason == "length"
         else None
     )
-    if final_stop_reason == "length" and (
-        terminal_boundary is None or not terminal_boundary.tail
-    ):
+    # Unlike a nonterminal truncation, the final sampled output needs no
+    # synthetic boundary to connect it to a later prompt.
+    if terminal_boundary is not None and not terminal_boundary.tail:
         return None
 
     # The final prompt proves every earlier boundary. Only this terminal tail
@@ -5201,6 +5201,7 @@ def _tokenize_chat_view(
             _SampledSourceKey, _RenderedLengthStopBoundary
         ] = {}
         length_stop_count = 0
+        length_stop_boundaries_complete = True
         for position, message_index in enumerate(sampled_message_indices):
             source = history.message_sources[message_index]
             assert source is not None
@@ -5248,11 +5249,18 @@ def _tokenize_chat_view(
                 else None
             )
             if boundary is None:
-                break
+                if position + 1 < len(sampled_message_indices):
+                    length_stop_boundaries_complete = False
+                    break
+                # A terminal length stop needs no renderer-owned tail: the
+                # authoritative prompt and sampled output already describe the
+                # complete trainable sequence. A later turn is required only
+                # to prove a nonterminal synthetic boundary.
+                continue
             length_stop_boundaries[source_key] = boundary
         if (
             length_stop_count
-            and len(length_stop_boundaries) == length_stop_count
+            and length_stop_boundaries_complete
             and (
                 exact := _tokenize_exact_projected_chat_history(
                     history,

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -757,6 +757,42 @@ def test_exact_chain_appends_renderer_owned_terminal_length_tail() -> None:
     assert not any(flag & tr.TokenFlag.SAMPLED for flag in tokenized.flags[-2:])
 
 
+def test_exact_chain_accepts_unproven_terminal_length_tail() -> None:
+    first = _chat_exchange([1], [2])
+    first.response.choices[0].finish_reason = "length"
+    second = _chat_exchange([1, 2, 7, 9, 3], [4], offset=1)
+    second.response.choices[0].finish_reason = "length"
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second])
+    ).chat_completions_history()
+    from art.trajectories._tokenize import (
+        _RenderedLengthStopBoundary,
+        _sampled_source_key,
+        _tokenize_exact_projected_chat_history,
+    )
+
+    first_source = history.message_sources[1]
+    assert first_source is not None
+    tokenized = _tokenize_exact_projected_chat_history(
+        history,
+        tokenizer=_StopTokenizer(),
+        length_stop_boundaries={
+            _sampled_source_key(first_source): _RenderedLengthStopBoundary(
+                tail=(7, 9), following=(3,)
+            ),
+        },
+        projection_validated=True,
+    )
+
+    assert tokenized is not None
+    assert tokenized.tokens == [1, 2, 7, 9, 3, 4]
+    assert tokenized.flags[2:4] == [
+        tr.TokenFlag.EXACT | tr.TokenFlag.ASSISTANT,
+        tr.TokenFlag.EXACT | tr.TokenFlag.STOP,
+    ]
+    assert tokenized.flags[-1] == _SAMPLED_ASSISTANT_OUTPUT
+
+
 def test_exact_chain_declines_unrecognized_or_mismatched_length_boundary() -> None:
     first = _chat_exchange([1], [2])
     first.response.choices[0].finish_reason = "length"
@@ -894,7 +930,7 @@ def test_exact_output_boundary_after_sampled_tool_call() -> None:
 
     tokenized = history.tokenize(tokenizer=tokenizer)
 
-    assert tokenized.tokens == [1, 2, 7, 9, 3, 4, 9, 5, 6, 9]
+    assert tokenized.tokens == [1, 2, 7, 9, 3, 4, 9, 5, 6]
     sampled = [
         index
         for index, flag in enumerate(tokenized.flags)
@@ -903,8 +939,8 @@ def test_exact_output_boundary_after_sampled_tool_call() -> None:
     assert sampled == [1, 2, 3, 5, 6, 8]
     assert [
         index for index, flag in enumerate(tokenized.flags) if flag & tr.TokenFlag.STOP
-    ] == [3, 6, 9]
-    assert tokenized.flags[9] == tr.TokenFlag.STOP
+    ] == [3, 6]
+    assert tokenized.flags[-1] == _SAMPLED_ASSISTANT_OUTPUT
 
 
 def test_proven_exact_output_boundary_does_not_require_prompt_token_ids() -> None:


### PR DESCRIPTION
## Summary

- allow exact chat-history reconstruction to end at an authoritative terminal length-truncated output when no renderer-owned tail can be proven
- continue requiring a later exact prompt to prove every nonterminal length-stop boundary
- preserve existing synthetic terminal tails whenever rendering can prove one

## Motivation

Experiment 046 produced a trajectory with an earlier 4,096-token length stop and a terminal 4,096-token length stop. The following request proved the earlier renderer-owned boundary, but the terminal parsed response could not be re-rendered byte-for-byte. ART rejected the entire exact chain even though the final exchange carried the authoritative prompt token IDs, sampled token IDs, and logprobs.

The captured production trajectory now tokenizes to 28,261 tokens with all 19,367 sampled tokens and logprobs retained; its terminal sampled token is correctly not marked STOP.

## Validation

- 219 tokenizer unit tests passed
- Ruff check and format passed
- ty passed
- exact captured experiment trajectory reproduced before the fix and passed after it