### PR TITLE
Prove exact nonterminal length boundaries

### DIFF
--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -522,6 +522,22 @@ def _prove_exact_sampled_assistant_span(
     return start, end
 
 
+def _prove_exact_length_stopped_assistant_prefix(
+    matches: Sequence[tuple[int, int]],
+    assistant_mask: Sequence[bool],
+    *,
+    expected_start: int,
+) -> tuple[int, int] | None:
+    """Prove sampled content before a separately validated renderer stop tail."""
+
+    if len(matches) != 1 or matches[0][0] != expected_start:
+        return None
+    start, end = matches[0]
+    if not all(assistant_mask[start:end]) or (start > 0 and assistant_mask[start - 1]):
+        return None
+    return start, end
+
+
 def _rendered_flag(assistant: bool, output: bool, stop: bool) -> TokenFlag:
     flag = TokenFlag.ASSISTANT if assistant else TokenFlag(0)
     if output:
@@ -5215,6 +5231,19 @@ def _tokenize_chat_view(
                 else marked_bounds.get(message_index)
                 or probed_bounds.get(message_index)
             )
+            if (
+                bounds is None
+                and position + 1 < len(sampled_message_indices)
+                and source_matches_context(source)
+            ):
+                prompt = source_prompt_tokens(source)
+                output, _ = source_output_tokens(source)
+                if prompt is not None and output:
+                    bounds = _prove_exact_length_stopped_assistant_prefix(
+                        locations(output, 0),
+                        assistant_mask,
+                        expected_start=len(prompt),
+                    )
             next_prompt_end: int | None
             if position + 1 < len(sampled_message_indices):
                 next_message_index = sampled_message_indices[position + 1]

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -566,7 +566,7 @@ def test_exact_coverage_stops_at_a_duplicated_length_terminator() -> None:
     assert not tokenized.flags[4] & tr.TokenFlag.EXACT
 
 
-def test_terminal_length_stays_synthetic_after_an_earlier_length_stop() -> None:
+def test_terminal_length_stays_exact_after_an_earlier_length_stop() -> None:
     first = _chat_exchange([1], [2])
     first.response.choices[0].finish_reason = "length"
     second = _chat_exchange([1, 2, 9, 3], [4, 9], offset=1)
@@ -576,10 +576,10 @@ def test_terminal_length_stays_synthetic_after_an_earlier_length_stop() -> None:
         exchanges=TrajectoryExchanges(chat_completions=[first, second])
     ).tokenize(tokenizer=_StopTokenizer())
 
-    assert tokenized.tokens == [1, 2, 9, 3, 4, 9, 9]
+    assert tokenized.tokens == [1, 2, 9, 3, 4, 9]
     assert tokenized.flags[-2:] == [
         _SAMPLED_ASSISTANT_OUTPUT,
-        tr.TokenFlag.STOP,
+        _SAMPLED_ASSISTANT_OUTPUT,
     ]
 
 
@@ -634,6 +634,47 @@ def test_exact_output_boundaries_survive_prefix_order_drift_and_length_stop() ->
         match="Could not prove a sampled history message boundary",
     ):
         history.tokenize(tokenizer=tokenizer, chat_template="explicit override")
+
+
+def test_exact_length_boundary_with_multiple_assistant_parts() -> None:
+    first = _chat_exchange([1], [2, 9])
+    second = _chat_exchange([1, 2, 9, 3], [4, 5], offset=1)
+    second_data = second.response.model_dump(mode="python")
+    second_data["choices"][0]["finish_reason"] = "length"
+    second_data["choices"][0]["message"] = {
+        "role": "assistant",
+        "reasoning_content": "reason",
+        "content": "answer",
+    }
+    second.response = ChatCompletion.model_validate(second_data)
+    third = _chat_exchange([1, 2, 9, 3, 4, 5, 9, 6], [7, 9], offset=2)
+    third.request["messages"] = [
+        first.request["messages"][0],
+        first.response.choices[0].message.model_dump(mode="python", exclude_none=True),
+        second.request["messages"][-1],
+        second.response.choices[0].message.model_dump(mode="python", exclude_none=True),
+        third.request["messages"][-1],
+    ]
+    history = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second, third])
+    ).chat_completions_history()
+    tokenizer = _BoundaryTokenizer(
+        ("user", [8]),
+        ("assistant", [2, 9]),
+        ("user", [3]),
+        ("assistant", [4, 5, 9]),
+        ("user", [6]),
+        ("assistant", [7, 9]),
+    )
+
+    tokenized = history.tokenize(tokenizer=tokenizer)
+
+    assert tokenized.tokens == [1, 2, 9, 3, 4, 5, 9, 6, 7, 9]
+    assert tokenized.flags[4:7] == [
+        _SAMPLED_ASSISTANT_OUTPUT,
+        _SAMPLED_ASSISTANT_OUTPUT,
+        tr.TokenFlag.EXACT | tr.TokenFlag.STOP,
+    ]
 
 
 def test_public_exact_chain_preserves_raw_drift_across_proven_length_boundary() -> None:


### PR DESCRIPTION
## Summary
- recognize a nonterminal length-stopped sampled span from its exact output at the authoritative prompt offset
- continue requiring the renderer to prove the following assistant stop tail before admitting the exact chain
- cover reasoning-plus-content responses whose multiple text parts prevent marker-based boundary probes

## Why
A live Qwen3.5 tau-bench trajectory retained every sampled token exactly in the next request, but tokenization failed because the boundary prover required the renderer-owned stop tail to end before it would locate the sampled span. The new proof permits that trailing assistant run only as input to the existing strict stop-tail validator.

## Validation
- `PYTHONPATH=<branch>/src uv run pytest -q tests/unit/trajectories/test_tokenize.py` (220 passed)
- `uv run prek run --files src/art/trajectories/_tokenize.py tests/unit/trajectories/test_tokenize.py`
- both captured production failures tokenize successfully with the patched code
