### PR TITLE
Export Gemma 4 MoE LoRA as per-expert projections

### DIFF
--- a/src/art/megatron/distributed_service.py
+++ b/src/art/megatron/distributed_service.py
@@ -376,7 +376,8 @@ class DistributedMegatronService:
     @property
     def _temporal_gpu_sharing(self) -> bool:
         return (
-            get_external_vllm_runtime_config(self.config) is None
+            bool(self.runtime.topology.model_services)
+            and get_external_vllm_runtime_config(self.config) is None
             and self._model_service_spec().temporal_gpu_sharing
         )
 

--- a/src/art/megatron/model_support/handlers/gemma4.py
+++ b/src/art/megatron/model_support/handlers/gemma4.py
@@ -1801,11 +1801,75 @@ def _add_gemma4_k_eq_v_v_lora_tensors(
 
 def _vllm_moe_config(adapter_config: dict[str, Any]) -> dict[str, Any]:
     config = dict(adapter_config)
-    target_modules = list(config.get("target_modules") or [])
-    if "experts" not in target_modules:
-        target_modules.append("experts")
+    target_modules = [
+        name for name in config.get("target_modules") or [] if name != "experts"
+    ]
+    for name in ("gate_proj", "up_proj", "down_proj"):
+        if name not in target_modules:
+            target_modules.append(name)
     config["target_modules"] = target_modules
+    config["target_parameters"] = None
     return config
+
+
+def _export_per_expert_lora_tensors(
+    tensors: dict[str, torch.Tensor],
+    *,
+    adapter_config: dict[str, Any],
+) -> tuple[dict[str, torch.Tensor], dict[str, Any]]:
+    """Separate the expert and rank axes for vLLM's default MoE LoRA loader.
+
+    The packed publisher keeps gate/up fused during training and transport. On
+    disk, each expert uses ordinary gate/up/down projection keys and 2D factors.
+    B's packed columns are rank-major, so splitting consecutive columns would
+    silently mix experts for ranks greater than one.
+    """
+    grouped: dict[str, dict[str, torch.Tensor]] = {}
+    transformed: dict[str, torch.Tensor] = {}
+    for key, tensor in tensors.items():
+        match = _VLLM_MOE_KEY_RE.match(key)
+        if match is None:
+            transformed[key] = tensor
+            continue
+        slot = (
+            f"{'base_layer.' if match.group('base_layer') else ''}{match.group('lora')}"
+        )
+        grouped.setdefault(match.group("prefix"), {})[slot] = tensor
+    rank = int(adapter_config["r"])
+    for prefix, slots in grouped.items():
+        try:
+            gate_up_a = slots["base_layer.lora_A"]
+            gate_up_b = slots["base_layer.lora_B"]
+            down_a = slots["lora_A"]
+            down_b = slots["lora_B"]
+        except KeyError as exc:
+            raise RuntimeError(
+                f"Incomplete Gemma 4 MoE LoRA block for {prefix}"
+            ) from exc
+        if rank <= 0 or gate_up_a.shape[0] % rank:
+            raise RuntimeError(f"{prefix}: invalid packed LoRA rank {rank}")
+        num_experts = gate_up_a.shape[0] // rank
+        gate_up_b = _unpack_vllm_3d_lora_b(
+            gate_up_b, num_experts=num_experts, rank=rank
+        )
+        down_b = _unpack_vllm_3d_lora_b(down_b, num_experts=num_experts, rank=rank)
+        for expert in range(num_experts):
+            rows = slice(expert * rank, (expert + 1) * rank)
+            gate_b, up_b = gate_up_b[expert].chunk(2, dim=0)
+            factors = {
+                "gate_proj": (gate_up_a[rows], gate_b),
+                "up_proj": (gate_up_a[rows], up_b),
+                "down_proj": (down_a[rows], down_b[expert]),
+            }
+            for module, (a, b) in factors.items():
+                for name, tensor in (("A", a), ("B", b)):
+                    key = f"{prefix}.{expert}.{module}.lora_{name}.weight"
+                    if key in transformed:
+                        raise RuntimeError(f"Duplicate Gemma 4 LoRA tensor: {key}")
+                    transformed[key] = _clone(tensor)
+    if grouped or any(_VLLM_MOE_EXPERT_KEY_RE.match(k) for k in tensors):
+        adapter_config = _vllm_moe_config(adapter_config)
+    return transformed, adapter_config
 
 
 def _canonicalize_gemma4_peft_moe_target_parameter_layout(
@@ -1917,10 +1981,8 @@ def _to_vllm_lora_tensors(
             transformed,
             adapter_config=adapter_config,
         )
-        has_fused_experts = any(_VLLM_MOE_KEY_RE.match(key) for key in transformed)
-        return (
-            transformed,
-            _vllm_moe_config(adapter_config) if has_fused_experts else adapter_config,
+        return _export_per_expert_lora_tensors(
+            transformed, adapter_config=adapter_config
         )
 
     transformed: dict[str, torch.Tensor] = {}
@@ -1998,7 +2060,7 @@ def _to_vllm_lora_tensors(
         transformed,
         adapter_config=adapter_config,
     )
-    return transformed, _vllm_moe_config(adapter_config)
+    return _export_per_expert_lora_tensors(transformed, adapter_config=adapter_config)
 
 
 def _from_vllm_lora_tensors(

--- a/src/art/megatron/model_support/handlers/gemma4.py
+++ b/src/art/megatron/model_support/handlers/gemma4.py
@@ -625,6 +625,10 @@ class Gemma4MoeHandler(_Gemma4TokenizerMixin, DefaultMoeHandler):
         )
 
         target_set = set(target_modules)
+        # Per-expert checkpoints name the three projections independently;
+        # Megatron trains the routed experts through its fused LoRA wrapper.
+        if {"gate_proj", "up_proj", "down_proj"} <= target_set:
+            target_set.add("experts")
         for chunk in model_chunks:
             for module_name, module in chunk.named_modules():
                 if not isinstance(module, TransformerLayer):

--- a/tests/integration/megatron/lora/test_lora_disk_codecs.py
+++ b/tests/integration/megatron/lora/test_lora_disk_codecs.py
@@ -1022,8 +1022,11 @@ def test_gemma4_peft_target_parameter_moe_layout_is_transposed(tmp_path: Path):
         down_a = internal[f"{art_prefix}.{expert}.down_proj.lora_A.weight"]
         down_b = internal[f"{art_prefix}.{expert}.down_proj.lora_B.weight"]
         assert torch.equal(gate_up_a, peft_gate_up_b[:, expert].unsqueeze(0))
-        assert torch.equal(gate_up_b[:4], peft_gate_up_a[expert].unsqueeze(1))
-        assert torch.count_nonzero(gate_up_b[4:]) == 0
+        gate_b, up_b = gate_up_b.chunk(2, dim=0)
+        assert torch.equal(gate_b[:2], peft_gate_up_a[expert, :2].unsqueeze(1))
+        assert torch.equal(up_b[:2], peft_gate_up_a[expert, 2:].unsqueeze(1))
+        assert torch.count_nonzero(gate_b[2:]) == 0
+        assert torch.count_nonzero(up_b[2:]) == 0
         assert torch.equal(down_a[:, :2], peft_down_b[:, expert].unsqueeze(0))
         assert torch.count_nonzero(down_a[:, 2:]) == 0
         assert torch.equal(down_b, peft_down_a[expert].unsqueeze(1))

--- a/tests/integration/megatron/lora/test_lora_disk_codecs.py
+++ b/tests/integration/megatron/lora/test_lora_disk_codecs.py
@@ -989,14 +989,27 @@ def test_gemma4_peft_target_parameter_moe_layout_is_transposed(tmp_path: Path):
         adapter_config=adapter_config,
     )
 
-    assert torch.equal(
-        normalized[f"{prefix}.base_layer.lora_A.weight"], peft_gate_up_b.T
-    )
-    assert torch.equal(
-        normalized[f"{prefix}.base_layer.lora_B.weight"], peft_gate_up_a.T
-    )
-    assert torch.equal(normalized[f"{prefix}.lora_A.weight"], peft_down_b.T)
-    assert torch.equal(normalized[f"{prefix}.lora_B.weight"], peft_down_a.T)
+    assert len(normalized) == 12
+    for expert in range(2):
+        for module, a, b in (
+            (
+                "gate_proj",
+                peft_gate_up_b[:, expert][None],
+                peft_gate_up_a[expert, :2, None],
+            ),
+            (
+                "up_proj",
+                peft_gate_up_b[:, expert][None],
+                peft_gate_up_a[expert, 2:, None],
+            ),
+            ("down_proj", peft_down_b[:, expert][None], peft_down_a[expert, :, None]),
+        ):
+            assert torch.equal(
+                normalized[f"{prefix}.{expert}.{module}.lora_A.weight"], a
+            )
+            assert torch.equal(
+                normalized[f"{prefix}.{expert}.{module}.lora_B.weight"], b
+            )
 
     internal = GEMMA4_MOE_HANDLER.from_vllm_lora_tensors(
         peft_tensors,
@@ -1014,6 +1027,90 @@ def test_gemma4_peft_target_parameter_moe_layout_is_transposed(tmp_path: Path):
         assert torch.equal(down_a[:, :2], peft_down_b[:, expert].unsqueeze(0))
         assert torch.count_nonzero(down_a[:, 2:]) == 0
         assert torch.equal(down_b, peft_down_a[expert].unsqueeze(1))
+
+
+@pytest.mark.parametrize("rank", [1, 3])
+@pytest.mark.parametrize("packed", [False, True])
+def test_gemma4_exports_all_experts_as_standard_projection_lora(
+    tmp_path: Path, rank: int, packed: bool
+) -> None:
+    from art.megatron.model_support.internal_padding import pack_vllm_3d_lora_b
+
+    model_dir = tmp_path / "base"
+    model_dir.mkdir()
+    hidden, intermediate, num_experts = 16, 7, 4
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "text_config": {
+                    "enable_moe_block": True,
+                    "hidden_size": hidden,
+                    "moe_intermediate_size": intermediate,
+                    "num_experts": num_experts,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = _config(str(model_dir), rank=rank)
+    config["target_modules"].append("experts")
+    config["target_parameters"] = ["moe.experts.gate_up_proj", "moe.experts.down_proj"]
+    prefix = "base_model.model.model.layers.0.moe.experts"
+    art_prefix = prefix.replace(".moe.", ".mlp.")
+    generator = torch.Generator().manual_seed(17)
+    expected = {}
+    for expert in range(num_experts):
+        gate_a = torch.randn(rank, hidden, generator=generator)
+        for module, a, b in (
+            ("gate_proj", gate_a, torch.randn(intermediate, rank, generator=generator)),
+            (
+                "up_proj",
+                gate_a.clone(),
+                torch.randn(intermediate, rank, generator=generator),
+            ),
+            (
+                "down_proj",
+                torch.randn(rank, intermediate, generator=generator),
+                torch.randn(hidden, rank, generator=generator),
+            ),
+        ):
+            expected[f"{prefix}.{expert}.{module}.lora_A.weight"] = a
+            expected[f"{prefix}.{expert}.{module}.lora_B.weight"] = b
+    internal: dict[str, torch.Tensor] = GEMMA4_MOE_HANDLER.from_vllm_lora_tensors(
+        expected, adapter_config=config
+    )
+    original = internal
+    if packed:
+        internal = {}
+        for module, slot in (("gate_up_proj", "base_layer."), ("down_proj", "")):
+            for factor in ("A", "B"):
+                blocks = [
+                    original[f"{art_prefix}.{e}.{module}.lora_{factor}.weight"]
+                    for e in range(num_experts)
+                ]
+                internal[f"{art_prefix}.{slot}lora_{factor}.weight"] = (
+                    torch.cat(blocks) if factor == "A" else pack_vllm_3d_lora_b(blocks)
+                )
+    exported, exported_config = GEMMA4_MOE_HANDLER.to_vllm_lora_tensors(
+        internal, adapter_config=config
+    )
+    _assert_tensors_equal(exported, expected)
+    assert len(exported) == num_experts * 6
+    assert exported_config["r"] == rank
+    assert exported_config["lora_alpha"] == config["lora_alpha"]
+    assert "experts" not in exported_config["target_modules"]
+    assert exported_config["target_parameters"] is None
+    _assert_tensors_equal(
+        GEMMA4_MOE_HANDLER.from_vllm_lora_tensors(
+            exported, adapter_config=exported_config
+        ),
+        original,
+    )
+    adapter_dir = tmp_path / "adapter"
+    save_vllm_lora_tensors(adapter_dir, exported, exported_config)
+    _assert_tensors_equal(
+        load_file(adapter_dir / "adapter_model.safetensors"), expected
+    )
 
 
 def test_gpt_oss_vllm_canonical_roundtrip_and_stock_loader(tmp_path: Path):

--- a/tests/integration/megatron/runtime_isolation/test_service_runtime_boundary.py
+++ b/tests/integration/megatron/runtime_isolation/test_service_runtime_boundary.py
@@ -13,6 +13,23 @@ import httpx
 import pytest
 
 
+def test_trainer_only_service_does_not_require_inference_topology(
+    tmp_path: Path,
+) -> None:
+    from art.megatron.distributed_service import DistributedMegatronService
+
+    runtime = SimpleNamespace(topology=SimpleNamespace(model_services=()))
+    service = DistributedMegatronService(
+        model_name="trainer-only",
+        base_model="base",
+        config={},
+        output_dir=str(tmp_path),
+        runtime=cast(Any, runtime),
+        enable_expert_replay=False,
+    )
+    assert service._temporal_gpu_sharing is False
+
+
 def _process_is_running(pid: int) -> bool:
     try:
         state = Path(f"/proc/{pid}/stat").read_text().split()[2]

--- a/vllm_runtime/src/art_vllm_runtime/gemma4_moe_lora_patch.py
+++ b/vllm_runtime/src/art_vllm_runtime/gemma4_moe_lora_patch.py
@@ -12,9 +12,6 @@ def patch_gemma4_moe_lora_support() -> None:
     from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
 
     # Remove this shim when upstream vLLM Gemma4 MoE defines these natively.
-    Gemma4ForCausalLM.is_3d_moe_weight = True
-    Gemma4ForConditionalGeneration.is_3d_moe_weight = True
-
     if not hasattr(Gemma4ForCausalLM, "get_expert_mapping"):
 
         def get_causal_expert_mapping(


### PR DESCRIPTION
Gemma 4 adapters currently export fused expert factors with the expert and rank axes packed together. Stock vLLM's default MoE LoRA loader cannot activate those tensors unless the request selects the 3D format. Export each expert under `moe.experts.{expert}.{gate_proj,up_proj,down_proj}` instead, with ordinary `[r, input]` and `[output, r]` factors.

This preserves every expert delta, rank, and alpha. Training and the packed publisher stay fused; export unpacks B's rank-major expert columns, duplicates the shared gate/up A, and splits gate/up B after trimming Megatron padding. Remove the fused `experts` target and ART's Gemma-specific 3D inference override. The existing per-expert importer supports resuming these checkpoints.

Validation on CKS-WB3 H200:
- Trained a rank-1 dummy adapter on the full `google/gemma-4-26B-A4B-it` base for three optimizer steps: loss 9.0773 → 8.9565 → 8.8492.
- Export contained all 23,040 expert factors (128 experts × 30 layers × 3 projections × A/B), plus 420 attention/shared-MLP factors. Every layer's gate/up/down adapters received updates.
- Stock `vllm/vllm-openai:v0.28.0-cu129`: adapter load and three chat generations returned HTTP 200, with **no `--enable-mixed-moe-lora-format` and no `is_3d_lora_weight` request field**.
- Six Gemma codec tests pass, including packed/unpacked exports at ranks 1 and 3, exact round trips, serialization, and PEFT input normalization.
- `uv run prek run --all-files` passes on Linux. Local macOS type checking encounters existing Linux-only APIs; `ty --python-platform linux` also passes.

The tradeoff is more checkpoint keys and a duplicated gate/up A factor on disk. This changes Gemma's exported format; deployments that explicitly force the 3D format must stop doing so.

The native trainer service also supports a topology with no inference service, and Gemma maps exported gate/up/down target names back to its fused training wrapper when resuming. A Serverless bridge smoke test trained, saved, recreated the Monarch runtime, loaded optimizer state, and continued training on the full Gemma base. The trainer-only topology regression plus the six Gemma codec tests pass (seven total); Linux prek passes on the final commit.

Downstream native-runtime migration draft: https://github.com/coreweave/serverless-training/pull/553.
