### PR TITLE
Separate TrainerRank retained memory from backward peaks

### DIFF
--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -574,14 +574,13 @@ class _MemoryProfile:
     bytes_per_token: float
     packed_tokens: int
     logical_per_packed: float = 1.0
-    # Fraction of a forward's observed peak still allocated after it returns
-    # (activations retained for backward): a physical ratio, so it needs no
-    # trusted denominator (the cold call's static estimate is far below the
-    # real peak). ``None`` until observed, max-merged afterwards. Observed at
-    # forward return only — it says nothing about the backward's own
-    # workspace. Trusted only near the ``packed_tokens`` /
-    # ``logical_per_packed`` scale it was observed at.
+    # Historical forward-retained/forward-peak ratio for calibration telemetry,
+    # max-merged only from forward-return observations. Admission uses the
+    # independent retained compute rate below, not this ratio of past peaks.
     retained_fraction: float | None = None
+    # Separate the retained compute rate from the peak, which also learns
+    # caller-owned backward workspace. Requested outputs are charged explicitly.
+    retained_compute_bytes_per_token: float | None = None
 
 
 @dataclass(frozen=True)
@@ -2482,39 +2481,45 @@ class TrainerRank:
             signature=signature,
             logical_tokens=logical_tokens,
         )
-        retained = int(
-            required
-            * self._retained_fraction(
-                signature, packed_tokens=packed_tokens, logical_tokens=logical_tokens
-            )
+        retained = self._retained_memory_bytes(
+            signature,
+            packed_tokens=packed_tokens,
+            logical_tokens=logical_tokens,
+            output_bytes=output_bytes,
+            required=required,
         )
         return _SubforwardCost(required=required, retained=retained)
 
-    def _retained_fraction(
+    def _retained_memory_bytes(
         self,
         signature: _MemorySignature,
         *,
         packed_tokens: int,
         logical_tokens: int,
-    ) -> float:
-        """Share of a subforward's peak still allocated after it returns.
+        output_bytes: int,
+        required: int,
+    ) -> int:
+        """Forward-retained bytes, independent of a later backward peak.
 
-        Applied to the estimated peak, which is at least the real one whenever
-        the estimate is trusted. 1.0 (everything retained) until observed. An
-        observation is trusted only near the scale and sharing ratio it was
-        made at — the growth range that already gates ``bytes_per_token`` —
-        so a small profiled forward cannot authorize a much larger split.
+        Retain the full estimate until observed near the current scale and
+        sharing ratio, so a small forward cannot authorize a much larger split.
         """
 
         profile = self._memory_profiles.get(signature)
-        if profile is None or profile.retained_fraction is None:
-            return 1.0
+        if profile is None or profile.retained_compute_bytes_per_token is None:
+            return required
         if packed_tokens > profile.packed_tokens * _MEMORY_PROFILE_TRUST_GROWTH:
-            return 1.0
+            return required
         ratio = logical_tokens / max(1, packed_tokens)
         if ratio > profile.logical_per_packed * _MEMORY_PROFILE_TRUST_GROWTH:
-            return 1.0
-        return profile.retained_fraction
+            return required
+        retained = (
+            output_bytes
+            + profile.retained_compute_bytes_per_token
+            * packed_tokens
+            * max(1.0, ratio / profile.logical_per_packed)
+        )
+        return min(required, int(retained * _MEMORY_SAFETY_FACTOR))
 
     def _split_request_order(
         self,
@@ -4655,6 +4660,9 @@ class TrainerRank:
         bytes_per_token = compute_delta / max(1, plan.packed_tokens)
         previous = self._memory_profiles.get(plan.signature)
         retained_fraction = None if previous is None else previous.retained_fraction
+        retained_compute = (
+            None if previous is None else previous.retained_compute_bytes_per_token
+        )
         if retained_bytes is not None:
             observed = min(1.0, retained_bytes / max(1, peak_delta_bytes))
             # Max-merge once observed. ``None`` (never observed) is distinct
@@ -4665,6 +4673,10 @@ class TrainerRank:
                 if retained_fraction is None
                 else max(retained_fraction, observed)
             )
+            observed_compute = max(
+                0, min(retained_bytes, peak_delta_bytes) - plan.output_bytes
+            ) / max(1, plan.packed_tokens)
+            retained_compute = max(retained_compute or 0.0, observed_compute)
         self._memory_profiles[plan.signature] = _MemoryProfile(
             bytes_per_token=max(
                 bytes_per_token,
@@ -4679,6 +4691,7 @@ class TrainerRank:
                 1.0 if previous is None else previous.logical_per_packed,
             ),
             retained_fraction=retained_fraction,
+            retained_compute_bytes_per_token=retained_compute,
         )
 
     def _forward_item(self, request: AnyForwardInput) -> _ForwardItem:

--- a/tests/unit/test_trainer_rank_split.py
+++ b/tests/unit/test_trainer_rank_split.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from contextlib import nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import sys
 from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
@@ -150,7 +150,7 @@ def test_dp_rank_forward_splits_instead_of_raising(
     # Unsplit: 40 packed tokens. Budget admits 20, so two subforwards of two
     # requests fit once a retained profile says earlier graphs cost nothing
     # extra here (the cumulative test covers the conservative default).
-    monkeypatch.setattr(rank, "_retained_fraction", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(rank, "_retained_memory_bytes", lambda *_args, **_kwargs: 0)
     _packed_budget(monkeypatch, rank, 20)
 
     outputs = rank.dp_rank_forward(inputs)
@@ -192,7 +192,7 @@ def test_split_outputs_preserve_nested_caller_order(
         [_request(2)],
         [_request(3), _request(4), _request(5)],
     ]
-    monkeypatch.setattr(rank, "_retained_fraction", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(rank, "_retained_memory_bytes", lambda *_args, **_kwargs: 0)
     _packed_budget(monkeypatch, rank, 20)
 
     outputs = rank.dp_rank_forward(nested)
@@ -273,7 +273,11 @@ def test_split_admission_uses_a_retained_profile_when_available(
     rank = _rank(monkeypatch)
     executed = _recording_executor(monkeypatch, rank)
     _packed_budget(monkeypatch, rank, 25)
-    monkeypatch.setattr(rank, "_retained_fraction", lambda *_args, **_kwargs: 0.1)
+    monkeypatch.setattr(
+        rank,
+        "_retained_memory_bytes",
+        lambda *_args, **kwargs: int(kwargs["required"] * 0.1),
+    )
 
     outputs = rank.dp_rank_forward([_request(marker) for marker in range(4)])
 
@@ -286,7 +290,7 @@ def test_forward_micro_batches_splits_the_minimum_wave(
 ) -> None:
     rank = _rank(monkeypatch)
     _recording_executor(monkeypatch, rank)
-    monkeypatch.setattr(rank, "_retained_fraction", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(rank, "_retained_memory_bytes", lambda *_args, **_kwargs: 0)
     # One top-level item holding four requests (40 tokens) under a 20-token
     # budget: the minimum wave cannot fit unsplit and must split, not raise.
     items = [[_request(marker) for marker in range(4)]]
@@ -306,7 +310,7 @@ def test_forward_micro_batches_splits_the_minimum_wave(
 def test_split_decisions_are_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:
     rank = _rank(monkeypatch)
     executed = _recording_executor(monkeypatch, rank)
-    monkeypatch.setattr(rank, "_retained_fraction", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(rank, "_retained_memory_bytes", lambda *_args, **_kwargs: 0)
     _packed_budget(monkeypatch, rank, 30)
     inputs = [_request(marker) for marker in range(8)]
 
@@ -337,7 +341,7 @@ def test_split_ladder_ensures_checkpoint_slots_once(
 
     rank = _rank(monkeypatch)
     _recording_executor(monkeypatch, rank)
-    monkeypatch.setattr(rank, "_retained_fraction", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(rank, "_retained_memory_bytes", lambda *_args, **_kwargs: 0)
     ensured = 0
     original = rank._ensure_checkpoint_slots
 
@@ -372,10 +376,14 @@ def test_retained_profile_is_trusted_only_near_its_observed_scale(
     _packed_budget(monkeypatch, rank, 25)
     inputs = [_request(marker) for marker in range(4)]
     signature = rank._plan_flat_forward(inputs).signature
+    monkeypatch.setattr(
+        rank, "_estimate_group_request_output_bytes", lambda requests: 0
+    )
     rank._memory_profiles[signature] = _MemoryProfile(
         bytes_per_token=1.0,
         packed_tokens=observed_packed_tokens,
         retained_fraction=0.1,
+        retained_compute_bytes_per_token=0.1 / 1.1,
     )
 
     if expect_split:
@@ -394,15 +402,12 @@ def test_retained_observations_are_max_merged_once_observed(
     _packed_budget(monkeypatch, rank, 1_000)
     plan = rank._plan_flat_forward([_request(marker) for marker in range(4)])
 
-    def fraction() -> float:
-        return rank._retained_fraction(
-            plan.signature,
-            packed_tokens=plan.packed_tokens,
-            logical_tokens=plan.logical_tokens,
-        )
+    def fraction() -> float | None:
+        profile = rank._memory_profiles.get(plan.signature)
+        return None if profile is None else profile.retained_fraction
 
     # Observations are retained bytes over the same forward's peak delta (40).
-    assert fraction() == 1.0  # never observed
+    assert fraction() is None  # never observed
     rank._update_memory_profile(plan, 40, retained_bytes=40)
     assert fraction() == 1.0  # observed: everything retained
     rank._update_memory_profile(plan, 40, retained_bytes=4)
@@ -419,12 +424,134 @@ def test_retained_observations_are_max_merged_once_observed(
     assert fraction() == pytest.approx(0.7)  # peak-only update keeps it
 
 
+@pytest.mark.parametrize("output_gib", [0, 4])
+@pytest.mark.parametrize("peak_first", [False, True])
+def test_backward_peak_does_not_inflate_retained_split_memory(
+    monkeypatch: pytest.MonkeyPatch, output_gib: int, peak_first: bool
+) -> None:
+    rank = TrainerRank(_runtime())
+    gib = 1 << 30
+    plan = replace(
+        rank._plan_flat_forward([_request(0)]),
+        packed_tokens=100,
+        logical_tokens=100,
+        output_bytes=output_gib * gib,
+    )
+    half = replace(
+        plan, packed_tokens=50, logical_tokens=50, output_bytes=plan.output_bytes // 2
+    )
+    if peak_first:
+        rank._update_memory_profile(plan, 100 * gib, retained_bytes=None)
+    rank._update_memory_profile(plan, 60 * gib, retained_bytes=30 * gib)
+    forward = rank._plan_cost(half)
+    rank._update_memory_profile(plan, 100 * gib, retained_bytes=None)
+    backward = rank._plan_cost(half)
+
+    assert forward.required == (55 if peak_first else 33) * gib
+    assert backward.required == 55 * gib
+    assert forward.retained == backward.retained == int(16.5 * gib)
+    monkeypatch.setattr(rank, "_available_memory_bytes", lambda: 75 * gib)
+    check = rank._split_rung_check([backward, backward])
+    assert check.fits
+    assert check.estimated_required_bytes == int(71.5 * gib)
+
+
+@pytest.mark.parametrize("retained_bytes", [20_000, 40_000, 60_000])
+@pytest.mark.parametrize("output_bytes", [10_000, 30_000])
+def test_retained_outputs_are_charged_separately(
+    retained_bytes: int, output_bytes: int
+) -> None:
+    rank = TrainerRank(_runtime())
+    plan = replace(
+        rank._plan_flat_forward([_request(0)]),
+        packed_tokens=100,
+        logical_tokens=100,
+        output_bytes=40_000,
+    )
+    rank._update_memory_profile(plan, 100_000, retained_bytes=retained_bytes)
+    rank._update_memory_profile(plan, 200_000, retained_bytes=None)
+    half = replace(plan, packed_tokens=50, logical_tokens=50, output_bytes=output_bytes)
+    retained_compute = max(0, retained_bytes - plan.output_bytes) // 2
+    assert rank._plan_cost(half).retained == int(
+        (output_bytes + retained_compute) * 1.1
+    )
+
+
+def test_retained_compute_observations_are_max_merged_independently() -> None:
+    rank = TrainerRank(_runtime())
+    plan = replace(
+        rank._plan_flat_forward([_request(0)]),
+        packed_tokens=100,
+        logical_tokens=100,
+        output_bytes=40_000,
+    )
+    rank._update_memory_profile(plan, 100_000, retained_bytes=60_000)
+    larger = replace(plan, packed_tokens=200, logical_tokens=200, output_bytes=80_000)
+    rank._update_memory_profile(larger, 200_000, retained_bytes=180_000)
+    retained = rank._plan_cost(plan).retained
+    rank._update_memory_profile(larger, 300_000, retained_bytes=None)
+    rank._update_memory_profile(plan, 100_000, retained_bytes=41_000)
+
+    assert rank._memory_profiles[plan.signature].retained_compute_bytes_per_token == 500
+    assert rank._plan_cost(plan).retained == retained == 99_000
+
+
+def test_changed_output_allocation_does_not_inflate_retained_compute() -> None:
+    rank = TrainerRank(_runtime())
+    plan = replace(
+        rank._plan_flat_forward([_request(0)]),
+        packed_tokens=100,
+        logical_tokens=100,
+        output_bytes=40_000,
+    )
+    rank._update_memory_profile(plan, 100_000, retained_bytes=60_000)
+    retained = rank._plan_cost(plan).retained
+    larger_output = replace(plan, output_bytes=140_000)
+    rank._update_memory_profile(larger_output, 200_000, retained_bytes=160_000)
+
+    assert rank._memory_profiles[plan.signature].retained_compute_bytes_per_token == 200
+    assert rank._plan_cost(plan).retained == retained == 66_000
+    assert rank._plan_cost(larger_output).retained == 176_000
+
+
+@pytest.mark.parametrize(
+    ("packed_tokens", "logical_tokens", "trusted"),
+    [(800, 800, True), (801, 801, False), (100, 800, True), (100, 801, False)],
+)
+def test_retained_compute_keeps_growth_and_sharing_trust_limits(
+    packed_tokens: int, logical_tokens: int, trusted: bool
+) -> None:
+    rank = TrainerRank(_runtime())
+    plan = replace(
+        rank._plan_flat_forward([_request(0)]),
+        packed_tokens=100,
+        logical_tokens=100,
+        output_bytes=40_000,
+    )
+    candidate = replace(
+        plan, packed_tokens=packed_tokens, logical_tokens=logical_tokens
+    )
+    cold = rank._plan_cost(candidate)
+    assert cold.retained == cold.required
+    # A peak-only observation cannot authorize releasing any retained memory.
+    rank._update_memory_profile(plan, 100_000, retained_bytes=None)
+    unknown = rank._plan_cost(candidate)
+    assert unknown.retained == unknown.required
+    rank._update_memory_profile(plan, 100_000, retained_bytes=60_000)
+    observed = rank._plan_cost(candidate)
+    if trusted:
+        assert observed.retained == 220_000
+        assert observed.retained < observed.required
+    else:
+        assert observed.retained == observed.required
+
+
 @pytest.mark.parametrize("failing_ordinal", (0, 1))
 def test_split_execution_failure_is_reported_as_partial_execution(
     monkeypatch: pytest.MonkeyPatch, failing_ordinal: int
 ) -> None:
     rank = _rank(monkeypatch)
-    monkeypatch.setattr(rank, "_retained_fraction", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(rank, "_retained_memory_bytes", lambda *_args, **_kwargs: 0)
     _packed_budget(monkeypatch, rank, 20)
     runs = 0
 
@@ -461,7 +588,7 @@ def test_split_subforwards_track_independent_slot_graphs(
     the second is released too."""
 
     rank = _rank(monkeypatch)
-    monkeypatch.setattr(rank, "_retained_fraction", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(rank, "_retained_memory_bytes", lambda *_args, **_kwargs: 0)
     _packed_budget(monkeypatch, rank, 20)
     ref = cast("LoRASlotRef", _SlotRef("teacher"))
     monkeypatch.setattr(rank, "_slot_ref", lambda name: _SlotRef(name))


### PR DESCRIPTION
When a caller's backward pass peaks above its forward pass, TrainerRank currently applies the old forward-retained fraction to the larger peak. This can reject a feasible split: a 60 GiB forward with 30 GiB retained, followed by a 100 GiB backward peak, prices two half-sized subforwards at 82.5 GiB instead of 71.5 GiB (including the existing safety margin).

Track forward-retained compute bytes per token independently from peak workspace. Charge requested output bytes separately, keep maximum observations and the existing scale/sharing trust guards, and leave peak-only backward updates unable to inflate retained memory. Production changes are confined to `art.trainer_rank`; the public API is unchanged. The historical fraction remains available for calibration telemetry.

Validation at `e13e5eb18`: [Prek CI](https://github.com/OpenPipe/ART/actions/runs/34158863565) passed all lint/format/type/lock checks, 678 lightweight tests and 1,033 unit tests (14 skips). [GPU CI](https://github.com/OpenPipe/ART/actions/runs/34158863561) passed 56 tests (one four-device-only skip on the two-H200 job), followed by public CP2/TP2 checks with zero head/slot backward differences. New CPU regressions cover the admission example, either observation order, changing output sizes, maximum retention, and trust boundaries. GPU resources were cleaned up and independently verified absent.

Related to #848. This addresses a distinct warm-profile bookkeeping bug; it does not change cold estimates or the logical/packed sharing multiplier, and does not claim to resolve the original GPU symptoms. Fresh reproduction of those symptoms on merged main is separate. Kept in draft pending review; no merge requested automatically.
