### PR TITLE
Limit TrainerRank bootstrap apt commands to Ubuntu sources

### DIFF
--- a/.github/workflows/trainer-rank-gpu.yml
+++ b/.github/workflows/trainer-rank-gpu.yml
@@ -80,8 +80,14 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends socat
+          # socat only needs Ubuntu; unrelated third-party apt feeds can be broken.
+          test -s /etc/apt/sources.list.d/ubuntu.sources
+          apt_sources=(
+            -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources
+            -o Dir::Etc::sourceparts=-
+          )
+          sudo apt-get "${apt_sources[@]}" update --error-on=any
+          sudo apt-get "${apt_sources[@]}" install -y --no-install-recommends socat
           kubectl_version="$(curl -LsSf https://dl.k8s.io/release/stable.txt)"
           kubectl_path="${RUNNER_TEMP}/kubectl"
           curl -LsSf -o "${kubectl_path}" \


### PR DESCRIPTION
The Ubuntu 24.04 GPU CI runner fails before launch when an unrelated Chrome apt index has a hash mismatch. Restrict both apt commands to the runner's Ubuntu sources while installing `socat`, and fail if that source file is missing or the Ubuntu update/install fails.

Validation: six offline command checks cover source selection, success, missing/malformed sources, and update/install failures; shell syntax, ShellCheck, Prek lint/format/lock, and pinned type checks pass. The workflow-only diff skips GPU validation; no GPU workload was launched.

Fixes #873.
