### PR TITLE
Release retained MoE checkpoint graphs within TrainerRank

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -227,6 +227,7 @@ jobs:
             tests/unit/test_trainer_rank_weird_shapes.py \
             tests/unit/test_trainer_rank_split.py \
             tests/acceptance/trainer_rank_planner \
+            tests/integration/megatron/model_support/test_dispatcher_graph_retention.py \
             tests/integration/megatron/gdn_shared_prefix/test_gdn_planner_runtime_model.py \
             tests/integration/megatron/gdn_shared_prefix/test_gdn_cp_layout_distributed.py::test_distributed_gdn_cp_layout_all_to_all_roundtrips \
             tests/integration/megatron/gdn_shared_prefix/test_gdn_cp_layout_distributed.py::test_distributed_gdn_cp_layout_handles_empty_ranks

--- a/src/art/megatron/runtime/bridge_runtime.py
+++ b/src/art/megatron/runtime/bridge_runtime.py
@@ -936,6 +936,7 @@ def install_art_bridge_runtime_patches() -> None:
     _patch_router_gating_linear_empty_input()
     _patch_bias_swiglu_empty_input()
     _patch_moe_unpermute_empty_input()
+    _patch_moe_dispatcher_graph_retention()
     _patch_nonuniform_expert_export()
     if not getattr(
         model_provider_module.get_model, "__art_meta_materialization__", False
@@ -1123,6 +1124,32 @@ def _patch_bias_swiglu_empty_input() -> None:
     setattr(mlp, "weighted_bias_swiglu_impl", _weighted_bias_swiglu_empty_safe)
     setattr(experts, "weighted_bias_swiglu_impl", _weighted_bias_swiglu_empty_safe)
     setattr(shared_experts, "bias_swiglu_impl", _bias_swiglu_empty_safe)
+
+
+def _patch_moe_dispatcher_graph_retention() -> None:
+    from megatron.core.transformer.moe.token_dispatcher import (
+        MoEAlltoAllTokenDispatcher,
+    )
+
+    original = MoEAlltoAllTokenDispatcher.dispatch_preprocess
+    if getattr(original, "__art_detached_probs_cache__", False):
+        return
+
+    def _dispatch_preprocess(
+        self: Any,
+        hidden_states: torch.Tensor,
+        routing_map: torch.Tensor,
+        probs: torch.Tensor,
+    ):
+        result = original(self, hidden_states, routing_map, probs)
+        # MCore reads this persistent cache only for dtype. Keeping its graph
+        # retains each recomputed checkpoint input and its gradient after backward.
+        # The returned routing probabilities keep their original gradient path.
+        self.probs = probs.detach()
+        return result
+
+    setattr(_dispatch_preprocess, "__art_detached_probs_cache__", True)
+    MoEAlltoAllTokenDispatcher.dispatch_preprocess = _dispatch_preprocess
 
 
 def _patch_moe_unpermute_empty_input() -> None:

--- a/src/art/megatron/runtime/bridge_runtime.py
+++ b/src/art/megatron/runtime/bridge_runtime.py
@@ -1144,14 +1144,14 @@ def _patch_moe_dispatcher_graph_retention() -> None:
         probs: torch.Tensor,
     ):
         result = original(self, hidden_states, routing_map, probs)
-        # MCore reads this cache only for dtype. A detached alias can still retain
-        # its base graph under compilation; an empty tensor owns no input storage.
+        # MCore reads this cache only for dtype; an empty tensor owns no graph or
+        # input storage. Keeping probabilities retains checkpoint inputs and grads.
         # Returned routing probabilities keep their original gradient path.
         self.probs = probs.new_empty(0)
         return result
 
     setattr(_dispatch_preprocess, "__art_probs_dtype_cache__", True)
-    MoEAlltoAllTokenDispatcher.dispatch_preprocess = _dispatch_preprocess
+    setattr(MoEAlltoAllTokenDispatcher, "dispatch_preprocess", _dispatch_preprocess)
 
 
 def _patch_moe_unpermute_empty_input() -> None:

--- a/src/art/megatron/runtime/bridge_runtime.py
+++ b/src/art/megatron/runtime/bridge_runtime.py
@@ -5,7 +5,6 @@ import contextlib
 import copy
 from dataclasses import replace
 import fnmatch
-import functools
 import re
 from typing import Any, cast
 
@@ -937,7 +936,6 @@ def install_art_bridge_runtime_patches() -> None:
     _patch_router_gating_linear_empty_input()
     _patch_bias_swiglu_empty_input()
     _patch_moe_unpermute_empty_input()
-    _patch_moe_dispatcher_graph_retention()
     _patch_nonuniform_expert_export()
     if not getattr(
         model_provider_module.get_model, "__art_meta_materialization__", False
@@ -1125,33 +1123,6 @@ def _patch_bias_swiglu_empty_input() -> None:
     setattr(mlp, "weighted_bias_swiglu_impl", _weighted_bias_swiglu_empty_safe)
     setattr(experts, "weighted_bias_swiglu_impl", _weighted_bias_swiglu_empty_safe)
     setattr(shared_experts, "bias_swiglu_impl", _bias_swiglu_empty_safe)
-
-
-def _patch_moe_dispatcher_graph_retention() -> None:
-    from megatron.core.transformer.moe.token_dispatcher import (
-        MoEAlltoAllTokenDispatcher,
-    )
-
-    original = MoEAlltoAllTokenDispatcher.dispatch_preprocess
-    if getattr(original, "__art_probs_dtype_cache__", False):
-        return
-
-    @functools.wraps(original)
-    def _dispatch_preprocess(
-        self: Any,
-        hidden_states: torch.Tensor,
-        routing_map: torch.Tensor,
-        probs: torch.Tensor,
-    ):
-        result = original(self, hidden_states, routing_map, probs)
-        # MCore reads this cache only for dtype; an empty tensor owns no graph or
-        # input storage. Keeping probabilities retains checkpoint inputs and grads.
-        # Returned routing probabilities keep their original gradient path.
-        self.probs = probs.new_empty(0)
-        return result
-
-    setattr(_dispatch_preprocess, "__art_probs_dtype_cache__", True)
-    setattr(MoEAlltoAllTokenDispatcher, "dispatch_preprocess", _dispatch_preprocess)
 
 
 def _patch_moe_unpermute_empty_input() -> None:

--- a/src/art/megatron/runtime/bridge_runtime.py
+++ b/src/art/megatron/runtime/bridge_runtime.py
@@ -5,6 +5,7 @@ import contextlib
 import copy
 from dataclasses import replace
 import fnmatch
+import functools
 import re
 from typing import Any, cast
 
@@ -1132,9 +1133,10 @@ def _patch_moe_dispatcher_graph_retention() -> None:
     )
 
     original = MoEAlltoAllTokenDispatcher.dispatch_preprocess
-    if getattr(original, "__art_detached_probs_cache__", False):
+    if getattr(original, "__art_probs_dtype_cache__", False):
         return
 
+    @functools.wraps(original)
     def _dispatch_preprocess(
         self: Any,
         hidden_states: torch.Tensor,
@@ -1142,13 +1144,13 @@ def _patch_moe_dispatcher_graph_retention() -> None:
         probs: torch.Tensor,
     ):
         result = original(self, hidden_states, routing_map, probs)
-        # MCore reads this persistent cache only for dtype. Keeping its graph
-        # retains each recomputed checkpoint input and its gradient after backward.
-        # The returned routing probabilities keep their original gradient path.
-        self.probs = probs.detach()
+        # MCore reads this cache only for dtype. A detached alias can still retain
+        # its base graph under compilation; an empty tensor owns no input storage.
+        # Returned routing probabilities keep their original gradient path.
+        self.probs = probs.new_empty(0)
         return result
 
-    setattr(_dispatch_preprocess, "__art_detached_probs_cache__", True)
+    setattr(_dispatch_preprocess, "__art_probs_dtype_cache__", True)
     MoEAlltoAllTokenDispatcher.dispatch_preprocess = _dispatch_preprocess
 
 

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import struct
 import threading
 import time
-from types import TracebackType
+from types import MethodType, TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1135,6 +1135,46 @@ def _split_chunks(
     return tuple(tuple(chunk) for chunk in chunks)
 
 
+def _configure_moe_dispatcher_caches(model: Sequence[torch.nn.Module]) -> None:
+    for chunk in model:
+        for module in chunk.modules():
+            dispatcher = getattr(module, "token_dispatcher", None)
+            if dispatcher is None:
+                continue
+            from megatron.core.transformer.moe.token_dispatcher import (
+                MoEAlltoAllTokenDispatcher,
+            )
+
+            if type(dispatcher) is not MoEAlltoAllTokenDispatcher or (
+                "dispatch_preprocess" in vars(dispatcher)
+            ):
+                continue
+
+            def _dispatch_preprocess(
+                self: Any,
+                hidden_states: torch.Tensor,
+                routing_map: torch.Tensor,
+                probs: torch.Tensor,
+            ):
+                result = MoEAlltoAllTokenDispatcher.dispatch_preprocess(
+                    self, hidden_states, routing_map, probs
+                )
+                # MCore uses this cache only for dtype. Keep the real routing
+                # outputs differentiable without retaining their checkpoint graph.
+                self.probs = probs.new_empty(0)
+                return result
+
+            # Persist through caller-owned backward/checkpoint recomputation;
+            # other dispatcher instances and custom implementations stay intact.
+            setattr(
+                dispatcher,
+                "dispatch_preprocess",
+                MethodType(_dispatch_preprocess, dispatcher),
+            )
+            if (probs := getattr(dispatcher, "probs", None)) is not None:
+                dispatcher.probs = probs.new_empty(0)
+
+
 class TrainerRank:
     def __init__(self, runtime: TrainingRuntime) -> None:
         pp_size = int(getattr(runtime.provider, "pipeline_model_parallel_size", 1) or 1)
@@ -1271,6 +1311,7 @@ class TrainerRank:
         self._planning_seconds_accum = 0.0
         self._speculative_planning_seconds = 0.0
         self._last_forward_telemetry_snapshot: dict[str, Any] | None = None
+        _configure_moe_dispatcher_caches(runtime.model)
         self.zero_grad()
 
     def zero_grad(self) -> None:

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -15,6 +15,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from dataclasses import field as dataclass_field
+from functools import partial
 import hashlib
 import logging
 import math
@@ -23,7 +24,7 @@ from pathlib import Path
 import struct
 import threading
 import time
-from types import MethodType, TracebackType
+from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1135,6 +1136,21 @@ def _split_chunks(
     return tuple(tuple(chunk) for chunk in chunks)
 
 
+def _moe_dispatch_preprocess(
+    dispatcher: Any,
+    hidden_states: torch.Tensor,
+    routing_map: torch.Tensor,
+    probs: torch.Tensor,
+):
+    result = type(dispatcher).dispatch_preprocess(
+        dispatcher, hidden_states, routing_map, probs
+    )
+    # MCore uses this cache only for dtype. Keep the real routing outputs
+    # differentiable without retaining their checkpoint graph.
+    dispatcher.probs = probs.new_empty(0)
+    return result
+
+
 def _configure_moe_dispatcher_caches(model: Sequence[torch.nn.Module]) -> None:
     for chunk in model:
         for module in chunk.modules():
@@ -1150,26 +1166,12 @@ def _configure_moe_dispatcher_caches(model: Sequence[torch.nn.Module]) -> None:
             ):
                 continue
 
-            def _dispatch_preprocess(
-                self: Any,
-                hidden_states: torch.Tensor,
-                routing_map: torch.Tensor,
-                probs: torch.Tensor,
-            ):
-                result = MoEAlltoAllTokenDispatcher.dispatch_preprocess(
-                    self, hidden_states, routing_map, probs
-                )
-                # MCore uses this cache only for dtype. Keep the real routing
-                # outputs differentiable without retaining their checkpoint graph.
-                self.probs = probs.new_empty(0)
-                return result
-
             # Persist through caller-owned backward/checkpoint recomputation;
             # other dispatcher instances and custom implementations stay intact.
             setattr(
                 dispatcher,
                 "dispatch_preprocess",
-                MethodType(_dispatch_preprocess, dispatcher),
+                partial(_moe_dispatch_preprocess, dispatcher),
             )
             if (probs := getattr(dispatcher, "probs", None)) is not None:
                 dispatcher.probs = probs.new_empty(0)

--- a/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
+++ b/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gc
+import inspect
 from types import SimpleNamespace
 import weakref
 
@@ -15,7 +16,7 @@ from megatron.core.transformer.moe.token_dispatcher import MoEAlltoAllTokenDispa
 
 from art.megatron.runtime.bridge_runtime import _patch_moe_dispatcher_graph_retention
 
-_UPSTREAM_DISPATCH = MoEAlltoAllTokenDispatcher.dispatch_preprocess
+_UPSTREAM_DISPATCH = inspect.unwrap(MoEAlltoAllTokenDispatcher.dispatch_preprocess)
 
 
 class _CpuDispatcher(MoEAlltoAllTokenDispatcher):

--- a/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
+++ b/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
@@ -232,7 +232,7 @@ def test_dispatcher_adaptation_survives_serialization(
         pickle.loads(pickle.dumps(model)) if round_trip == "pickle" else deepcopy(model)
     )
     for layer in clone:
-        dispatcher = cast(Any, layer.token_dispatcher)
+        dispatcher = layer.token_dispatcher
         wrapper = dispatcher.dispatch_preprocess
         assert isinstance(wrapper, partial)
         assert wrapper.args[0] is dispatcher

--- a/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
+++ b/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import gc
-import inspect
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
+from typing import Any, cast
 import weakref
 
 import pytest
@@ -12,84 +12,94 @@ from torch._dynamo.testing import CompileCounterWithBackend
 pytest.importorskip("megatron.bridge")
 
 from megatron.core.tensor_parallel import random as mcore_random
-from megatron.core.transformer.moe.token_dispatcher import MoEAlltoAllTokenDispatcher
+from megatron.core.transformer.moe.token_dispatcher import (
+    MoEAllGatherTokenDispatcher,
+    MoEAlltoAllTokenDispatcher,
+    MoEFlexTokenDispatcher,
+)
 
-from art.megatron.runtime.bridge_runtime import _patch_moe_dispatcher_graph_retention
-
-_UPSTREAM_DISPATCH = inspect.unwrap(MoEAlltoAllTokenDispatcher.dispatch_preprocess)
+from art.trainer_rank._impl import _configure_moe_dispatcher_caches
 
 
-class _CpuDispatcher(MoEAlltoAllTokenDispatcher):
+def _preprocess(self, routing_map):
+    return routing_map.sum(0)
+
+
+def _synchronize(self, point, tokens_per_expert=None):
+    assert tokens_per_expert is not None
+    return tokens_per_expert
+
+
+def _dispatcher() -> Any:
+    # Keep the exact upstream type and dispatch/permute implementation, replacing
+    # only CUDA/distributed initialization and metadata transfers for this CPU test.
+    dispatcher: Any = object.__new__(MoEAlltoAllTokenDispatcher)
+    dispatcher.config = SimpleNamespace(
+        moe_router_padding_for_quantization=False, moe_permute_fusion=False
+    )
+    dispatcher.shared_experts = None
+    dispatcher.drop_and_pad = False
+    dispatcher.num_out_tokens = 22
+    dispatcher.preprocess = MethodType(_preprocess, dispatcher)
+    dispatcher._maybe_dtoh_and_synchronize = MethodType(_synchronize, dispatcher)
+    return dispatcher
+
+
+class _RouterLayer(torch.nn.Module):
     def __init__(self):
-        # Exercise the real dispatcher/permute without CUDA streams or collectives.
-        self.config = SimpleNamespace(
-            moe_router_padding_for_quantization=False, moe_permute_fusion=False
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(8, 4, dtype=torch.float64))
+        self.token_dispatcher = _dispatcher()
+
+    def forward(self, value):
+        probs = (value.reshape(-1, 8) @ self.weight).softmax(-1)
+        routing = torch.zeros_like(probs, dtype=torch.bool)
+        routing.scatter_(1, probs.topk(2, dim=-1).indices, True)
+        dispatcher = self.token_dispatcher
+        routed, routed_probs = dispatcher.dispatch_preprocess(value, routing, probs)
+        transformed = routed.tanh() * routed_probs[:, None]
+        merged = torch.zeros_like(value.reshape(-1, 8)).index_add(
+            0, dispatcher.reversed_local_input_permutation_mapping, transformed
         )
-        self.shared_experts = None
-        self.drop_and_pad = False
-        self.num_out_tokens = 22  # Eleven tokens, two selected experts each.
-
-    def preprocess(self, routing_map):
-        return routing_map.sum(0)
-
-    def _maybe_dtoh_and_synchronize(self, point, tokens_per_expert=None):
-        assert tokens_per_expert is not None
-        return tokens_per_expert
+        return value + 0.2 * merged.reshape_as(value)
 
 
-def _run_checkpointed_router(backend):
-    torch.manual_seed(47)
-    initial = torch.randn(1, 11, 8, dtype=torch.float64, requires_grad=True)
-    weights = [
-        torch.randn(8, 4, dtype=torch.float64, requires_grad=True) for _ in range(4)
-    ]
-    dispatchers = [_CpuDispatcher() for _ in weights]
+def _run_checkpointed_router(model, *, install_before_backward=False):
+    model.zero_grad(set_to_none=True)
+    initial = torch.linspace(-1, 1, 88, dtype=torch.float64).reshape(1, 11, 8)
+    initial.requires_grad_()
     inputs = []
 
-    def layer(index):
+    def checkpointed(layer):
         def compute(value):
-            probs = (value.reshape(-1, 8) @ weights[index]).softmax(-1)
-            routing = torch.zeros_like(probs, dtype=torch.bool)
-            routing.scatter_(1, probs.topk(2, dim=-1).indices, True)
-            dispatcher = dispatchers[index]
-            routed, routed_probs = dispatcher.dispatch_preprocess(value, routing, probs)
-            transformed = routed.tanh() * routed_probs[:, None]
-            merged = torch.zeros_like(value.reshape(-1, 8)).index_add(
-                0, dispatcher.reversed_local_input_permutation_mapping, transformed
-            )
-            return value + 0.2 * merged.reshape_as(value)
-
-        execute = (
-            compute if backend is None else torch.compile(compute, backend=backend)
-        )
-
-        def forward(value):
             if torch.is_grad_enabled():
                 assert value.is_leaf
                 inputs.append(weakref.ref(value))
-            return execute(value)
+            return layer(value)
 
-        return forward
+        return compute
 
     hidden = initial
-    for index in range(len(weights)):
-        hidden = mcore_random.CheckpointFunction.apply(layer(index), False, hidden)
+    for layer in model:
+        hidden = mcore_random.CheckpointFunction.apply(
+            checkpointed(layer), False, hidden
+        )
     loss = hidden.square().sum()
+    if install_before_backward:
+        _configure_moe_dispatcher_caches([model])
     loss.backward()
     gc.collect()
-    assert len(inputs) == len(weights)
+    assert len(inputs) == len(model)
     alive = [reference() is not None for reference in inputs]
-    for reference in inputs:
-        if (value := reference()) is not None:
-            assert value.grad is not None
-    del value
     gradients = []
-    for value in [initial, *weights]:
+    for value in [initial, *model.parameters()]:
         assert value.grad is not None
         gradients.append(value.grad.clone())
     # Keep the loss/output alive: clearing only the cache must release the leaves.
-    cache_sizes = [dispatcher.probs.numel() for dispatcher in dispatchers]
-    for dispatcher in dispatchers:
+    cache_sizes = []
+    for layer in model:
+        dispatcher = layer.token_dispatcher
+        cache_sizes.append(dispatcher.probs.numel())
         assert dispatcher.probs.dtype == initial.dtype
         assert dispatcher.probs.device == initial.device
         dispatcher.probs = None
@@ -98,38 +108,97 @@ def _run_checkpointed_router(backend):
     return loss.detach(), gradients, alive, cache_sizes
 
 
-@pytest.mark.parametrize("compiled", [False, True])
-def test_dispatcher_cache_does_not_retain_checkpoint_inputs(monkeypatch, compiled):
-    # The imported MCore checkpoint implementation runs unchanged except CPU RNG.
+@pytest.fixture
+def cpu_checkpoint_rng(monkeypatch):
+    # The imported MCore checkpoint implementation otherwise runs unchanged.
     monkeypatch.setattr(
         mcore_random, "_get_all_rng_states", lambda: (torch.get_rng_state(),)
     )
     monkeypatch.setattr(
         mcore_random, "_set_all_rng_states", lambda state: torch.set_rng_state(state)
     )
-    monkeypatch.setattr(
-        MoEAlltoAllTokenDispatcher, "dispatch_preprocess", _UPSTREAM_DISPATCH
-    )
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+@pytest.mark.parametrize("pending_graph", [False, True])
+def test_dispatcher_cache_releases_checkpoint_inputs(
+    cpu_checkpoint_rng, compiled, pending_graph
+):
+    torch.manual_seed(47)
+    original = MoEAlltoAllTokenDispatcher.dispatch_preprocess
     backend = CompileCounterWithBackend("aot_eager") if compiled else None
+    model = torch.nn.ModuleList([_RouterLayer() for _ in range(4)])
+    if backend is not None:
+        model = torch.nn.ModuleList(
+            [
+                cast(torch.nn.Module, torch.compile(layer, backend=backend))
+                for layer in model
+            ]
+        )
     try:
         reference_loss, reference_grads, retained, sizes = _run_checkpointed_router(
-            backend
+            model
         )
         assert all(retained)
         assert sizes == [44] * 4
-        # Production installs runtime patches before compiling any model graph.
-        torch.compiler.reset()
-        _patch_moe_dispatcher_graph_retention()
-        patched = MoEAlltoAllTokenDispatcher.dispatch_preprocess
-        _patch_moe_dispatcher_graph_retention()
-        assert MoEAlltoAllTokenDispatcher.dispatch_preprocess is patched
-        loss, gradients, retained, sizes = _run_checkpointed_router(backend)
+        # This same model has already compiled/executed both forward and backward.
+        # Do not reset the compiler between warming and installing the adaptation.
+        if not pending_graph:
+            _configure_moe_dispatcher_caches([model])
+        loss, gradients, retained, sizes = _run_checkpointed_router(
+            model, install_before_backward=pending_graph
+        )
         assert not any(retained)
         assert sizes == [0] * 4
         assert torch.equal(loss, reference_loss)
         for actual, expected in zip(gradients, reference_grads, strict=True):
             assert torch.equal(actual, expected)
+        assert MoEAlltoAllTokenDispatcher.dispatch_preprocess is original
         if backend is not None:
             assert backend.frame_count > 0
     finally:
         torch.compiler.reset()
+
+
+def test_dispatcher_adaptation_is_instance_scoped_and_collectable(cpu_checkpoint_rng):
+    class CustomDispatcher(MoEAlltoAllTokenDispatcher):
+        pass
+
+    target = _RouterLayer()
+    untouched = _RouterLayer()
+    subclass = object.__new__(CustomDispatcher)
+    overridden = _dispatcher()
+    override = overridden.dispatch_preprocess
+    overridden.dispatch_preprocess = override
+    excluded = [
+        subclass,
+        overridden,
+        object.__new__(MoEAllGatherTokenDispatcher),
+        object.__new__(MoEFlexTokenDispatcher),
+    ]
+    owners = [target, target]  # Shared module and dispatcher discovery is harmless.
+    for dispatcher in [target.token_dispatcher, *excluded]:
+        owner = torch.nn.Module()
+        setattr(owner, "token_dispatcher", dispatcher)
+        owners.append(owner)
+    model = torch.nn.ModuleList(owners)
+    original = MoEAlltoAllTokenDispatcher.dispatch_preprocess
+    _configure_moe_dispatcher_caches([model, model])
+    adapted = target.token_dispatcher.dispatch_preprocess
+    _configure_moe_dispatcher_caches([model])
+    assert target.token_dispatcher.dispatch_preprocess is adapted
+    assert MoEAlltoAllTokenDispatcher.dispatch_preprocess is original
+    assert untouched.token_dispatcher.dispatch_preprocess.__func__ is original
+    assert subclass.dispatch_preprocess.__func__ is original
+    assert overridden.dispatch_preprocess is override
+    for dispatcher in excluded:
+        assert "probs" not in vars(dispatcher)
+    _, _, retained, sizes = _run_checkpointed_router(torch.nn.ModuleList([untouched]))
+    assert retained == [True]
+    assert sizes == [44]
+    # Persistent bound methods must not keep the dispatcher alive once its owner
+    # and any pending graphs have gone away.
+    reference = weakref.ref(target.token_dispatcher)
+    del adapted, target, owners, model, owner
+    gc.collect()
+    assert reference() is None

--- a/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
+++ b/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import gc
+from types import SimpleNamespace
+import weakref
+
+import pytest
+import torch
+from torch._dynamo.testing import CompileCounterWithBackend
+
+pytest.importorskip("megatron.bridge")
+
+from megatron.core.tensor_parallel import random as mcore_random
+from megatron.core.transformer.moe.token_dispatcher import MoEAlltoAllTokenDispatcher
+
+from art.megatron.runtime.bridge_runtime import _patch_moe_dispatcher_graph_retention
+
+_UPSTREAM_DISPATCH = MoEAlltoAllTokenDispatcher.dispatch_preprocess
+
+
+class _CpuDispatcher(MoEAlltoAllTokenDispatcher):
+    def __init__(self):
+        # Exercise the real dispatcher/permute without CUDA streams or collectives.
+        self.config = SimpleNamespace(
+            moe_router_padding_for_quantization=False, moe_permute_fusion=False
+        )
+        self.shared_experts = None
+        self.drop_and_pad = False
+        self.num_out_tokens = 22  # Eleven tokens, two selected experts each.
+
+    def preprocess(self, routing_map):
+        return routing_map.sum(0)
+
+    def _maybe_dtoh_and_synchronize(self, point, value):
+        return value
+
+
+def _run_checkpointed_router(backend):
+    torch.manual_seed(47)
+    initial = torch.randn(1, 11, 8, dtype=torch.float64, requires_grad=True)
+    weights = [
+        torch.randn(8, 4, dtype=torch.float64, requires_grad=True) for _ in range(4)
+    ]
+    dispatchers = [_CpuDispatcher() for _ in weights]
+    inputs = []
+
+    def layer(index):
+        def compute(value):
+            probs = (value.reshape(-1, 8) @ weights[index]).softmax(-1)
+            routing = torch.zeros_like(probs, dtype=torch.bool)
+            routing.scatter_(1, probs.topk(2, dim=-1).indices, True)
+            dispatcher = dispatchers[index]
+            routed, routed_probs = dispatcher.dispatch_preprocess(value, routing, probs)
+            transformed = routed.tanh() * routed_probs[:, None]
+            merged = torch.zeros_like(value.reshape(-1, 8)).index_add(
+                0, dispatcher.reversed_local_input_permutation_mapping, transformed
+            )
+            return value + 0.2 * merged.reshape_as(value)
+
+        execute = (
+            compute if backend is None else torch.compile(compute, backend=backend)
+        )
+
+        def forward(value):
+            if torch.is_grad_enabled():
+                assert value.is_leaf
+                inputs.append(weakref.ref(value))
+            return execute(value)
+
+        return forward
+
+    hidden = initial
+    for index in range(len(weights)):
+        hidden = mcore_random.CheckpointFunction.apply(layer(index), False, hidden)
+    loss = hidden.square().sum()
+    loss.backward()
+    gc.collect()
+    assert len(inputs) == len(weights)
+    alive = [reference() is not None for reference in inputs]
+    for reference in inputs:
+        if (value := reference()) is not None:
+            assert value.grad is not None
+    del value
+    gradients = []
+    for value in [initial, *weights]:
+        assert value.grad is not None
+        gradients.append(value.grad.clone())
+    # Keep the loss/output alive: clearing only the cache must release the leaves.
+    for dispatcher in dispatchers:
+        dispatcher.probs = None
+    gc.collect()
+    assert all(reference() is None for reference in inputs)
+    return loss.detach(), gradients, alive
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_dispatcher_cache_does_not_retain_checkpoint_inputs(monkeypatch, compiled):
+    # The imported MCore checkpoint implementation runs unchanged except CPU RNG.
+    monkeypatch.setattr(
+        mcore_random, "_get_all_rng_states", lambda: (torch.get_rng_state(),)
+    )
+    monkeypatch.setattr(
+        mcore_random, "_set_all_rng_states", lambda state: torch.set_rng_state(state)
+    )
+    monkeypatch.setattr(
+        MoEAlltoAllTokenDispatcher, "dispatch_preprocess", _UPSTREAM_DISPATCH
+    )
+    backend = CompileCounterWithBackend("aot_eager") if compiled else None
+    try:
+        reference_loss, reference_grads, retained = _run_checkpointed_router(backend)
+        assert all(retained)
+        _patch_moe_dispatcher_graph_retention()
+        patched = MoEAlltoAllTokenDispatcher.dispatch_preprocess
+        _patch_moe_dispatcher_graph_retention()
+        assert MoEAlltoAllTokenDispatcher.dispatch_preprocess is patched
+        loss, gradients, retained = _run_checkpointed_router(backend)
+        assert not any(retained)
+        assert torch.equal(loss, reference_loss)
+        for actual, expected in zip(gradients, reference_grads, strict=True):
+            assert torch.equal(actual, expected)
+        if backend is not None:
+            assert backend.frame_count > 0
+    finally:
+        torch.compiler.reset()

--- a/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
+++ b/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
@@ -18,6 +18,7 @@ from megatron.core.transformer.moe.token_dispatcher import (
     MoEFlexTokenDispatcher,
 )
 
+from art.trainer_rank import TrainerRank
 from art.trainer_rank._impl import _configure_moe_dispatcher_caches
 
 
@@ -183,9 +184,19 @@ def test_dispatcher_adaptation_is_instance_scoped_and_collectable(cpu_checkpoint
         owners.append(owner)
     model = torch.nn.ModuleList(owners)
     original = MoEAlltoAllTokenDispatcher.dispatch_preprocess
-    _configure_moe_dispatcher_caches([model, model])
+    target.token_dispatcher.probs = target.weight.softmax(-1)
+    cached = weakref.ref(target.token_dispatcher.probs)
+    runtime = SimpleNamespace(
+        model=[model],
+        provider=SimpleNamespace(hidden_size=8, num_layers=1),
+        model_support_handler=SimpleNamespace(),
+        optimizer=None,
+    )
+    trainer = TrainerRank(cast(Any, runtime))
+    assert cached() is None
+    assert target.token_dispatcher.probs.numel() == 0
     adapted = target.token_dispatcher.dispatch_preprocess
-    _configure_moe_dispatcher_caches([model])
+    _configure_moe_dispatcher_caches([model, model])
     assert target.token_dispatcher.dispatch_preprocess is adapted
     assert MoEAlltoAllTokenDispatcher.dispatch_preprocess is original
     assert untouched.token_dispatcher.dispatch_preprocess.__func__ is original
@@ -199,6 +210,6 @@ def test_dispatcher_adaptation_is_instance_scoped_and_collectable(cpu_checkpoint
     # Persistent bound methods must not keep the dispatcher alive once its owner
     # and any pending graphs have gone away.
     reference = weakref.ref(target.token_dispatcher)
-    del adapted, target, owners, model, owner
+    del adapted, target, owners, model, owner, trainer, runtime
     gc.collect()
     assert reference() is None

--- a/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
+++ b/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from functools import partial
 import gc
-from types import MethodType, SimpleNamespace
+import pickle
+from types import SimpleNamespace
 from typing import Any, cast
 import weakref
 
@@ -41,8 +44,8 @@ def _dispatcher() -> Any:
     dispatcher.shared_experts = None
     dispatcher.drop_and_pad = False
     dispatcher.num_out_tokens = 22
-    dispatcher.preprocess = MethodType(_preprocess, dispatcher)
-    dispatcher._maybe_dtoh_and_synchronize = MethodType(_synchronize, dispatcher)
+    dispatcher.preprocess = partial(_preprocess, dispatcher)
+    dispatcher._maybe_dtoh_and_synchronize = partial(_synchronize, dispatcher)
     return dispatcher
 
 
@@ -207,9 +210,51 @@ def test_dispatcher_adaptation_is_instance_scoped_and_collectable(cpu_checkpoint
     _, _, retained, sizes = _run_checkpointed_router(torch.nn.ModuleList([untouched]))
     assert retained == [True]
     assert sizes == [44]
-    # Persistent bound methods must not keep the dispatcher alive once its owner
+    # Persistent callables must not keep the dispatcher alive once its owner
     # and any pending graphs have gone away.
     reference = weakref.ref(target.token_dispatcher)
     del adapted, target, owners, model, owner, trainer, runtime
     gc.collect()
     assert reference() is None
+
+
+@pytest.mark.parametrize("round_trip", ["pickle", "deepcopy"])
+@pytest.mark.parametrize("compiled", [False, True])
+def test_dispatcher_adaptation_survives_serialization(
+    cpu_checkpoint_rng, round_trip, compiled
+):
+    torch.manual_seed(47)
+    model = torch.nn.ModuleList([_RouterLayer() for _ in range(4)])
+    expected_loss, expected_grads, retained, _ = _run_checkpointed_router(model)
+    assert all(retained)
+    _configure_moe_dispatcher_caches([model])
+    clone = (
+        pickle.loads(pickle.dumps(model)) if round_trip == "pickle" else deepcopy(model)
+    )
+    for layer in clone:
+        dispatcher = cast(Any, layer.token_dispatcher)
+        wrapper = dispatcher.dispatch_preprocess
+        assert isinstance(wrapper, partial)
+        assert wrapper.args[0] is dispatcher
+        assert all(dispatcher is not original.token_dispatcher for original in model)
+        _configure_moe_dispatcher_caches([clone])
+        assert dispatcher.dispatch_preprocess is wrapper
+    backend = CompileCounterWithBackend("aot_eager") if compiled else None
+    if backend is not None:
+        clone = torch.nn.ModuleList(
+            [
+                cast(torch.nn.Module, torch.compile(layer, backend=backend))
+                for layer in clone
+            ]
+        )
+    try:
+        loss, gradients, retained, sizes = _run_checkpointed_router(clone)
+        assert not any(retained)
+        assert sizes == [0] * 4
+        assert torch.equal(loss, expected_loss)
+        for actual, expected in zip(gradients, expected_grads, strict=True):
+            assert torch.equal(actual, expected)
+        if backend is not None:
+            assert backend.frame_count > 0
+    finally:
+        torch.compiler.reset()

--- a/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
+++ b/tests/integration/megatron/model_support/test_dispatcher_graph_retention.py
@@ -32,8 +32,9 @@ class _CpuDispatcher(MoEAlltoAllTokenDispatcher):
     def preprocess(self, routing_map):
         return routing_map.sum(0)
 
-    def _maybe_dtoh_and_synchronize(self, point, value):
-        return value
+    def _maybe_dtoh_and_synchronize(self, point, tokens_per_expert=None):
+        assert tokens_per_expert is not None
+        return tokens_per_expert
 
 
 def _run_checkpointed_router(backend):
@@ -87,11 +88,14 @@ def _run_checkpointed_router(backend):
         assert value.grad is not None
         gradients.append(value.grad.clone())
     # Keep the loss/output alive: clearing only the cache must release the leaves.
+    cache_sizes = [dispatcher.probs.numel() for dispatcher in dispatchers]
     for dispatcher in dispatchers:
+        assert dispatcher.probs.dtype == initial.dtype
+        assert dispatcher.probs.device == initial.device
         dispatcher.probs = None
     gc.collect()
     assert all(reference() is None for reference in inputs)
-    return loss.detach(), gradients, alive
+    return loss.detach(), gradients, alive, cache_sizes
 
 
 @pytest.mark.parametrize("compiled", [False, True])
@@ -108,14 +112,20 @@ def test_dispatcher_cache_does_not_retain_checkpoint_inputs(monkeypatch, compile
     )
     backend = CompileCounterWithBackend("aot_eager") if compiled else None
     try:
-        reference_loss, reference_grads, retained = _run_checkpointed_router(backend)
+        reference_loss, reference_grads, retained, sizes = _run_checkpointed_router(
+            backend
+        )
         assert all(retained)
+        assert sizes == [44] * 4
+        # Production installs runtime patches before compiling any model graph.
+        torch.compiler.reset()
         _patch_moe_dispatcher_graph_retention()
         patched = MoEAlltoAllTokenDispatcher.dispatch_preprocess
         _patch_moe_dispatcher_graph_retention()
         assert MoEAlltoAllTokenDispatcher.dispatch_preprocess is patched
-        loss, gradients, retained = _run_checkpointed_router(backend)
+        loss, gradients, retained, sizes = _run_checkpointed_router(backend)
         assert not any(retained)
+        assert sizes == [0] * 4
         assert torch.equal(loss, reference_loss)
         for actual, expected in zip(gradients, reference_grads, strict=True):
             assert torch.equal(actual, expected)


### PR DESCRIPTION
MCore's all-to-all dispatcher retains differentiable routing probabilities on `self.probs`, although its only later use is a dtype lookup. Under activation recomputation this keeps checkpoint inputs and their gradients alive after backward. A captured Qwen3.6-35B-A3B single-H200 OOM contained 37 such gradient buffers totaling 10.62 GiB.

`TrainerRank` now adapts only standard all-to-all dispatcher instances discovered in its supplied model. After upstream `dispatch_preprocess` returns, the wrapper replaces the metadata cache with an independent zero-element tensor of the same dtype/device. Original probabilities still drive permutation and returned routing tensors remain differentiable. The adaptation persists through caller-owned backward and checkpoint recomputation; construction also releases an existing probability cache. A module-level helper bound with `functools.partial` preserves the adaptation and copied dispatcher ownership through pickle and deepcopy.

The production diff is **43 added lines, entirely in `art.trainer_rank._impl`**. No `art.megatron` files, MCore class methods, public `TrainerRank` API, Caladan code or experiment files change. Unrelated models, custom dispatcher subclasses and existing instance overrides remain untouched. Another executor sharing the same supplied model sees the adaptation too.

Validation:

- Nine focused regression cases pass using pinned MCore checkpoint/dispatcher/unfused permutation with CPU RNG and distributed setup adapted. They cover bitwise eager/AOT loss and input/router-gradient parity, checkpoint-input release, warmed compiled models without resetting the compiler during installation, pending checkpoint backward, constructor/cache release, isolation, idempotence, garbage collection, pickle and deepcopy.
- Minsky and McCarthy independently clear the final runtime implementation. McCarthy also verifies pickle restoration in a fresh process. Final head `9a1a1f26` only removes a redundant test cast from their reviewed `1f28e0bf`; production bytes are identical.
- Final [quality CI](https://github.com/OpenPipe/ART/actions/runs/34154463819) passes: 662 lightweight Megatron tests and 1,005 unit tests (14 skipped), plus lint/format/type/lock checks. Final [two-H200 CI](https://github.com/OpenPipe/ART/actions/runs/34154463817) also passes: 56 tests (one skipped), followed by real CP2/TP2 public-API checks with zero head/slot-gradient differences. The CI cluster and all matching Kubernetes resources are independently confirmed released.

**Full-model result:** the final runtime completes the native experiment049 batch on one H200: 4 groups, 20 trajectories, 339 histories, 445 active requests, all four backwards and three finite adapter updates. Peak allocated/reserved memory is **110.105 / 114.352 GiB**. Policy/reference-imitation Adam counters advance 0→1 and adversary 48→49 across 660 entries per adapter. All four unsplit plans preserve the original tested geometry. Driver exit0; cluster independently confirmed absent after cleanup.

The replay uses combined ART `e5292f0cd`, this final production implementation plus head recomputation [#857](https://github.com/OpenPipe/ART/pull/857), exact Caladan `ace09cf`, merged loss correction [Caladan #229](https://github.com/OpenPipe/caladan/pull/229), and verified `expandable_segments=True`. Original targets and checkpoint inputs are retained. Peak allocated memory matches the earlier global implementation exactly; scalar metrics differ across full-model runs, so full-model bitwise parity is not claimed. No production checkpoint is published. This validates the captured training step, not an entire production entrypoint run.

CUDA graph capture/replay is not qualified. General memory admission remains open in [#848](https://github.com/OpenPipe/ART/issues/848).
