### PR TITLE
Prefer exact length-stop boundaries over probe suffix collisions

### DIFF
--- a/src/art/trajectories/_tokenize.py
+++ b/src/art/trajectories/_tokenize.py
@@ -5252,10 +5252,8 @@ def _tokenize_chat_view(
                 else marked_bounds.get(message_index)
                 or probed_bounds.get(message_index)
             )
-            if (
-                bounds is None
-                and position + 1 < len(sampled_message_indices)
-                and source_matches_context(source)
+            if position + 1 < len(sampled_message_indices) and source_matches_context(
+                source
             ):
                 prompt = source_prompt_tokens(source)
                 output, _ = source_output_tokens(source)
@@ -5268,7 +5266,7 @@ def _tokenize_chat_view(
                     rendered_start = rendered_end - 1
                     while rendered_start and assistant_mask[rendered_start - 1]:
                         rendered_start -= 1
-                    bounds = _prove_exact_length_stopped_assistant_prefix(
+                    exact_bounds = _prove_exact_length_stopped_assistant_prefix(
                         [
                             match
                             for match in locations(output, rendered_start)
@@ -5277,6 +5275,7 @@ def _tokenize_chat_view(
                         assistant_mask,
                         expected_start=rendered_start,
                     )
+                    bounds = exact_bounds or bounds
             next_prompt_end: int | None
             if position + 1 < len(sampled_message_indices):
                 next_message_index = sampled_message_indices[position + 1]

--- a/tests/unit/trajectories/test_tokenize.py
+++ b/tests/unit/trajectories/test_tokenize.py
@@ -8009,3 +8009,122 @@ def test_exchange_training_requires_logprobs_unless_allowed() -> None:
     with pytest.raises(RuntimeError, match="missing logprobs"):
         tokenize(allow_missing=False)
     assert len(tokenize(allow_missing=True)) == 2
+
+
+@pytest.mark.parametrize(
+    ("suffix", "corruption"),
+    [
+        ("0", None),
+        ("7", None),
+        ("0", "missing_stop"),
+        ("0", "wrong_stop"),
+        ("0", "changed_sampled_token"),
+        ("7", "changed_sampled_token"),
+        ("7", "unrendered_sampled_token"),
+    ],
+)
+def test_length_boundary_preserves_output_despite_probe_suffix_collision(
+    suffix: str,
+    corruption: str | None,
+) -> None:
+    from art.trajectories._tokenize import (
+        _chat_source_full_tokens,
+        _chat_source_prompt_tokens,
+        _tokenize_trajectory_with_trace,
+    )
+
+    class ReasoningTokenizer(_CharacterTemplateTokenizer):
+        def __call__(self, text: str, **kwargs: object) -> dict[str, object]:
+            # Tokenizers without offsets use the content-replacement probe.
+            return {"input_ids": self._encode(text)}
+
+        def apply_chat_template(
+            self,
+            messages: list[dict[str, Any]],
+            *,
+            tokenize: bool = True,
+            add_generation_prompt: bool,
+            **kwargs: object,
+        ) -> str | list[int]:
+            text = ""
+            for message in messages:
+                if message["role"] == "user":
+                    text += f"<u>{message['content']}</u>"
+                else:
+                    text += "<a><think>\n" + (message.get("reasoning") or "")
+                    text += "\n</think>\n\n" + (message.get("content") or "") + "§"
+            if add_generation_prompt:
+                text += "<a><think>\n"
+            return self._encode(text) if tokenize else text
+
+    tokenizer = ReasoningTokenizer()
+    first_messages = [{"role": "user", "content": "question"}]
+    first_message = {"role": "assistant", "reasoning": "thought" + suffix}
+    final_messages = [
+        *first_messages,
+        first_message,
+        {"role": "user", "content": "continue"},
+    ]
+    final_message = {"role": "assistant", "reasoning": "ready", "content": "done"}
+    exchanges = []
+    for i, (messages, message, output, finish) in enumerate(
+        [
+            (first_messages, first_message, "thought" + suffix, "length"),
+            (final_messages, final_message, "ready\n</think>\n\ndone§", "stop"),
+        ]
+    ):
+        prompt = cast(
+            list[int],
+            tokenizer.apply_chat_template(messages, add_generation_prompt=True),
+        )
+        if i == 0 and corruption == "unrendered_sampled_token":
+            output = "!" + output[1:]
+        exchange = _chat_exchange(prompt, tokenizer._encode(output), offset=i)
+        exchange.request["messages"] = cast(list[ChatCompletionMessageParam], messages)
+        data = exchange.response.model_dump(mode="python")
+        data["choices"][0].update(message=message, finish_reason=finish)
+        exchange.response = ChatCompletion.model_validate(data)
+        exchanges.append(exchange)
+    first_choice, final_choice = (
+        exchange.response.choices[0] for exchange in exchanges
+    )
+    assert first_choice.model_extra is not None
+    assert final_choice.model_extra is not None
+    prompt = final_choice.model_extra["prompt_token_ids"]
+    if corruption == "missing_stop":
+        prompt.remove(9)
+    elif corruption == "wrong_stop":
+        prompt[prompt.index(9)] = tokenizer._encode("!")[0]
+    elif corruption in {"changed_sampled_token", "unrendered_sampled_token"}:
+        prefix = first_choice.model_extra["prompt_token_ids"]
+        prompt[len(prefix)] = tokenizer._encode("!")[0]
+    trajectory = art.Trajectory(
+        exchanges=TrajectoryExchanges(chat_completions=exchanges)
+    )
+    if corruption in {"missing_stop", "wrong_stop"}:
+        with pytest.raises(ValueError, match="Could not uniquely locate"):
+            _tokenize_trajectory_with_trace(trajectory, tokenizer=tokenizer)
+        return
+
+    tokenized, traces = _tokenize_trajectory_with_trace(trajectory, tokenizer=tokenizer)
+    assert len(tokenized.histories) == (
+        2 if corruption == "changed_sampled_token" else 1
+    )
+    assert sum(len(trace.sources) for trace in traces) == 2
+    for history, trace in zip(tokenized.histories, traces, strict=True):
+        for key, source in trace.sources.items():
+            positions = [
+                i for i, actual in enumerate(trace.source_keys) if actual == key
+            ]
+            output, logprobs = _chat_source_full_tokens(source)
+            assert output is not None
+            assert positions == list(range(positions[0], positions[0] + len(output)))
+            assert history.tokens[: positions[0]] == _chat_source_prompt_tokens(source)
+            assert [history.tokens[i] for i in positions] == output
+            assert [history.logprobs[i] for i in positions] == logprobs
+            assert all(math.isfinite(history.logprobs[i]) for i in positions)
+            assert all(
+                history.flags[i] & _SAMPLED_ASSISTANT_OUTPUT
+                == _SAMPLED_ASSISTANT_OUTPUT
+                for i in positions
+            )


### PR DESCRIPTION
A captured length-stopped assistant response can end with a token that overlaps the replacement probe's suffix. The shortened probe boundary then rejects a valid multi-turn history. Attempt the existing exact-prefix proof even when a boundary exists, prefer proved bounds, and retain the previous boundary when proof is unavailable. Source-context checks and subsequent captured-prompt validation are unchanged.

The regression covers colliding and ordinary suffixes, unavailable exact proof, missing/wrong stop evidence, and later-prompt corruption. It verifies complete captured prompts, contiguous output IDs, logprobs, and sampled flags.

Validation:
- `tests/unit/trajectories`: 451 passed, 7 skipped.
- New seven-case matrix on unchanged main: only the valid suffix collision fails; six cases pass. All seven pass with the correction.
- Offline replay: all eight saved captures match the previously tested patch; seven prior successes are unchanged. The failing capture now retains all 1,210 sampled tokens across three sources with exact prompts, outputs, and logprobs.
- Prek lint, formatting, and lock checks pass. Pinned `ty==0.0.59` passes across `src tests`, run separately with an isolated missing test dependency because the reused environment has an older type checker.

Closes #868.
