### PR TITLE
Probe multi-part sampled assistant messages

### DIFF
--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -5173,15 +5173,17 @@ def _tokenize_chat_view(
                     continue
             probe_messages = deepcopy(messages)
             slot_groups = _chat_message_text_slot_groups(probe_messages[message_index])
-            if len(slot_groups) != 1 or len(slot_groups[0]) != 1:
+            if not slot_groups:
                 continue
-            container, key = slot_groups[0][0]
-            original = str(container[key])
-            leading = original[: len(original) - len(original.lstrip())]
-            trailing = original[len(original.rstrip()) :]
-            container[key] = (
-                leading + f"ART_TRAJECTORY_{id(probe_messages):x}_PROBE" + trailing
-            )
+            for part_index, slots in enumerate(slot_groups):
+                for slot_index, (container, key) in enumerate(slots):
+                    original = str(container[key])
+                    leading = original[: len(original) - len(original.lstrip())]
+                    trailing = original[len(original.rstrip()) :]
+                    container[key] = (
+                        leading + f"ART_TRAJECTORY_{id(probe_messages):x}_"
+                        f"PROBE_{part_index}_{slot_index}" + trailing
+                    )
             try:
                 probe = render(
                     probe_messages,

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -345,6 +345,7 @@ def _character_template_history(
     *,
     following_user: str = "turn 2",
     omit_length_tail: bool = False,
+    length_reasoning: str | None = None,
 ) -> tuple[ChatCompletionsHistory, _CharacterTemplateTokenizer, list[int]]:
     tokenizer = _CharacterTemplateTokenizer()
     answer = tokenizer._encode("answer")
@@ -363,7 +364,15 @@ def _character_template_history(
     first = _chat_exchange(first_prompt, first_output)
     second = _chat_exchange(second_prompt, second_output, offset=1)
     second.response.choices[0].finish_reason = "length"
+    if length_reasoning is not None:
+        data = second.response.model_dump(mode="python")
+        data["choices"][0]["message"]["reasoning_content"] = length_reasoning
+        second.response = ChatCompletion.model_validate(data)
     third = _chat_exchange(third_prompt, third_output, offset=2)
+    if length_reasoning is not None:
+        third.request["messages"][-2] = second.response.choices[0].message.model_dump(
+            mode="python", exclude_none=True
+        )
     if following_user != "turn 2":
         third.request["messages"][-1] = {"role": "user", "content": following_user}
     history = art.Trajectory(
@@ -688,6 +697,16 @@ def test_public_exact_chain_preserves_raw_drift_across_proven_length_boundary() 
     tail = length_start + len("answer")
     assert tokenized.flags[tail] == tr.TokenFlag.EXACT | tr.TokenFlag.STOP
     assert not tokenized.flags[tail] & tr.TokenFlag.SAMPLED
+
+
+def test_public_exact_chain_probes_multi_part_length_response() -> None:
+    history, tokenizer, expected = _character_template_history(
+        length_reasoning="thinking"
+    )
+
+    tokenized = history.tokenize(tokenizer=tokenizer)
+
+    assert tokenized.tokens == expected
 
 
 def test_public_exact_chain_rejects_user_token_colliding_with_missing_tail(


### PR DESCRIPTION
## Summary
- extend the existing sampled-message render probe across all text parts, including reasoning plus content
- preserve exact sampled token IDs across a later renderer-proven length-stop boundary
- add a regression for a nonterminal multi-part length stop with prefix token drift

## Validation
- captured 046 production trajectory now tokenizes exactly (16,613 tokens; 7,955 sampled)
- `pytest -q tests/unit/trajectories/test_tokenize.py` (221 passed)
- broader trajectory subset: 415 passed, 3 skipped; 7 tensor-only tests require Torch in CI
- Ruff, ty, and diff checks pass