### PR TITLE
Fix release smoke test when Triton is unavailable

### DIFF
--- a/tests/unit/test_moe_lora_runtime_patches.py
+++ b/tests/unit/test_moe_lora_runtime_patches.py
@@ -1,0 +1,89 @@
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def patches():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "vllm_runtime/src/art_vllm_runtime/moe_lora_patches.py"
+    )
+    spec = importlib.util.spec_from_file_location("_art_moe_lora_patches", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def vllm_modules(monkeypatch):
+    triton_utils = ModuleType("vllm.triton_utils")
+    setattr(triton_utils, "HAS_TRITON", True)
+    triton_ops = ModuleType("vllm.lora.ops.triton_ops")
+    fused_op = SimpleNamespace()
+    setattr(triton_ops, "fused_moe_lora_op", fused_op)
+    monkeypatch.setitem(sys.modules, "vllm.triton_utils", triton_utils)
+    monkeypatch.setitem(sys.modules, "vllm.lora.ops.triton_ops", triton_ops)
+    return triton_utils, fused_op
+
+
+def test_small_batch_patch_skips_triton_placeholder(patches, vllm_modules):
+    triton_utils, fused_op = vllm_modules
+    triton_utils.HAS_TRITON = False
+
+    # vLLM's placeholder decorators leave an ordinary function without .fn.
+    def placeholder():
+        pass
+
+    fused_op._fused_moe_lora_small_batch_kernel = placeholder
+
+    patches.patch_small_batch_moe_lora_intermediate_dtype()
+
+    assert fused_op._fused_moe_lora_small_batch_kernel is placeholder
+
+
+def test_small_batch_patch_casts_intermediate_once(patches, vllm_modules):
+    _, fused_op = vllm_modules
+    anchor = (
+        "            # EXPAND: walk n_tiles_per_program consecutive output-N tiles\n"
+    )
+    source = "            rank_vec = tl.sum(acc, axis=0)\n" + anchor
+    updates = []
+    kernel = SimpleNamespace(src=source)
+
+    def update_source(updated):
+        updates.append(updated)
+        kernel.src = updated
+
+    kernel._unsafe_update_src = update_source
+    fused_op._fused_moe_lora_small_batch_kernel = SimpleNamespace(fn=kernel)
+
+    patches.patch_small_batch_moe_lora_intermediate_dtype()
+    patches.patch_small_batch_moe_lora_intermediate_dtype()
+
+    cast = "            rank_vec = rank_vec.to(out_ptr.dtype.element_ty)\n"
+    assert updates == [source.replace(anchor, cast + "\n" + anchor)]
+
+
+def test_small_batch_patch_rejects_changed_kernel_source(patches, vllm_modules):
+    _, fused_op = vllm_modules
+    fused_op._fused_moe_lora_small_batch_kernel = SimpleNamespace(
+        fn=SimpleNamespace(src="unexpected kernel source")
+    )
+
+    with pytest.raises(RuntimeError, match="Unsupported vLLM small-batch"):
+        patches.patch_small_batch_moe_lora_intermediate_dtype()
+
+
+def test_small_batch_patch_does_not_hide_active_triton_api_changes(
+    patches, vllm_modules
+):
+    _, fused_op = vllm_modules
+    fused_op._fused_moe_lora_small_batch_kernel = lambda: None
+
+    with pytest.raises(AttributeError, match="fn"):
+        patches.patch_small_batch_moe_lora_intermediate_dtype()

--- a/vllm_runtime/src/art_vllm_runtime/moe_lora_patches.py
+++ b/vllm_runtime/src/art_vllm_runtime/moe_lora_patches.py
@@ -57,6 +57,13 @@ def patch_local_3d_moe_dummy_lora() -> None:
 
 
 def patch_small_batch_moe_lora_intermediate_dtype() -> None:
+    from vllm.triton_utils import HAS_TRITON
+
+    # Without an active Triton driver (e.g. in the release smoke test), vLLM
+    # uses plain placeholder functions with no JIT source to patch.
+    if not HAS_TRITON:
+        return
+
     from vllm.lora.ops.triton_ops import fused_moe_lora_op
 
     kernel = fused_moe_lora_op._fused_moe_lora_small_batch_kernel.fn


### PR DESCRIPTION
The v0.5.20 [release run](https://github.com/OpenPipe/ART/actions/runs/34394051228) failed before publishing because the runtime smoke runner has no active Triton driver. vLLM disables Triton and leaves its kernel decorators as placeholders, so the small-batch MoE LoRA patch raises `AttributeError: 'function' object has no attribute 'fn'` during runtime initialization.

Skip this JIT-source patch when vLLM reports `HAS_TRITON=False`. When Triton is available, retain the dtype correction, idempotence, and strict checks for incompatible kernel changes. The release smoke-test gate remains in place.

Validation:
- Reproduced the original AttributeError with the new regression test before applying the fix.
- 8 targeted tests passed across `test_moe_lora_runtime_patches.py` and `test_dsv4_vllm_runtime_patches.py`.
- Ruff lint/format, ty on the new test file, and `git diff --check` passed.
- Full managed-runtime release smoke test and GPU execution were not run locally.

The failed release artifact predates this fix. Publishing 0.5.20 will require rebuilding from the corrected source; rerunning only the failed job against the old artifact will not include the remediation.
