### PR TITLE
Support filtered trajectory copies and safe empty-rank forwarding

### DIFF
--- a/src/art/trainer_rank/__init__.py
+++ b/src/art/trainer_rank/__init__.py
@@ -165,6 +165,7 @@ class TrainerRank(_impl.TrainerRank):
         *,
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
+        yield_empty: bool = False,
     ) -> Iterator[
         MicroBatch[
             ForwardInput[LogprobsT, TopKT, LogitsT, HiddenStatesT],
@@ -181,6 +182,7 @@ class TrainerRank(_impl.TrainerRank):
         *,
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
+        yield_empty: bool = False,
     ) -> Iterator[
         MicroBatch[
             Sequence[ForwardInput[LogprobsT, TopKT, LogitsT, HiddenStatesT]],
@@ -197,6 +199,7 @@ class TrainerRank(_impl.TrainerRank):
         *,
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
+        yield_empty: bool = False,
     ) -> Iterator[
         MicroBatch[
             Sequence[Sequence[ForwardInput[LogprobsT, TopKT, LogitsT, HiddenStatesT]]],
@@ -217,6 +220,7 @@ class TrainerRank(_impl.TrainerRank):
         *,
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
+        yield_empty: bool = False,
     ) -> Iterator[
         MicroBatch[
             Sequence[
@@ -238,6 +242,7 @@ class TrainerRank(_impl.TrainerRank):
         *,
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
+        yield_empty: bool = False,
     ) -> Iterator[MicroBatch[ForwardInputs, ForwardOutputs]]:
         """Forward replicated inputs in adaptive data-parallel microbatches.
 
@@ -247,12 +252,23 @@ class TrainerRank(_impl.TrainerRank):
         Input and target tensors may be on a different device from the trainer;
         ART moves its packed model inputs and labels internally without mutating
         the caller-owned `ForwardInput` objects.
+
+        Empty local microbatches are skipped unless `yield_empty=True`. Every
+        rank must use the same setting. When a wave skips ranks, TrainerRank
+        collective methods raise if called from its loop body; fully populated
+        waves permit them. Use `yield_empty=True` for per-wave collectives,
+        including reductions on ranks with no outputs. Exhaust or close a retained
+        iterator before making collective calls after an early exit. Guards apply
+        on the iterator's thread; raw torch.distributed calls are not guarded.
+        Collective calls must still match across ranks.
         """
         forward = cast(
             Callable[..., Iterator[MicroBatch[ForwardInputs, ForwardOutputs]]],
             super().forward_micro_batches,
         )
-        return forward(inputs, checkpoint=checkpoint, no_grad=no_grad)
+        return forward(
+            inputs, checkpoint=checkpoint, no_grad=no_grad, yield_empty=yield_empty
+        )
 
     @overload
     def dp_rank_forward(

--- a/src/art/trainer_rank/_checkpoint.py
+++ b/src/art/trainer_rank/_checkpoint.py
@@ -1641,6 +1641,7 @@ def snapshot_checkpoint(trainer: TrainerRank, source: str, destination: str) -> 
         _restore_slots(model_snapshot)
         trainer._checkpoint_slots.pop(destination, None)
         raise
+    trainer._snapshot_checkpoint_names.add(destination)
     return True
 
 
@@ -1976,6 +1977,7 @@ def snapshot_prepared_checkpoint(
             )
         return False
     load_checkpoint(trainer, source, destination, forward_only=True)
+    trainer._snapshot_checkpoint_names.add(destination)
     return True
 
 

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -1289,6 +1289,7 @@ class TrainerRank:
         self._default_slot_ref: LoRASlotRef | None = None
         self._slot_stack: list[LoRASlotRef] = []
         self._checkpoint_slots: dict[str, _CheckpointSlot] = {}
+        self._snapshot_checkpoint_names: set[str] = set()
         self._prepared_lora_exports: dict[str, tuple[str, _PreparedLoraExport]] = {}
         self._checkpoint_prefetches: dict[str, Future[PreparedCheckpoint]] = {}
         self._checkpoint_prefetch_sources: dict[str, str] = {}
@@ -1708,7 +1709,10 @@ class TrainerRank:
         group = _checkpoint._ensure_group(self)
         _checkpoint.raise_distributed(error, "prepare checkpoint", group)
         assert source is not None
-        _checkpoint.load_checkpoint(self, source, checkpoint)
+        if checkpoint in self._snapshot_checkpoint_names:
+            _checkpoint.load_checkpoint(self, source, checkpoint, forward_only=True)
+        else:
+            _checkpoint.load_checkpoint(self, source, checkpoint)
 
     def _ensure_checkpoint_slots(self, checkpoints: Iterable[str]) -> None:
         from . import _checkpoint

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -1677,7 +1677,6 @@ class TrainerRank:
             futures = [
                 self._checkpoint_prefetches[self._checkpoint_prefetch_sources[name]]
                 for name in checkpoints
-                if name not in self._checkpoint_slots
             ]
 
         async def wait() -> None:

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -6,6 +6,7 @@ import asyncio
 from collections import OrderedDict
 from collections.abc import (
     Callable,
+    Generator,
     Iterable,
     Iterator,
     Mapping,
@@ -1316,6 +1317,7 @@ class TrainerRank:
         self._hybridep_rows_high_water = 0
         self._memory_profiles: dict[_MemorySignature, _MemoryProfile] = {}
         self._last_global_micro_batch_size: int | None = None
+        self._skipped_forward_waves: dict[object, tuple[int, int, int]] = {}
         # Bounded LRU: steady-state hits are temporally local (identical
         # content on consecutive calls); fresh-token training steps must not
         # accumulate entries for the lifetime of the rank.
@@ -1391,6 +1393,7 @@ class TrainerRank:
         *,
         checkpoint: AdapterSelection,
     ) -> object:
+        self._guard_forward_collective(kind)
         from . import _checkpoint
 
         group = self._checkpoint_group()
@@ -1742,6 +1745,7 @@ class TrainerRank:
                 self._load_registered_checkpoint(name)
 
     def load_checkpoint(self, checkpoint: str | MaterializedCheckpoint | None) -> None:
+        self._guard_forward_collective("load_checkpoint")
         logical, source = self._checkpoint_source(checkpoint)
         with self._checkpoint_mutation_lock:
             if self._slot_stack:
@@ -1760,6 +1764,7 @@ class TrainerRank:
 
     def snapshot_checkpoint(self, source: str, destination: str) -> bool:
         """Clone a loaded checkpoint into a forward-only resident snapshot."""
+        self._guard_forward_collective("snapshot_checkpoint")
         from . import _checkpoint
 
         self._ensure_checkpoint_slots((source,))
@@ -1784,6 +1789,7 @@ class TrainerRank:
     def _push_checkpoint_sync(
         self, logical_path: str | None, source_path: str | None
     ) -> None:
+        self._guard_forward_collective("push_checkpoint")
         with self._checkpoint_mutation_lock:
             if source_path is not None:
                 assert logical_path is not None
@@ -1814,6 +1820,7 @@ class TrainerRank:
         output_dir: str,
         checkpoint_path: str | Literal["active"] = "active",
     ) -> None:
+        self._guard_forward_collective("prepare_checkpoint_save")
         from . import _checkpoint
 
         _checkpoint.prepare_checkpoint_save(
@@ -1821,11 +1828,13 @@ class TrainerRank:
         )
 
     def finish_checkpoint_save(self, output_dir: str) -> None:
+        self._guard_forward_collective("finish_checkpoint_save")
         from . import _checkpoint
 
         _checkpoint.finish_checkpoint_save(self, output_dir)
 
     def abort_checkpoint_save(self, output_dir: str) -> None:
+        self._guard_forward_collective("abort_checkpoint_save")
         from . import _checkpoint
 
         _checkpoint.abort_checkpoint_save(self, output_dir)
@@ -1835,6 +1844,7 @@ class TrainerRank:
         output_dir: str,
         checkpoint_path: str | Literal["active"] = "active",
     ) -> int:
+        self._guard_forward_collective("export_lora")
         from . import _lora_export
 
         return _lora_export.export_lora(
@@ -1995,6 +2005,7 @@ class TrainerRank:
         *,
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
+        yield_empty: bool = False,
     ) -> Iterator[
         MicroBatch[
             ForwardInput[LogprobsT, TopKT, LogitsT, HiddenStatesT],
@@ -2011,6 +2022,7 @@ class TrainerRank:
         *,
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
+        yield_empty: bool = False,
     ) -> Iterator[
         MicroBatch[
             Sequence[ForwardInput[LogprobsT, TopKT, LogitsT, HiddenStatesT]],
@@ -2027,6 +2039,7 @@ class TrainerRank:
         *,
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
+        yield_empty: bool = False,
     ) -> Iterator[
         MicroBatch[
             Sequence[Sequence[ForwardInput[LogprobsT, TopKT, LogitsT, HiddenStatesT]]],
@@ -2047,6 +2060,7 @@ class TrainerRank:
         *,
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
+        yield_empty: bool = False,
     ) -> Iterator[
         MicroBatch[
             Sequence[
@@ -2068,26 +2082,61 @@ class TrainerRank:
         *,
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
+        yield_empty: bool = False,
     ) -> Iterator[MicroBatch[ForwardInputs, ForwardOutputs]]:
+        if not isinstance(yield_empty, bool):
+            raise TypeError("yield_empty must be a bool")
         enabled = torch.is_grad_enabled() if no_grad is None else not no_grad
-        batches = self._forward_micro_batches(inputs, checkpoint=checkpoint)
-        while True:
-            with torch.set_grad_enabled(enabled):
+        batches = self._forward_micro_batches(
+            inputs, checkpoint=checkpoint, yield_empty=yield_empty
+        )
+        token = object()
+        try:
+            while True:
+                self._guard_forward_collective("forward_micro_batches")
+                with torch.set_grad_enabled(enabled):
+                    try:
+                        batch = next(batches)
+                    except StopIteration:
+                        return
+                if not yield_empty and not batch.outputs:
+                    continue
+                if (
+                    not yield_empty
+                    and batch.stats.global_count < self._dp_rank_and_size()[1]
+                ):
+                    self._skipped_forward_waves[token] = (
+                        threading.get_ident(),
+                        batch.stats.global_start,
+                        batch.stats.global_stop,
+                    )
                 try:
-                    batch = next(batches)
-                except StopIteration:
-                    return
-            yield batch
+                    yield batch
+                finally:
+                    self._skipped_forward_waves.pop(token, None)
+        finally:
+            batches.close()
+
+    def _guard_forward_collective(self, operation: str) -> None:
+        for thread, start, stop in tuple(self._skipped_forward_waves.values()):
+            if thread == threading.get_ident():
+                raise RuntimeError(
+                    f"{operation} cannot run during forward_micro_batches wave "
+                    f"[{start}, {stop}): yield_empty=False skips some data-parallel "
+                    "ranks. Move collective calls after the iterator or use "
+                    "yield_empty=True on every rank."
+                )
 
     def _forward_micro_batches(
         self,
         inputs: Iterable[ForwardInputs],
         *,
         checkpoint: AdapterSelection,
-    ) -> Iterator[MicroBatch[ForwardInputs, ForwardOutputs]]:
+        yield_empty: bool,
+    ) -> Generator[MicroBatch[ForwardInputs, ForwardOutputs], None, None]:
         items = [_materialize(item) for item in inputs]
         requests = list(_flatten(items))
-        self._validate_replicated_top_level_count(len(items))
+        self._validate_replicated_top_level_count(len(items), yield_empty=yield_empty)
         for _, indices in self._group_active_request_indices(
             requests, checkpoint=checkpoint
         ):
@@ -2225,6 +2274,7 @@ class TrainerRank:
         checkpoint: AdapterSelection = Unset,
         no_grad: bool | None = None,
     ) -> ForwardOutputs:
+        self._guard_forward_collective("dp_rank_forward")
         enabled = torch.is_grad_enabled() if no_grad is None else not no_grad
         with torch.set_grad_enabled(enabled):
             self._reset_planning_telemetry()
@@ -2622,6 +2672,7 @@ class TrainerRank:
         *,
         op: dist.ReduceOp.RedOpType = dist.ReduceOp.SUM,
     ) -> None:
+        self._guard_forward_collective("dp_reduce")
         from megatron.core import parallel_state as ps
 
         dist.all_reduce(
@@ -2638,6 +2689,7 @@ class TrainerRank:
         checkpoints: Sequence[str] | None = None,
         on_live_graphs: Literal["allow", "error"] = "allow",
     ) -> dict[str, float]:
+        self._guard_forward_collective("optim_step")
         if on_live_graphs not in ("allow", "error"):
             raise ValueError(
                 "on_live_graphs must be either 'allow' or 'error', got "
@@ -3692,17 +3744,22 @@ class TrainerRank:
 
         return candidate(best)
 
-    def _validate_replicated_top_level_count(self, count: int) -> None:
+    def _validate_replicated_top_level_count(
+        self, count: int, *, yield_empty: bool
+    ) -> None:
         if not (dist.is_available() and dist.is_initialized()):
             return
-        counts = [0 for _ in range(dist.get_world_size())]
-        dist.all_gather_object(counts, int(count))
-        if len(set(counts)) == 1:
+        configurations: list[tuple[int, bool] | None] = [
+            None for _ in range(dist.get_world_size())
+        ]
+        dist.all_gather_object(configurations, (int(count), yield_empty))
+        if len(set(configurations)) == 1:
             return
         raise ValueError(
-            "forward_micro_batches requires the same top-level input count on every "
+            "forward_micro_batches requires the same top-level input count and "
+            "yield_empty setting on every "
             "distributed rank. Pass already-DP-local inputs to dp_rank_forward instead. "
-            f"Observed counts by rank: {counts}."
+            f"Observed (count, yield_empty) by rank: {configurations}."
         )
 
     def _dp_rank_and_size(self) -> tuple[int, int]:

--- a/src/art/trajectories/__init__.py
+++ b/src/art/trajectories/__init__.py
@@ -20,11 +20,13 @@ from typing import (
     Generic,
     Literal,
     Protocol,
+    Self,
     TypeAlias,
     TypeVar,
     Union,
     cast,
     overload,
+    override,
 )
 
 from anthropic.types import (
@@ -298,6 +300,45 @@ class TrajectoryExchanges(pydantic.BaseModel):
     responses: list[ResponsesExchange] = pydantic.Field(default_factory=list)
     messages: list[MessagesExchange] = pydantic.Field(default_factory=list)
 
+    @override
+    def model_copy(
+        self,
+        *,
+        include_models: str | Iterable[str] | None = None,
+        exclude_models: str | Iterable[str] | None = None,
+        update: Mapping[str, Any] | None = None,
+        deep: bool = False,
+    ) -> Self:
+        """Copy with fresh protocol lists, including then excluding models.
+
+        Each selector matches an exact captured model first, otherwise a
+        case-sensitive shell pattern. ``None`` includes all/excludes none;
+        an empty iterable matches none. Shallow copies share exchange objects;
+        deep copies copy the retained graph. Explicit updates win, unvalidated
+        and used as supplied, without filtering or copying replacement values.
+        """
+        from ._selection import _matching_models
+
+        protocols = {
+            "chat_completions": self.chat_completions,
+            "completions": self.completions,
+            "responses": self.responses,
+            "messages": self.messages,
+        }
+        models = {item.model for items in protocols.values() for item in items}
+        selected = _matching_models(models, include_models)
+        if exclude_models is not None:
+            selected = selected - _matching_models(models, exclude_models)
+        filtered = super().model_copy(
+            update={
+                name: [item for item in items if item.model in selected]
+                if update is None or name not in update
+                else []
+                for name, items in protocols.items()
+            }
+        )
+        return super(TrajectoryExchanges, filtered).model_copy(update=update, deep=deep)
+
     def __bool__(self) -> bool:
         return any(
             (self.chat_completions, self.completions, self.responses, self.messages)
@@ -555,6 +596,32 @@ class Trajectory(_CompactModel):
         default_factory=lambda: datetime.now(UTC), exclude=True
     )
     _policy_token_counts: dict[int, int] | None = pydantic.PrivateAttr(default=None)
+
+    @override
+    def model_copy(
+        self,
+        *,
+        include_models: str | Iterable[str] | None = None,
+        exclude_models: str | Iterable[str] | None = None,
+        update: Mapping[str, Any] | None = None,
+        deep: bool = False,
+    ) -> Self:
+        """Copy, filtering exchanges with ``TrajectoryExchanges.model_copy``.
+
+        Exchanges follow ``deep`` by default; all other fields retain ordinary
+        Pydantic copy semantics. Explicit ``update`` values win unchanged: pass
+        an exchanges copy there to choose its copy depth independently.
+        """
+        filtered = super().model_copy(
+            update={
+                "exchanges": self.exchanges.model_copy(
+                    include_models=include_models, exclude_models=exclude_models
+                )
+                if update is None or "exchanges" not in update
+                else TrajectoryExchanges()
+            }
+        )
+        return super(Trajectory, filtered).model_copy(update=update, deep=deep)
 
     @pydantic.field_serializer("messages_and_choices", when_used="json")
     def serialize_messages_and_choices(self, value: MessagesAndChoices) -> list[Any]:

--- a/src/art/trajectories/_selection.py
+++ b/src/art/trajectories/_selection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
 import re
@@ -7,6 +8,24 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from . import Trajectory
+
+
+def _matching_models(
+    candidates: set[str | None], selectors: str | Iterable[str] | None
+) -> set[str | None]:
+    if selectors is None:
+        return candidates
+    return {
+        candidate
+        for selector in ((selectors,) if isinstance(selectors, str) else selectors)
+        for candidate in candidates
+        if candidate == selector
+        or (
+            selector not in candidates
+            and candidate is not None
+            and fnmatchcase(candidate, selector)
+        )
+    }
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/acceptance/trainer_rank_planner/test_public_contract.py
+++ b/tests/acceptance/trainer_rank_planner/test_public_contract.py
@@ -7,12 +7,12 @@ contract (research thread behavior spec, frozen 2026-08-31):
   head-chunk, or memory-safety policy knob. Its constructor accepts only the
   training runtime.
 - ``forward_micro_batches`` and ``dp_rank_forward`` accept only
-  ``inputs``, ``checkpoint``, and ``no_grad``.
+  ``inputs``, ``checkpoint``, and ``no_grad``, plus ``yield_empty`` on the iterator.
 - ``TrainerRankMemoryError`` reports only a predicted peak, the usable limit,
   and an actionable reduction suggestion. It carries no infeasibility proof.
 
-These tests define the landing contract: written and fail-verified before
-the implementation, they must pass unmodified on the landed tree.
+These tests preserve the landing's planner-policy constraints while checking
+subsequent public API additions.
 """
 
 from __future__ import annotations
@@ -83,6 +83,9 @@ def test_forward_method_signatures_are_knob_free(method_name: str) -> None:
     method = getattr(trainer_rank.TrainerRank, method_name)
     parameters = _parameters(method)
     allowed = {"inputs", "checkpoint", "no_grad"}
+    if method_name == "forward_micro_batches":
+        allowed.add("yield_empty")
+        assert parameters["yield_empty"].default is False
     assert set(parameters) <= allowed, (
         f"{method_name} accepts unexpected parameters:"
         f" {sorted(set(parameters) - allowed)}"

--- a/tests/integration/megatron/lora/test_dynamic_lora_slots.py
+++ b/tests/integration/megatron/lora/test_dynamic_lora_slots.py
@@ -603,6 +603,8 @@ def _trainer_for(lora: LoRA, device: torch.device) -> TrainerRank:
     trainer.device = device
     trainer._slot_stack = []
     trainer._default_slot_ref = None
+    trainer._skipped_forward_waves = {}
+    trainer._snapshot_checkpoint_names = set()
     trainer._checkpoint_slots = {
         name: _CheckpointSlot(
             tuple(lora.lora_slot_params(LoRASlotRef("checkpoint", name)))

--- a/tests/integration/megatron/lora/test_lora_disk_codecs.py
+++ b/tests/integration/megatron/lora/test_lora_disk_codecs.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import threading
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -1603,6 +1604,11 @@ def test_trainer_rank_publishes_named_checkpoint_slot_without_mutating_base(
     trainer._slot_stack = []
     trainer._pending_slot_graphs = {}
     trainer._checkpoint_slots = {}
+    trainer._skipped_forward_waves = {}
+    trainer._snapshot_checkpoint_names = set()
+    trainer._checkpoint_prefetch_sources = {}
+    trainer._checkpoint_prefetch_lock = threading.Lock()
+    trainer._checkpoint_mutation_lock = threading.RLock()
     config = _config("Qwen/Qwen3-8B", rank=2, alpha=2)
     assert trainer._load_checkpoint_slot("student", adapter, alpha=2) == 1
     trainer._checkpoint_slots["student"] = _CheckpointSlot(
@@ -1639,6 +1645,11 @@ def test_prepared_lora_export_is_immutable_and_abortable(tmp_path: Path):
     trainer._slot_stack = []
     trainer._pending_slot_graphs = {}
     trainer._checkpoint_slots = {}
+    trainer._skipped_forward_waves = {}
+    trainer._snapshot_checkpoint_names = set()
+    trainer._checkpoint_prefetch_sources = {}
+    trainer._checkpoint_prefetch_lock = threading.Lock()
+    trainer._checkpoint_mutation_lock = threading.RLock()
     config = _config("Qwen/Qwen3-8B", rank=2, alpha=2)
     assert trainer._load_checkpoint_slot("student", adapter, alpha=2) == 1
     trainer._checkpoint_slots["student"] = _CheckpointSlot(

--- a/tests/unit/test_trainer_rank_custom_tensors.py
+++ b/tests/unit/test_trainer_rank_custom_tensors.py
@@ -1008,6 +1008,61 @@ def test_loaded_custom_payload_is_owned_after_source_removal(
 
 
 @pytest.mark.skipif(find_spec("megatron") is None, reason="requires Megatron")
+@pytest.mark.parametrize("prepared", [False, True])
+@pytest.mark.parametrize("register_before_eviction", [False, True])
+def test_evicted_snapshot_reloads_frozen_without_changing_training_loads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    prepared: bool,
+    register_before_eviction: bool,
+) -> None:
+    from art.trainer_rank import _checkpoint
+
+    trainer, api = _real_lora_trainer()
+    head, temperature, _buffer = _register_custom_tensors(api)
+    _step_custom_tensors(trainer, head, temperature, monkeypatch)
+    saved = tmp_path / "saved"
+    trainer.save_checkpoint(str(saved), "student")
+    snapshot = "student:step0"
+    if prepared:
+        _checkpoint.snapshot_prepared_checkpoint(
+            trainer, prepare_checkpoint(str(saved)), snapshot
+        )
+    else:
+        trainer.snapshot_checkpoint("student", snapshot)
+    if register_before_eviction:
+        trainer._register_checkpoint_prefetch(snapshot, str(saved)).result()
+    trainer._discard_snapshot_checkpoint(snapshot)
+    if not register_before_eviction:
+        trainer._register_checkpoint_prefetch(snapshot, str(saved)).result()
+    trainer._ensure_checkpoint_slots((snapshot,))
+
+    slot = trainer._checkpoint_slots[snapshot]
+    assert slot.snapshot
+    assert slot.params and all(not parameter.requires_grad for parameter in slot.params)
+    assert slot.optimizer is None
+    frozen = api.parameter(
+        "temperature", lambda: torch.tensor(0.5), checkpoint=snapshot
+    )
+    torch.testing.assert_close(frozen, temperature)
+    assert not frozen.requires_grad
+    with pytest.raises(TrainerRankSlotStateError, match="forward-only"):
+        trainer.optim_step(
+            params=AdamParams(learning_rate=1e-3), checkpoints=[snapshot]
+        )
+
+    for name in ("ordinary", "another:step0"):
+        trainer.load_checkpoint(MaterializedCheckpoint(name, str(saved)))
+        loaded = trainer._checkpoint_slots[name]
+        assert not loaded.snapshot
+        assert all(parameter.requires_grad for parameter in loaded.params)
+        assert loaded.optimizer is not None
+        assert api.parameter(
+            "temperature", lambda: torch.tensor(0.5), checkpoint=name
+        ).requires_grad
+
+
+@pytest.mark.skipif(find_spec("megatron") is None, reason="requires Megatron")
 def test_prepared_forward_snapshot_restores_frozen_custom_tensors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -952,19 +952,22 @@ async def test_shared_checkpoint_prefetch_survives_waiter_cancellation() -> None
 
     def prepare() -> PreparedCheckpoint:
         started.set()
-        release.wait()
+        assert release.wait(5)
         return source
 
-    future = trainer._register_checkpoint_prefetch("student", "student", prepare)
-    first = asyncio.create_task(trainer._await_checkpoint_prefetch(future))
-    second = asyncio.create_task(trainer._await_checkpoint_prefetch(future))
+    trainer._checkpoint_slots["student"] = _CheckpointSlot(snapshot=True)
+    trainer._register_checkpoint_prefetch("student", "student", prepare)
+    first = trainer._checkpoint_prefetch_waiter("student")
+    second = trainer._checkpoint_prefetch_waiter("student")
     await asyncio.to_thread(started.wait)
     first.cancel()
     with pytest.raises(asyncio.CancelledError):
         await first
     release.set()
 
-    assert await second is source
+    assert await second is None
+    trainer._checkpoint_slots.pop("student")
+    assert trainer._prefetched_checkpoint("student") is source
     [cached] = trainer._checkpoint_prefetches.values()
     assert cached.result() is source
 

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -3430,7 +3430,7 @@ def _forward_yield_modes_worker(rank: int, world_size: int, init_method: str) ->
                 from megatron.core import parallel_state
             except ImportError:
                 core = ModuleType("megatron.core")
-                parallel_state = SimpleNamespace()
+                parallel_state = cast(Any, SimpleNamespace())
                 cast(Any, core).parallel_state = parallel_state
                 monkeypatch.setitem(sys.modules, "megatron.core", core)
             monkeypatch.setattr(

--- a/tests/unit/test_trainer_rank_validation.py
+++ b/tests/unit/test_trainer_rank_validation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from datetime import timedelta
 import gc
@@ -13,7 +14,7 @@ import sys
 import threading
 import time
 from types import ModuleType, SimpleNamespace
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Never, cast
 
 import pytest
 import torch
@@ -3289,18 +3290,237 @@ def test_dp_rank_forward_supports_arbitrary_nested_depth(
     assert _output_values(outputs) == [0, 1, 2]
 
 
+@pytest.mark.parametrize("yield_empty", [False, True])
 def test_forward_micro_batches_uses_deterministic_dp_windows(
     monkeypatch: pytest.MonkeyPatch,
+    yield_empty: bool,
 ) -> None:
     trainer = TrainerRank(_runtime())
     _stub_forward(monkeypatch, trainer, dp=(1, 2))
 
     batches = list(
-        trainer.forward_micro_batches([_target_request(i) for i in range(5)])
+        trainer.forward_micro_batches(
+            [_target_request(i) for i in range(5)], yield_empty=yield_empty
+        )
     )
 
-    assert [batch.indices for batch in batches] == [(1,), (3,), ()]
-    assert [len(batch.outputs) for batch in batches] == [1, 1, 0]
+    assert [batch.indices for batch in batches] == [(1,), (3,)] + (
+        [()] if yield_empty else []
+    )
+    assert [len(batch.outputs) for batch in batches] == [1, 1] + (
+        [0] if yield_empty else []
+    )
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "dp_reduce",
+        "optim_step",
+        "parameter",
+        "module",
+        "buffer",
+        "load_checkpoint",
+        "snapshot_checkpoint",
+        "push_checkpoint",
+        "save_checkpoint",
+        "prepare_checkpoint_save",
+        "finish_checkpoint_save",
+        "abort_checkpoint_save",
+        "export_lora",
+        "dp_rank_forward",
+        "forward_micro_batches",
+    ],
+)
+def test_skipped_forward_wave_rejects_collectives_before_backend(
+    monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    trainer = TrainerRank(_runtime())
+    _stub_forward(monkeypatch, trainer, dp=(0, 2))
+    batches = trainer.forward_micro_batches([_target_request(1)])
+    next(batches)
+    assert trainer._skipped_forward_waves
+
+    def unexpected(*_args: object, **_kwargs: object) -> Never:
+        pytest.fail("partial-wave guard must run before backend work")
+
+    monkeypatch.setattr(dist, "all_reduce", unexpected)
+    monkeypatch.setattr(trainer, "_checkpoint_group", unexpected)
+    calls = {
+        "dp_reduce": lambda: trainer.dp_reduce(torch.tensor(1)),
+        "optim_step": lambda: trainer.optim_step(params=AdamParams(learning_rate=1e-3)),
+        "parameter": lambda: trainer.parameter("p", unexpected),
+        "module": lambda: trainer.module("m", unexpected),
+        "buffer": lambda: trainer.buffer("b", unexpected),
+        "load_checkpoint": lambda: trainer.load_checkpoint("missing"),
+        "snapshot_checkpoint": lambda: trainer.snapshot_checkpoint("a", "b"),
+        "push_checkpoint": lambda: trainer.push_checkpoint("missing").__enter__(),
+        "save_checkpoint": lambda: trainer.save_checkpoint("/unused"),
+        "prepare_checkpoint_save": lambda: trainer.prepare_checkpoint_save("/unused"),
+        "finish_checkpoint_save": lambda: trainer.finish_checkpoint_save("/unused"),
+        "abort_checkpoint_save": lambda: trainer.abort_checkpoint_save("/unused"),
+        "export_lora": lambda: trainer.export_lora("/unused"),
+        "dp_rank_forward": lambda: trainer.dp_rank_forward([_target_request(1)]),
+        "forward_micro_batches": lambda: next(
+            trainer.forward_micro_batches([_target_request(1)], yield_empty=True)
+        ),
+    }
+    with pytest.raises(RuntimeError, match="yield_empty=False skips"):
+        calls[operation]()
+    cast(Any, batches).close()
+    assert not trainer._skipped_forward_waves
+
+
+@pytest.mark.parametrize("finish", ["exhaust", "close", "throw"])
+def test_skipped_forward_wave_cleans_up_retained_iterator(
+    monkeypatch: pytest.MonkeyPatch, finish: str
+) -> None:
+    trainer = TrainerRank(_runtime())
+    _stub_forward(monkeypatch, trainer, dp=(0, 2))
+    batches = trainer.forward_micro_batches([_target_request(1)], no_grad=True)
+    for _batch in batches:
+        break
+    assert torch.is_grad_enabled()
+    with pytest.raises(RuntimeError, match="yield_empty=False"):
+        trainer._guard_forward_collective("test")
+    # An independent actor thread may finish an all-rank checkpoint save while
+    # this callback is paused in its loop body.
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(trainer._guard_forward_collective, "test").result()
+    if finish == "exhaust":
+        assert list(batches) == []
+    elif finish == "close":
+        cast(Any, batches).close()
+    else:
+        with pytest.raises(LookupError, match="injected"):
+            cast(Any, batches).throw(LookupError("injected"))
+    assert not trainer._skipped_forward_waves
+    assert torch.is_grad_enabled()
+    trainer._guard_forward_collective("test")
+
+
+def test_skipped_forward_wave_cannot_resume_another_iterator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trainer = TrainerRank(_runtime())
+    _stub_forward(monkeypatch, trainer, dp=(0, 2))
+    outer = trainer.forward_micro_batches([_target_request(i) for i in range(4)])
+    next(outer)  # Every rank participates in this wave, so nesting is allowed.
+    inner = trainer.forward_micro_batches([_target_request(1)])
+    next(inner)
+    with pytest.raises(RuntimeError, match="yield_empty=False skips"):
+        next(outer)
+    with pytest.raises(RuntimeError, match="yield_empty=False skips"):
+        trainer._guard_forward_collective("test")
+    cast(Any, inner).close()
+    trainer._guard_forward_collective("test")
+
+
+def _forward_yield_modes_worker(rank: int, world_size: int, init_method: str) -> None:
+    dist.init_process_group(
+        "gloo",
+        rank=rank,
+        world_size=world_size,
+        init_method=init_method,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            try:
+                from megatron.core import parallel_state
+            except ImportError:
+                core = ModuleType("megatron.core")
+                parallel_state = SimpleNamespace()
+                cast(Any, core).parallel_state = parallel_state
+                monkeypatch.setitem(sys.modules, "megatron.core", core)
+            monkeypatch.setattr(
+                parallel_state,
+                "get_data_parallel_group",
+                lambda **_: dist.group.WORLD,
+                raising=False,
+            )
+            for count in (0, 1, world_size - 1, world_size, 2 * world_size + 1):
+                for mode in (None, False, True):
+                    trainer = TrainerRank(_runtime())
+                    parameter = torch.nn.Parameter(torch.tensor(2.0))
+
+                    def execute(plan, **_kwargs):
+                        return [
+                            ForwardOutput(
+                                parameter * item.input_ids.float(), None, None, None
+                            )
+                            for group in plan.groups
+                            for item in group.items
+                        ]
+
+                    # Only the model execution and Megatron topology are mocked;
+                    # ART's iterator, wave planning, and Gloo collectives are real.
+                    _stub_forward(monkeypatch, trainer, execute, dp=(rank, world_size))
+                    monkeypatch.setattr(trainer, "_topology_key", lambda: (1, 1, 1, 1))
+                    monkeypatch.setattr(trainer, "_forward_memory_group", lambda: None)
+                    requests = [_target_request(i) for i in range(count)]
+                    batches = (
+                        trainer.forward_micro_batches(requests)
+                        if mode is None
+                        else trainer.forward_micro_batches(requests, yield_empty=mode)
+                    )
+                    local_indices: list[int] = []
+                    total_loss = torch.tensor(0.0)
+                    for batch in batches:
+                        local_indices.extend(batch.indices)
+                        participation = torch.tensor(len(batch.outputs))
+                        if mode is True or batch.stats.global_count >= world_size:
+                            trainer.dp_reduce(participation)
+                            assert participation.item() == batch.stats.global_count
+                        else:
+                            with pytest.raises(RuntimeError, match="skips"):
+                                trainer.dp_reduce(participation)
+                        loss = torch.tensor(0.0)
+                        for output in batch.outputs:
+                            loss = loss + output.target_logprobs.sum()
+                        # The old mode needs a guard; the default supports the
+                        # original experiment's unconditional backward directly.
+                        if mode is not True or batch.outputs:
+                            loss.backward()
+                        total_loss += loss.detach()
+                    assert local_indices == list(range(rank, count, world_size))
+                    assert not trainer._skipped_forward_waves
+                    gradient = (
+                        torch.zeros_like(parameter)
+                        if parameter.grad is None
+                        else parameter.grad
+                    )
+                    trainer.dp_reduce(gradient)
+                    trainer.dp_reduce(total_loss)
+                    assert gradient.item() == count**2
+                    assert total_loss.item() == 2 * count**2
+
+            with pytest.raises(ValueError, match="yield_empty setting"):
+                list(trainer.forward_micro_batches(requests, yield_empty=rank == 0))
+            completed = torch.tensor(1)
+            trainer.dp_reduce(completed)
+            assert completed.item() == world_size
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_forward_micro_batches_yield_modes_collectively(
+    tmp_path: Path, world_size: int
+) -> None:
+    context = mp.spawn(
+        _forward_yield_modes_worker,
+        args=(world_size, f"file://{tmp_path / 'forward-yields'}"),
+        nprocs=world_size,
+        join=False,
+    )
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        if context.join(timeout=1):
+            return
+    for process in context.processes:
+        process.terminate()
+    pytest.fail("forward yield modes test hung")
 
 
 def test_forward_micro_batches_syncs_fit_decision_across_dp(
@@ -3495,7 +3715,7 @@ def test_forward_micro_batches_rejects_mismatched_replicated_counts(
     monkeypatch.setattr(trainer_rank.dist, "all_reduce", lambda *_args, **_kwargs: None)
 
     def gather(output, value):
-        output[:] = [value, value + 1]
+        output[:] = [value, (value[0] + 1, value[1])]
 
     monkeypatch.setattr(trainer_rank.dist, "all_gather_object", gather)
 

--- a/tests/unit/test_trajectory_copy.py
+++ b/tests/unit/test_trajectory_copy.py
@@ -1,12 +1,25 @@
-"""Tests for TrajectoryGroup copy and deepcopy functionality."""
+"""Tests for trajectory and group copy semantics."""
 
 import copy
+from datetime import UTC, datetime
 
-from openai.types.chat import ChatCompletionMessage
+from anthropic.types import Message
+from openai.types import Completion
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
+from openai.types.responses import Response
 import pytest
 
-from art.trajectories import PydanticException, Trajectory, TrajectoryGroup
+from art.trajectories import (
+    ChatCompletionsExchange,
+    CompletionsExchange,
+    MessagesExchange,
+    PydanticException,
+    ResponsesExchange,
+    Trajectory,
+    TrajectoryExchanges,
+    TrajectoryGroup,
+)
 
 
 @pytest.fixture
@@ -191,3 +204,137 @@ def test_copy_empty_group():
     deep = copy.deepcopy(empty_group)
     assert deep is not empty_group
     assert len(deep.trajectories) == 0
+
+
+@pytest.fixture
+def captured_trajectory():
+    class TaggedExchanges(TrajectoryExchanges):
+        tag: str = "exchanges"
+
+    class TaggedTrajectory(Trajectory):
+        tag: str = "trajectory"
+
+    protocols = {}
+    for name, exchange_type, response_type in (
+        ("chat_completions", ChatCompletionsExchange, ChatCompletion),
+        ("completions", CompletionsExchange, Completion),
+        ("responses", ResponsesExchange, Response),
+        ("messages", MessagesExchange, Message),
+    ):
+        protocols[name] = [
+            exchange_type.model_construct(
+                request={"model": model} if model not in ("world", None) else {},
+                response=response_type.model_construct(
+                    model=model if model in ("world", None) else "served"
+                ),
+                start_time=datetime.now(UTC),
+                end_time=datetime.now(UTC),
+            )
+            for model in ("policy@1", "policy@2", "policy@*", "Policy@3", "world", None)
+        ]
+    trajectory = TaggedTrajectory(exchanges=TaggedExchanges.model_validate(protocols))
+    trajectory.metadata["exchange"] = trajectory.exchanges.chat_completions[0]
+    trajectory._policy_token_counts = {1: 3}
+    return trajectory
+
+
+@pytest.mark.parametrize("owner", ["trajectory", "exchanges"])
+@pytest.mark.parametrize(
+    "include,exclude,indices",
+    [
+        (None, None, range(6)),
+        ("policy@*", None, [2]),
+        ("policy@?", "policy@2", [0, 2]),
+        (["policy@1", "world"], None, [0, 4]),
+        ("*", "policy@*", [0, 1, 3, 4]),
+        (None, ["world", "Policy@*"], [0, 1, 2, 5]),
+        ([], None, []),
+        (None, [], range(6)),
+        (None, "*", [5]),
+        ("missing", None, []),
+        (None, "served", range(6)),
+    ],
+)
+def test_model_copy_filters(captured_trajectory, owner, include, exclude, indices):
+    original = captured_trajectory
+    source = original if owner == "trajectory" else original.exchanges
+    copied = source.model_copy(
+        include_models=iter(include) if isinstance(include, list) else include,
+        exclude_models=iter(exclude) if isinstance(exclude, list) else exclude,
+    )
+    assert type(copied) is type(source)
+    exchanges = copied.exchanges if owner == "trajectory" else copied
+    assert type(exchanges) is type(original.exchanges)
+    for name in TrajectoryExchanges.model_fields:
+        before, after = getattr(original.exchanges, name), getattr(exchanges, name)
+        assert after is not before
+        assert [id(item) for item in after] == [id(before[index]) for index in indices]
+        after.clear()
+        assert len(before) == 6
+
+
+@pytest.mark.parametrize("deep", [False, True])
+def test_model_copy_depth_and_aliases(captured_trajectory, deep):
+    copied = captured_trajectory.model_copy(include_models="policy@1", deep=deep)
+    original_exchange = captured_trajectory.exchanges.chat_completions[0]
+    copied_exchange = copied.exchanges.chat_completions[0]
+    assert copied.metadata["exchange"] is copied_exchange
+    assert (copied_exchange is original_exchange) is not deep
+    assert (copied_exchange.request is original_exchange.request) is not deep
+    assert (copied.metadata is captured_trajectory.metadata) is not deep
+    assert (copied.metrics is captured_trajectory.metrics) is not deep
+    assert (
+        copied._policy_token_counts is captured_trajectory._policy_token_counts
+    ) is not deep
+
+
+@pytest.mark.parametrize("deep", [False, True])
+@pytest.mark.parametrize("exchange_deep", [False, True])
+def test_model_copy_explicit_exchanges(captured_trajectory, deep, exchange_deep):
+    exchanges = captured_trajectory.exchanges.model_copy(deep=exchange_deep)
+    copied = captured_trajectory.model_copy(
+        exclude_models="*", update={"exchanges": exchanges}, deep=deep
+    )
+    assert copied.exchanges is exchanges
+    assert (copied.metrics is captured_trajectory.metrics) is not deep
+    for name in TrajectoryExchanges.model_fields:
+        before, after = (
+            getattr(captured_trajectory.exchanges, name),
+            getattr(exchanges, name),
+        )
+        assert after is not before
+        assert (after[0] is before[0]) is not exchange_deep
+
+
+@pytest.mark.parametrize("deep", [False, True])
+def test_model_copy_updates_are_unvalidated(captured_trajectory, deep):
+    replacement = object()
+    update = {"exchanges": replacement, "reward": replacement}
+    copied = captured_trajectory.model_copy(update=update, deep=deep)
+    assert copied.exchanges is copied.reward is replacement
+    assert update == {"exchanges": replacement, "reward": replacement}
+    exchanges = captured_trajectory.exchanges.model_copy(
+        include_models=[], update={"messages": replacement}, deep=deep
+    )
+    assert exchanges.messages is replacement
+    assert not exchanges.chat_completions
+
+
+def test_model_copy_filters_before_deepcopy(captured_trajectory):
+    class Uncopyable:
+        def __deepcopy__(self, memo):
+            raise AssertionError("Excluded exchange was copied")
+
+    for name in TrajectoryExchanges.model_fields:
+        getattr(captured_trajectory.exchanges, name)[-1].request["extra"] = Uncopyable()
+    for source in (captured_trajectory, captured_trajectory.exchanges):
+        source.model_copy(include_models="policy@1", deep=True)
+
+
+@pytest.mark.parametrize("deep", [False, True])
+def test_model_copy_filters_leave_legacy_history(sample_trajectory, deep):
+    copied = sample_trajectory.model_copy(include_models=[], deep=deep)
+    assert copied.messages_and_choices == sample_trajectory.messages_and_choices
+    assert (
+        copied.messages_and_choices is sample_trajectory.messages_and_choices
+    ) is not deep


### PR DESCRIPTION
Uneven data-parallel batches can give a rank an empty microbatch, making an otherwise ordinary loss/backward loop fail. `TrainerRank.forward_micro_batches(..., yield_empty=False)` now skips locally empty yields by default while every rank still participates in internal planning and forward operations. `yield_empty=True` retains the previous behavior. Public collective operations reject calls from waves that skip ranks; fully participating waves allow them. Guards handle nested and retained iterators, with documented thread scope and cleanup requirements.

Add `include_models` and `exclude_models` to `Trajectory.model_copy()` and `TrajectoryExchanges.model_copy()` so callers can copy the dynamics exchanges directly. Selectors prefer exact captured model names, then case-sensitive shell patterns. Copies get fresh exchange lists; `deep` controls retained object copying, and explicit `update` values preserve Pydantic's existing semantics. Legacy message history remains unchanged by model filtering.

Checkpoint prefetch now waits for backing-source preparation even when a snapshot is already resident. This prevents callers from cleaning the materialization pin while preparation is pending and keeps the source usable when a later save evicts that snapshot. The resident-snapshot, delayed-preparation, cancellation, and eviction regression passes; all 17 targeted prefetch tests pass.

Snapshot names now retain their forward-only identity across resident eviction and registered reload. Only names created through snapshot helpers are marked; ordinary logical or exact-name training loads remain mutable. This prevents Caladan’s default grouped save from including an old validation snapshot as a second member of the same collection. The correction adds six net production lines; 32 targeted tests pass, including actual LoRA/custom-state reloads for both snapshot origins and either prefetch-registration order.

Final CI passed: 714 lightweight tests and 1,069 unit tests (21 skipped), plus 61 GPU tests (one skipped) and CP2/TP2 public-API validation on two H200s. Integration fixtures initialize the same private guard/snapshot state and locks as production constructors. Ruff, formatting, type checks, and lock validation pass; both independent reviewers cleared the final head.

Caladan’s [targeted H200 qualification](https://github.com/OpenPipe/caladan/pull/239#issuecomment-5591939032) additionally confirms both snapshot origins reload frozen, ordinary exact-name training loads remain mutable, and default grouped selection excludes saved snapshots. All owned validation pods and services were cleaned up. The squash-merge tree is identical to the reviewed, CI-tested head.
