### PR TITLE
Expose TrainerRank.hidden_size for custom heads

### DIFF
--- a/src/art/trainer_rank/__init__.py
+++ b/src/art/trainer_rank/__init__.py
@@ -72,6 +72,11 @@ class TrainerRank(_impl.TrainerRank):
     def __init__(self, runtime: TrainingRuntime) -> None:
         super().__init__(runtime)
 
+    @property
+    def hidden_size(self) -> int:
+        """Width of the returned hidden states."""
+        return self._hidden_size
+
     def zero_grad(self) -> None:
         super().zero_grad()
 

--- a/tests/unit/test_trainer_rank_custom_tensors.py
+++ b/tests/unit/test_trainer_rank_custom_tensors.py
@@ -166,6 +166,14 @@ def _trainer(*names: str) -> tuple[TrainerRank, _CustomTensorAPI]:
     return trainer, cast(_CustomTensorAPI, trainer)
 
 
+def test_custom_head_uses_model_hidden_size_before_forward() -> None:
+    trainer, api = _trainer("student")
+    weight = api.parameter(
+        "head", lambda: torch.zeros(trainer.hidden_size), checkpoint="student"
+    )
+    assert weight.shape == (4,)
+
+
 def _distributed_custom_registration_worker(
     rank: int,
     world_size: int,


### PR DESCRIPTION
Custom-head initialization currently needs a forward result to determine hidden width. That can put collective parameter registration inside a loop over rank-local work, where unequal workloads can deadlock.

Expose the existing runtime width as read-only `TrainerRank.hidden_size` so every rank can register heads before its first forward. Add a regression that creates a correctly sized checkpoint head without running a forward pass.

Validation: 35 custom-tensor unit tests passed, including CPU/Gloo distributed cases; 9 GPU-only tests skipped. Ruff checks and formatting passed. Focused type checking completed without errors (existing distributed-stub/config warnings remain).
