### PR TITLE
Anchor exact length boundaries to rendered stop spans

### DIFF
--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -5216,6 +5216,9 @@ def _tokenize_chat_view(
         length_stop_boundaries: dict[
             _SampledSourceKey, _RenderedLengthStopBoundary
         ] = {}
+        rendered_length_stops = [
+            index for index, selected in enumerate(length_stop_mask) if selected
+        ]
         length_stop_count = 0
         length_stop_boundaries_complete = True
         for position, message_index in enumerate(sampled_message_indices):
@@ -5238,11 +5241,23 @@ def _tokenize_chat_view(
             ):
                 prompt = source_prompt_tokens(source)
                 output, _ = source_output_tokens(source)
-                if prompt is not None and output:
+                if (
+                    prompt is not None
+                    and output
+                    and length_stop_count <= len(rendered_length_stops)
+                ):
+                    rendered_end = rendered_length_stops[length_stop_count - 1] + 1
+                    rendered_start = rendered_end - 1
+                    while rendered_start and assistant_mask[rendered_start - 1]:
+                        rendered_start -= 1
                     bounds = _prove_exact_length_stopped_assistant_prefix(
-                        locations(output, 0),
+                        [
+                            match
+                            for match in locations(output, rendered_start)
+                            if match[1] <= rendered_end
+                        ],
                         assistant_mask,
-                        expected_start=len(prompt),
+                        expected_start=rendered_start,
                     )
             next_prompt_end: int | None
             if position + 1 < len(sampled_message_indices):

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -636,7 +636,7 @@ def test_exact_output_boundaries_survive_prefix_order_drift_and_length_stop() ->
         history.tokenize(tokenizer=tokenizer, chat_template="explicit override")
 
 
-def test_exact_length_boundary_with_multiple_assistant_parts() -> None:
+def test_exact_length_boundary_with_multiple_parts_and_prefix_drift() -> None:
     first = _chat_exchange([1], [2, 9])
     second = _chat_exchange([1, 2, 9, 3], [4, 5], offset=1)
     second_data = second.response.model_dump(mode="python")
@@ -661,7 +661,7 @@ def test_exact_length_boundary_with_multiple_assistant_parts() -> None:
     tokenizer = _BoundaryTokenizer(
         ("user", [8]),
         ("assistant", [2, 9]),
-        ("user", [3]),
+        ("user", [3, 99]),
         ("assistant", [4, 5, 9]),
         ("user", [6]),
         ("assistant", [7, 9]),


### PR DESCRIPTION
## Summary
- anchor fallback length-stop boundary proof to the renderer-attributed assistant span rather than the authoritative prompt's absolute offset
- continue requiring exact sampled output at the start of that span and the existing exact next-prompt validation of the complete renderer tail
- extend the reasoning-plus-content regression with a canonical-only prefix drift

## Why
A second live Qwen3.5 tau-bench trajectory had two consecutive nonterminal length stops. Every sampled output and following boundary was preserved exactly in the next prompt, but full-history rendering inserted one canonical token before the second output. Absolute offsets therefore differed by one even though the renderer unambiguously attributed the output and stop to the correct assistant turn.

## Validation
- full tokenizer suite: 220 passed
- touched-file Ruff, formatting, ty, and lock check pass
- all three captured production failures tokenize successfully
