### PR TITLE
Index checkpoint shard metadata lookups by key

### DIFF
--- a/src/art/trainer_rank/_checkpoint.py
+++ b/src/art/trainer_rank/_checkpoint.py
@@ -992,6 +992,19 @@ def _read_snapshot(
     return {key: payload[f"{prefix}/{key}"] for key in keys}
 
 
+def _matching_shards(
+    prepared: _PreparedSave, metadata: Sequence[LoraShardMeta]
+) -> dict[str, list[_LocalShard]]:
+    by_key: dict[str, list[LoraShardMeta]] = {}
+    for item in metadata:
+        by_key.setdefault(item.key, []).append(item)
+    matched: dict[str, list[_LocalShard]] = {}
+    for record in prepared.shards:
+        if record.metadata in by_key.get(record.metadata.key, ()):
+            matched.setdefault(record.metadata.key, []).append(record)
+    return matched
+
+
 def _merge_component(
     prepared: _PreparedSave,
     metadata: Sequence[LoraShardMeta],
@@ -1005,16 +1018,15 @@ def _merge_component(
     error: BaseException | None = None
     try:
         if owned:
-            files = {
-                record.file for record in prepared.shards if record.metadata in owned
-            }
+            shards = _matching_shards(prepared, owned)
+            files = {record.file for records in shards.values() for record in records}
             for relative in files:
                 keys = [
                     item.key
                     for item in owned
                     if next(
                         record.file
-                        for record in prepared.shards
+                        for record in shards.get(item.key, ())
                         if record.metadata == item
                     )
                     == relative
@@ -1174,8 +1186,8 @@ def _finish(trainer: TrainerRank, prepared: _PreparedSave) -> None:
             try:
                 for relative in {
                     record.file
-                    for record in prepared.shards
-                    if record.metadata in owned
+                    for records in _matching_shards(prepared, owned).values()
+                    for record in records
                 }:
                     load = importlib.import_module("safetensors.torch").load_file
                     payload = load(prepared.snapshot / relative)

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timedelta
 import gc
 from importlib.util import find_spec
@@ -40,6 +40,7 @@ from art.trainer_rank._checkpoint import (
     PreparedCheckpoint,
     _file_digest,
     _FinalizedSave,
+    _LocalShard,
     _manifest_digest,
     _merge_component,
     _PreparedSave,
@@ -1863,6 +1864,62 @@ def test_optimizer_shards_are_received_as_float32(
 
     assert received == [torch.float32]
     assert merged["weight"].dtype == torch.float32
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("owner_rank", 1),
+        ("shape", (3, 2)),
+        ("dtype_name", "float32"),
+        ("manifest", {"kind": "different"}),
+        ("block", "other"),
+    ],
+)
+def test_checkpoint_merge_rejects_same_key_with_different_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, field: str, value: object
+) -> None:
+    metadata = SimpleNamespace(
+        key="weight",
+        owner_rank=0,
+        shape=(2, 3),
+        dtype_name="bfloat16",
+        manifest={"kind": "replicated"},
+        block="block",
+    )
+    decoy = SimpleNamespace(**{**vars(metadata), field: value})
+    prepared = replace(
+        _prepared_save(tmp_path, 0),
+        shards=(
+            _LocalShard(cast(Any, decoy), "decoy"),
+            _LocalShard(cast(Any, metadata), "selected"),
+        ),
+    )
+    tensor = torch.ones(2, 3)
+
+    def read(_prepared, relative, component, keys):
+        assert (relative, component, list(keys)) == ("selected", "master", ["weight"])
+        return {"weight": tensor}
+
+    monkeypatch.setattr("art.trainer_rank._checkpoint._read_snapshot", read)
+    monkeypatch.setattr("art.trainer_rank._checkpoint._rank", lambda: 0)
+    monkeypatch.setattr(
+        "art.trainer_rank._checkpoint.raise_distributed", lambda *_: None
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "art.megatron.weights.lora_publish",
+        SimpleNamespace(
+            merge_sharded_adapter_entries=lambda entries: {
+                key: values[0][1] for key, values in entries.items()
+            },
+        ),
+    )
+    selected = SimpleNamespace(
+        **{**vars(metadata), "manifest": dict(metadata.manifest)}
+    )
+    merged = _merge_component(prepared, cast(Any, [selected]), "master", None)
+    torch.testing.assert_close(merged["weight"], tensor)
 
 
 def test_checkpoint_fifo_abort_and_failure_do_not_block_later_save(


### PR DESCRIPTION
Saving adapters across many experts repeatedly scans all shard metadata for each block, component, and tensor key. Index candidate shards by key while retaining full metadata equality, including ownership and layout. Tensor merging, serialization, and checkpoint formats are unchanged.

A live rank-1 050 save profile stopped in `_merge_component`'s metadata membership scan. A CPU benchmark with 30,720 records and 768 selected records produced identical file/key selections: median 0.571 seconds before and 0.00186 seconds after (three repetitions). This measures lookup work only, not total save time.

Validation: hosted quality checks pass. Independent review ran 198 selected tests with no skips in the installed Megatron runtime, including actual weights-only/optimizer codec round trips, custom tensors, and LoRA codec/publishing cases; 2,000 randomized old/new comparisons preserved selections and ordering. Both reviewers found no blockers. Ruff, full type checking with pinned ty 0.0.59, and lock consistency also pass.

The 2-H200 CI job failed during provisioning due to unavailable GPU capacity, before tests. Direct Kubernetes inspection confirmed no resources remained for workflow cluster `trainer-rank-gpu-34185408245-1`. This is not a passing GPU CI result or an end-to-end save-speed measurement. Merge requires the owner's decision.
