### PR TITLE
Split token-limited structured chat continuations

### DIFF
--- a/src/art/trajectories/_history.py
+++ b/src/art/trajectories/_history.py
@@ -490,6 +490,53 @@ def _chat_retains_sampled_suffix(
     return _retains_output_suffix(prior_prompt, prior_output, prompt_ids)
 
 
+def _chat_structured_generation_hit_limit(
+    branch: _Branch[Message, ChatCompletionsMessageSource, _ChatContext],
+    prompt_length: int,
+    cache: dict[tuple[int, int], _GenerationTokens],
+) -> bool:
+    """Reject append-only reconciliation of a token-limited structured output."""
+
+    prior_source = next(
+        (
+            source
+            for source in reversed(branch.sources[:prompt_length])
+            if source is not None
+            and isinstance(source.exchange, ChatCompletionsExchange)
+            and source.choice_index is not None
+        ),
+        None,
+    )
+    if prior_source is None or prior_source.choice_index is None:
+        return False
+    if not isinstance(prior_source.exchange, ChatCompletionsExchange):
+        raise AssertionError("Native Chat history has a non-Chat source")
+    exchange = prior_source.exchange
+    choice = next(
+        (
+            choice
+            for choice in exchange.response.choices
+            if choice.index == prior_source.choice_index
+        ),
+        None,
+    )
+    if (
+        choice is None
+        or choice.finish_reason != "tool_calls"
+        or not choice.message.tool_calls
+    ):
+        return False
+    limit = exchange.request.get("max_completion_tokens")
+    if limit is None:
+        limit = exchange.request.get("max_tokens")
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+        return False
+    _, prior_output = _chat_generation_tokens(
+        exchange, prior_source.choice_index, cache
+    )
+    return prior_output is not None and len(prior_output) >= limit
+
+
 def _anthropic_exact_generation_extends(
     branch: _Branch[AnthropicMessageParam, AnthropicMessageSource, _AnthropicContext],
     prompt_ids: Sequence[int] | None,
@@ -656,12 +703,17 @@ def chat_completions_histories(
                 branch, prompt_ids, len(prompt), token_cache
             )
             continuation = lambda branch: (
-                reconcile
-                or (
-                    _chat_retains_sampled_reasoning(
-                        branch, prompt_ids, len(prompt), token_cache
+                not _chat_structured_generation_hit_limit(
+                    branch, len(prompt), token_cache
+                )
+                and (
+                    reconcile
+                    or (
+                        _chat_retains_sampled_reasoning(
+                            branch, prompt_ids, len(prompt), token_cache
+                        )
+                        and exact_continuation(branch)
                     )
-                    and exact_continuation(branch)
                 )
             )
             source_continuation = lambda branch: (

--- a/tests/unit/trajectories/test_history.py
+++ b/tests/unit/trajectories/test_history.py
@@ -1636,6 +1636,53 @@ def test_chat_template_stripped_reasoning_splits_exact_histories() -> None:
         trajectory.tokenize()
 
 
+@pytest.mark.parametrize("output_limit, expected_histories", [(2, 2), (3, 1)])
+def test_token_limited_structured_output_splits_append_only_continuation(
+    output_limit: int, expected_histories: int
+) -> None:
+    tool_call = {
+        "id": "call-1",
+        "type": "function",
+        "function": {"name": "lookup", "arguments": '{"id":"1"}'},
+    }
+    first = _chat([{"role": "user", "content": "one"}], "")
+    first.request["max_completion_tokens"] = output_limit
+    first_data = first.response.model_dump(mode="python")
+    first_data["prompt_token_ids"] = [1]
+    first_data["choices"][0]["finish_reason"] = "tool_calls"
+    first_data["choices"][0]["message"] = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [tool_call],
+    }
+    first_data["choices"][0]["token_ids"] = [2, 3]
+    first.response = ChatCompletion.model_validate(first_data)
+
+    second = _chat(
+        [
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": None, "tool_calls": [tool_call]},
+            {"role": "tool", "tool_call_id": "call-1", "content": "result"},
+        ],
+        "done",
+        offset=1,
+    )
+    second_data = second.response.model_dump(mode="python")
+    second_data["prompt_token_ids"] = [1, 2, 3, 4]
+    second_data["choices"][0]["token_ids"] = [5]
+    second.response = ChatCompletion.model_validate(second_data)
+    trajectory = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=[first, second])
+    )
+
+    histories = trajectory.chat_completions_histories()
+
+    assert len(histories) == expected_histories
+    assert [len(history.messages) for history in histories] == (
+        [2, 4] if expected_histories == 2 else [4]
+    )
+
+
 def test_chat_reasoning_retokenization_reconciles_when_text_is_preserved() -> None:
     first = _chat([{"role": "user", "content": "one"}], "first")
     first_data = first.response.model_dump(mode="python")


### PR DESCRIPTION
## Summary

- classify structured Chat Completions that exhaust their configured output-token limit as ambiguous continuations
- prevent append-only reconciliation from treating parser-completed, truncated tool calls as authoritative sampled history
- preserve the existing path for valid structured generations below the limit

## Production evidence

A Qwen3.5 tau-bench rollout returned `finish_reason=tool_calls` at exactly 4096 output tokens. The sampled text ended midway through the tool-call markup, while the parsed response and next prompt supplied the missing structure. `histories()` previously returned one branch and tensorization failed later because it could not prove the sampled assistant boundary. With this change the same captured trajectory produces two histories, so judged grouping excludes it through the existing history-split policy.

## Validation

- `tests/unit/trajectories/test_history.py`: 76 passed in the ART environment
- combined history/tokenize suite in the Caladan Torch environment: 294 passed; only 2 unrelated async tests could not run because that environment lacks pytest-asyncio
- Ruff, format, Ty, uv.lock sync, diff check: pass
- replayed four captured production failures: the malformed token-limited tool call now splits; the three previously repaired trajectories retain a single history