### PR TITLE
Fix trainer-rank memory estimates and split pruning at profile boundaries

### DIFF
--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -2540,10 +2540,10 @@ class TrainerRank:
         measures it on a real cell.
 
         Cost: the cheap full-sharing lower bound (one O(tokens) CPU scan per
-        chunk) rejects a rung without planning anything. A rung that survives
-        is priced exactly with cost-optimal layouts and, failing that, with
-        memory-minimal layouts, whose packed tokens equal the lower bound — so
-        the planner runs for at most one rung, the one that executes.
+        chunk) can reject a rung without planning it. A surviving rung is
+        priced exactly with cost-optimal and then memory-minimal layouts.
+        Retained-profile trust boundaries can make the bound optimistic, so
+        more than one rung may need exact planning before one executes.
         """
 
         lower = [
@@ -2597,7 +2597,11 @@ class TrainerRank:
         *,
         checkpoint: AdapterSelection,
     ) -> _SubforwardCost:
-        """Cheapest possible cost of a chunk: its full-sharing packed tokens."""
+        """Optimistic retention; exact layouts still decide admission.
+
+        The required term keeps the estimator's packed-profile trust cutoff;
+        crossing that separate cutoff can still invalidate its lower bound.
+        """
 
         groups = self._group_active_request_indices(
             requests, checkpoint=checkpoint, ensure_slots=False
@@ -2610,16 +2614,37 @@ class TrainerRank:
             )
             assert estimated is not None  # rows are CPU copies
             packed_tokens += self._physical_tokens(estimated)
-        return self._subforward_cost(
-            packed_tokens=packed_tokens,
-            output_bytes=self._estimate_group_request_output_bytes(requests),
-            signature=self._memory_signature_from_requests(
-                requests,
-                slot_group_count=len(groups),
-                grad_modes=tuple(mode for (_, mode), _ in groups),
-            ),
-            logical_tokens=sum(int(row.numel()) for row in rows),
+        output_bytes = self._estimate_group_request_output_bytes(requests)
+        signature = self._memory_signature_from_requests(
+            requests,
+            slot_group_count=len(groups),
+            grad_modes=tuple(mode for (_, mode), _ in groups),
         )
+        logical_tokens = sum(int(row.numel()) for row in rows)
+        cost = self._subforward_cost(
+            packed_tokens=packed_tokens,
+            output_bytes=output_bytes,
+            signature=signature,
+            logical_tokens=logical_tokens,
+        )
+        profile = self._memory_profiles.get(signature)
+        if (
+            profile is not None
+            and profile.retained_compute_bytes_per_token is not None
+            and logical_tokens / max(1, packed_tokens)
+            > profile.logical_per_packed * _MEMORY_PROFILE_TRUST_GROWTH
+            and logical_tokens
+            / (profile.logical_per_packed * _MEMORY_PROFILE_TRUST_GROWTH)
+            <= profile.packed_tokens * _MEMORY_PROFILE_TRUST_GROWTH
+        ):
+            # A larger layout may trust retained compute where full sharing
+            # cannot. Its full-required retention is not a pruning lower bound.
+            # Charge only outputs here; exact plan costs keep both trust guards.
+            return _SubforwardCost(
+                required=cost.required,
+                retained=min(cost.retained, int(output_bytes * _MEMORY_SAFETY_FACTOR)),
+            )
+        return cost
 
     def _plan_cost(self, plan: _FlatForwardPlan) -> _SubforwardCost:
         return self._subforward_cost(

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -2723,11 +2723,8 @@ class TrainerRank:
         ratio = logical_tokens / max(1, packed_tokens)
         if ratio > profile.logical_per_packed * _MEMORY_PROFILE_TRUST_GROWTH:
             return required
-        retained = (
-            output_bytes
-            + profile.retained_compute_bytes_per_token
-            * packed_tokens
-            * max(1.0, ratio / profile.logical_per_packed)
+        retained = output_bytes + profile.retained_compute_bytes_per_token * max(
+            packed_tokens, logical_tokens / profile.logical_per_packed
         )
         return min(required, int(retained * _MEMORY_SAFETY_FACTOR))
 
@@ -4817,10 +4814,13 @@ class TrainerRank:
         # A profile learned under lighter sharing (lower logical/packed ratio)
         # underestimates the per-packed-token footprint of a deeper-shared
         # plan; scale the trusted estimate up by the ratio gap.
-        ratio_scale = 1.0
+        # Normalize before multiplying: cancelling packed tokens through two
+        # float operations can otherwise make a larger warm layout cheaper.
+        profiled_tokens: int | float = packed_tokens
         if profiled is not None and logical_tokens is not None:
-            current_ratio = logical_tokens / max(1, packed_tokens)
-            ratio_scale = max(1.0, current_ratio / profiled.logical_per_packed)
+            profiled_tokens = max(
+                packed_tokens, logical_tokens / profiled.logical_per_packed
+            )
         if (
             profiled is None
             or profiled.packed_tokens * _MEMORY_PROFILE_TRUST_GROWTH < packed_tokens
@@ -4829,7 +4829,7 @@ class TrainerRank:
         else:
             compute = max(
                 static_compute,
-                int(profiled.bytes_per_token * packed_tokens * ratio_scale),
+                int(profiled.bytes_per_token * profiled_tokens),
             )
         return int((output_bytes + compute) * _MEMORY_SAFETY_FACTOR)
 

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -1195,6 +1195,85 @@ def _configure_moe_dispatcher_caches(model: Sequence[torch.nn.Module]) -> None:
                 )
 
 
+def _moe_output_bytes_per_token(
+    model: Sequence[torch.nn.Module], shape: ParallelShape
+) -> int:
+    """Known FC2 output pair, not a bound on the complete live working set."""
+    if shape != ParallelShape(tp=1, cp=1):
+        return 0
+    from megatron.core.extensions.transformer_engine import TERowParallelGroupedLinear
+    from megatron.core.transformer.moe.experts import TEGroupedMLP
+    from megatron.core.transformer.moe.moe_layer import BaseMoELayer, MoELayer
+    from megatron.core.transformer.moe.router import TopKRouter
+    from megatron.core.transformer.moe.token_dispatcher import (
+        MoEAlltoAllTokenDispatcher,
+    )
+
+    from art.megatron.lora import LoRA, MLPExpertsLinearFC2LoRA
+
+    coefficient = 0
+    for chunk in model:
+        for layer in chunk.modules():
+            if not isinstance(layer, BaseMoELayer):
+                continue
+            experts = getattr(layer, "experts", None)
+            fc2: Any = getattr(experts, "linear_fc2", None)
+            lora: Any = getattr(fc2, "lora", None)
+            dispatcher = getattr(layer, "token_dispatcher", None)
+            sites = (
+                (layer, MoELayer),
+                (experts, TEGroupedMLP),
+                (fc2, MLPExpertsLinearFC2LoRA),
+                (lora, LoRA),
+                (getattr(fc2, "linear_fc2", None), TERowParallelGroupedLinear),
+                (getattr(layer, "router", None), TopKRouter),
+            )
+            if (
+                any(
+                    type(site) is not expected
+                    or "forward" in vars(site)
+                    or getattr(site, "_forward_hooks", None)
+                    or getattr(site, "_forward_pre_hooks", None)
+                    for site, expected in sites
+                )
+                or type(dispatcher) is not MoEAlltoAllTokenDispatcher
+            ):
+                return 0
+            config = layer.config
+            if (
+                config.moe_expert_capacity_factor is not None
+                or config.moe_pad_expert_input_to_capacity
+                or config.moe_router_padding_for_quantization
+                or config.fp8
+                or config.fp4
+                or config.moe_latent_size is not None
+                or config.cuda_graph_impl != "none"
+                or any(
+                    name in vars(dispatcher)
+                    for name in (
+                        "preprocess",
+                        "dispatch_preprocess",
+                        "dispatch_postprocess",
+                    )
+                )
+                or "routing" in vars(layer.router)
+            ):
+                return 0
+            weights = lora.B_T
+            if (
+                weights.dtype not in (torch.float16, torch.bfloat16)
+                or weights.shape[-1] != fc2.out_features
+                or fc2.out_features != config.hidden_size
+                or getattr(layer.router, "topk", None) != config.moe_router_topk
+            ):
+                return 0
+            coefficient = max(
+                coefficient,
+                2 * config.moe_router_topk * fc2.out_features * weights.element_size(),
+            )
+    return coefficient
+
+
 class TrainerRank:
     def __init__(self, runtime: TrainingRuntime) -> None:
         pp_size = int(getattr(runtime.provider, "pipeline_model_parallel_size", 1) or 1)
@@ -1261,6 +1340,11 @@ class TrainerRank:
         ep_size, etp_size = _expert_parallel_shape(runtime.provider)
         self._parallel_shape = ParallelShape(
             tp=tp_size, cp=cp_size, ep=ep_size, etp=etp_size
+        )
+        self._moe_output_bytes_per_token = (
+            _moe_output_bytes_per_token(runtime.model, self._parallel_shape)
+            if self._moe_layers
+            else 0
         )
         selection = select_scoring(
             device_capability=capability,
@@ -4676,6 +4760,11 @@ class TrainerRank:
             * self._hidden_size
             * self._param_dtype_size
             * activation_factor
+        )
+        # Groups execute sequentially: summed packed rows conservatively bound
+        # this output-pair component, not simultaneous workspace or retained graphs.
+        static_compute = max(
+            static_compute, packed_tokens * self._moe_output_bytes_per_token
         )
         # A profile learned under lighter sharing (lower logical/packed ratio)
         # underestimates the per-packed-token footprint of a deeper-shared

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -2651,8 +2651,14 @@ class TrainerRank:
             and logical_tokens / max(1, packed_tokens)
             > profile.logical_per_packed * _MEMORY_PROFILE_TRUST_GROWTH
             and logical_tokens
-            / (profile.logical_per_packed * _MEMORY_PROFILE_TRUST_GROWTH)
-            <= profile.packed_tokens * _MEMORY_PROFILE_TRUST_GROWTH
+            / max(
+                1,
+                min(
+                    unshared_packed_tokens,
+                    profile.packed_tokens * _MEMORY_PROFILE_TRUST_GROWTH,
+                ),
+            )
+            <= profile.logical_per_packed * _MEMORY_PROFILE_TRUST_GROWTH
         ):
             # A larger layout may trust retained compute where full sharing
             # cannot. Its full-required retention is not a pruning lower bound.

--- a/src/art/trainer_rank/_impl.py
+++ b/src/art/trainer_rank/_impl.py
@@ -2597,16 +2597,13 @@ class TrainerRank:
         *,
         checkpoint: AdapterSelection,
     ) -> _SubforwardCost:
-        """Optimistic retention; exact layouts still decide admission.
-
-        The required term keeps the estimator's packed-profile trust cutoff;
-        crossing that separate cutoff can still invalidate its lower bound.
-        """
+        """Optimistic cost across layout and profile-trust boundaries."""
 
         groups = self._group_active_request_indices(
             requests, checkpoint=checkpoint, ensure_slots=False
         )
         packed_tokens = 0
+        unshared_packed_tokens = 0
         for _, group_indices in groups:
             estimated = estimate_prefix_tree_packed_tokens(
                 (rows[index] for index in group_indices),
@@ -2614,6 +2611,9 @@ class TrainerRank:
             )
             assert estimated is not None  # rows are CPU copies
             packed_tokens += self._physical_tokens(estimated)
+            unshared_packed_tokens += self._physical_tokens(
+                sum(int(rows[index].numel()) for index in group_indices)
+            )
         output_bytes = self._estimate_group_request_output_bytes(requests)
         signature = self._memory_signature_from_requests(
             requests,
@@ -2628,6 +2628,23 @@ class TrainerRank:
             logical_tokens=logical_tokens,
         )
         profile = self._memory_profiles.get(signature)
+        if profile is not None:
+            cap = profile.packed_tokens * _MEMORY_PROFILE_TRUST_GROWTH
+            if packed_tokens <= cap < unshared_packed_tokens:
+                # Required cost can drop when a larger layout leaves the
+                # profile window. Cold cost grows with packed tokens, so its
+                # first integer count bounds every possible post-cap layout,
+                # even when TP padding makes that count itself unattainable.
+                cold = self._subforward_cost(
+                    packed_tokens=cap + 1,
+                    output_bytes=output_bytes,
+                    signature=signature,
+                    logical_tokens=logical_tokens,
+                )
+                cost = _SubforwardCost(
+                    required=min(cost.required, cold.required),
+                    retained=min(cost.retained, cold.retained),
+                )
         if (
             profile is not None
             and profile.retained_compute_bytes_per_token is not None

--- a/tests/unit/test_trainer_rank_moe_memory.py
+++ b/tests/unit/test_trainer_rank_moe_memory.py
@@ -1,0 +1,345 @@
+"""CPU contracts for one known MoE component, not a whole-model memory bound."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any, cast
+import weakref
+
+import pytest
+import torch
+
+from art.trainer_rank import ForwardInput, TrainerRank
+from art.trainer_rank._impl import (
+    _MemoryProfile,
+    _MemorySignature,
+    _moe_output_bytes_per_token,
+)
+from art.trainer_rank._planner_cost import ParallelShape
+
+
+@pytest.fixture
+def layer() -> Any:
+    lora_module = pytest.importorskip("art.megatron.lora")
+    from megatron.core.transformer.moe.moe_layer import MoELayer
+    from megatron.core.transformer.moe.router import TopKRouter
+    from megatron.core.transformer.moe.token_dispatcher import (
+        MoEAlltoAllTokenDispatcher,
+    )
+
+    def module(cls):
+        value = cls.__new__(cls)
+        torch.nn.Module.__init__(value)
+        return value
+
+    # Actual supported types, without CUDA/process-group initialization. No
+    # model forward is faked here: these tests inspect constructor metadata only.
+    config = SimpleNamespace(
+        hidden_size=2048,
+        num_layers=40,
+        num_moe_experts=256,
+        moe_router_topk=8,
+        moe_ffn_hidden_size=512,
+        moe_expert_capacity_factor=None,
+        moe_pad_expert_input_to_capacity=False,
+        moe_router_padding_for_quantization=False,
+        fp8=None,
+        fp4=None,
+        moe_latent_size=None,
+        cuda_graph_impl="none",
+    )
+    value = module(MoELayer)
+    value.config = config
+    value.router = module(TopKRouter)
+    value.router.topk = 8
+    value.token_dispatcher = object.__new__(MoEAlltoAllTokenDispatcher)
+    value.token_dispatcher.config = config
+    value.experts = module(lora_module.TEGroupedMLP)
+    value.experts.linear_fc2 = module(lora_module.MLPExpertsLinearFC2LoRA)
+    value.experts.linear_fc2.out_features = 2048
+    value.experts.linear_fc2.linear_fc2 = module(lora_module.TERowParallelGroupedLinear)
+    value.experts.linear_fc2.lora = module(lora_module.LoRA)
+    value.experts.linear_fc2.lora.B_T = torch.nn.Parameter(
+        torch.empty(256, 8, 2048, dtype=torch.bfloat16)
+    )
+    return value
+
+
+def _rank(layer=None):
+    model = layer if layer is not None else torch.nn.Linear(1, 1).bfloat16()
+    return TrainerRank(
+        cast(
+            Any,
+            SimpleNamespace(
+                model=[model],
+                optimizer=None,
+                provider=SimpleNamespace(hidden_size=2048, num_layers=40),
+                model_support_handler=SimpleNamespace(build_gdn_execution_spec=False),
+            ),
+        )
+    )
+
+
+def _signature():
+    return _MemorySignature((1, 1, 1, 1), (1, None), 1, (), True, (True,))
+
+
+def test_supported_constructor_and_original_shape(layer):
+    rank = _rank(layer)
+    assert rank._moe_output_bytes_per_token == 2 * 8 * 2048 * 2
+    estimate = rank._estimate_required_memory_bytes_from_values(
+        packed_tokens=106432,
+        output_bytes=0,
+        signature=_signature(),
+    )
+    # This independent storage arithmetic exceeds the former 6,713,560,268.
+    base = torch.empty(106432 * 8, 2048, dtype=torch.bfloat16, device="meta")
+    adapter = torch.empty_like(base)
+    assert base.untyped_storage()._cdata != adapter.untyped_storage()._cdata
+    pair = base.untyped_storage().nbytes() + adapter.untyped_storage().nbytes()
+    assert pair == 6_975_127_552
+    assert estimate == int(pair * 1.1)
+    assert rank._memory_check_required(6_800_000_000).fits  # CPU default budget
+    rank._available_memory_bytes = lambda: 6_800_000_000
+    assert not rank._memory_check_required(estimate).fits
+
+
+@pytest.mark.parametrize("field", ["tp", "cp", "ep", "etp"])
+def test_sharded_path_unchanged(layer, field):
+    assert (
+        _moe_output_bytes_per_token(
+            [layer], replace(ParallelShape(tp=1, cp=1), **{field: 2})
+        )
+        == 0
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("moe_expert_capacity_factor", 1.0),
+        ("moe_pad_expert_input_to_capacity", True),
+        ("moe_router_padding_for_quantization", True),
+        ("fp8", "hybrid"),
+        ("fp4", "e2m1"),
+        ("moe_latent_size", 1024),
+        ("cuda_graph_impl", "local"),
+    ],
+)
+def test_padded_or_alternate_config_unchanged(layer, field, value):
+    setattr(layer.config, field, value)
+    assert _moe_output_bytes_per_token([layer], ParallelShape(tp=1, cp=1)) == 0
+
+
+@pytest.mark.parametrize(
+    "site",
+    [
+        "",
+        "experts",
+        "experts.linear_fc2",
+        "experts.linear_fc2.lora",
+        "experts.linear_fc2.linear_fc2",
+        "router",
+        "token_dispatcher",
+    ],
+)
+def test_custom_subclasses_unchanged(layer, site):
+    value = layer
+    for name in site.split(".") if site else ():
+        value = getattr(value, name)
+    value.__class__ = type("Custom", (type(value),), {})
+    assert _moe_output_bytes_per_token([layer], ParallelShape(tp=1, cp=1)) == 0
+
+
+@pytest.mark.parametrize(
+    "site,method",
+    [
+        (
+            "experts.linear_fc2",
+            "forward",
+        ),  # Includes an instance residual-fusion patch.
+        ("experts.linear_fc2.lora", "forward"),
+        ("token_dispatcher", "preprocess"),
+        ("token_dispatcher", "dispatch_preprocess"),
+        ("token_dispatcher", "dispatch_postprocess"),
+        ("router", "routing"),
+    ],
+)
+def test_instance_execution_overrides_unchanged(layer, site, method):
+    value = layer
+    for name in site.split("."):
+        value = getattr(value, name)
+    setattr(value, method, lambda *args: None)
+    assert _moe_output_bytes_per_token([layer], ParallelShape(tp=1, cp=1)) == 0
+
+
+def test_hooks_dtype_and_geometry_exclusions(layer):
+    shape = ParallelShape(tp=1, cp=1)
+    hook = layer.experts.linear_fc2.register_forward_pre_hook(lambda *args: None)
+    assert _moe_output_bytes_per_token([layer], shape) == 0
+    hook.remove()
+    lora = layer.experts.linear_fc2.lora
+    lora.B_T = torch.nn.Parameter(lora.B_T.float())
+    assert _moe_output_bytes_per_token([layer], shape) == 0
+    lora.B_T = torch.nn.Parameter(lora.B_T.bfloat16())
+    layer.experts.linear_fc2.out_features = 1024
+    assert _moe_output_bytes_per_token([layer], shape) == 0
+
+
+def test_topk_not_expert_count_controls_envelope(layer):
+    shape = ParallelShape(tp=1, cp=1)
+    old = _moe_output_bytes_per_token([layer], shape)
+    layer.config.num_moe_experts = 512
+    assert _moe_output_bytes_per_token([layer], shape) == old
+    layer.config.moe_router_topk = layer.router.topk = 4
+    assert _moe_output_bytes_per_token([layer], shape) == old // 2
+
+
+def test_profiles_outputs_trust_and_empty_plan_unchanged():
+    rank = _rank()
+    signature = _signature()
+    assert rank._moe_output_bytes_per_token == 0
+    rank._moe_output_bytes_per_token = 65536
+    estimate = rank._estimate_required_memory_bytes_from_values
+    assert estimate(packed_tokens=0, output_bytes=123, signature=signature) == 123
+    assert estimate(packed_tokens=100, output_bytes=123, signature=signature) == int(
+        (100 * 65536 + 123) * 1.1
+    )
+    rank._memory_profiles[signature] = _MemoryProfile(
+        bytes_per_token=100000,
+        packed_tokens=100,
+        logical_per_packed=1,
+    )
+    for tokens in (100, 800):
+        assert estimate(
+            packed_tokens=tokens, output_bytes=123, signature=signature
+        ) == int((tokens * 100000 + 123) * 1.1)
+    assert estimate(packed_tokens=801, output_bytes=123, signature=signature) == int(
+        (801 * 65536 + 123) * 1.1
+    )
+    assert estimate(
+        packed_tokens=100, logical_tokens=200, output_bytes=123, signature=signature
+    ) == int((100 * 200000 + 123) * 1.1)
+
+
+def test_summed_group_envelope_and_retained_profile_unchanged():
+    rank = _rank()
+    rank._moe_output_bytes_per_token = 65536
+    tokens = torch.arange(8)
+    plan = rank._plan_flat_forward(
+        [
+            ForwardInput(input_tokens=tokens, target_tokens=tokens),
+            ForwardInput(input_tokens=tokens, target_tokens=tokens, no_grad=True),
+        ]
+    )
+    assert len(plan.groups) == 2
+    assert plan.packed_tokens == 16
+    assert plan.output_bytes == 16 * 4
+    assert rank._plan_cost(plan).required == int((16 * 65536 + 16 * 4) * 1.1)
+    plan = replace(plan, packed_tokens=200, logical_tokens=200, output_bytes=4000)
+    required = rank._plan_cost(plan).required
+    assert required == int((200 * 65536 + 4000) * 1.1)
+    # Existing cold fallback retains the full estimate, not a newly derived rate.
+    assert rank._plan_cost(plan).retained == required
+    rank._memory_profiles[plan.signature] = _MemoryProfile(
+        bytes_per_token=100000,
+        packed_tokens=200,
+        retained_compute_bytes_per_token=100,
+    )
+    cost = rank._plan_cost(plan)
+    assert cost.retained == int((4000 + 200 * 100) * 1.1)
+    assert cost.ephemeral == cost.required - cost.retained
+    # Two sequential groups use a conservative sum envelope, not a simultaneous
+    # output-pair lower bound. No per-group coefficients or profiles are changed.
+    doubled = replace(plan, packed_tokens=400, logical_tokens=400)
+    assert rank._plan_cost(doubled).required == int((400 * 100000 + 4000) * 1.1)
+
+
+def test_fc2_base_remains_live_during_native_lora_output_allocation(layer, monkeypatch):
+    from art.megatron import lora as lora_module
+    from art.megatron.kernels import cute_grouped_lora_quack as kernel
+
+    fc2 = layer.experts.linear_fc2
+    rows = 16
+    x = torch.empty(rows, 512, dtype=torch.bfloat16)
+    counts = torch.zeros(256, dtype=torch.int64)
+    counts[0] = rows  # Imbalance does not reduce the total routed-row allocation.
+    a = torch.empty(256, 512, 1, dtype=x.dtype)
+    b = torch.empty(256, 1, 2048, dtype=x.dtype)
+    seen = {}
+
+    def base(value, _counts):
+        output = value.new_empty(rows, 2048)
+        seen["base"] = weakref.ref(output)
+        return output, None
+
+    def gemm(value, weights, output, residual, bias, **kwargs):
+        if output.shape[-1] == 2048:
+            base_output = seen["base"]()
+            assert base_output is not None
+            assert residual is None
+            assert (
+                base_output.untyped_storage()._cdata != output.untyped_storage()._cdata
+            )
+            seen["pair_bytes"] = base_output.nbytes + output.nbytes
+            assert value.shape == (rows, 8)  # Actual rank-1 padding path.
+
+    def adapter(_lora, value, tokens_per_expert, _width):
+        # Original Python allocation path; only CUDA validation/compute and
+        # distributed base-layer initialization are bypassed in this CPU witness.
+        return kernel._QuackGroupedLoraFn.forward(
+            SimpleNamespace(save_for_backward=lambda *args: None),
+            value,
+            a,
+            b,
+            tokens_per_expert,
+            1.0,
+            None,
+        )
+
+    monkeypatch.setattr(fc2.linear_fc2, "forward", base)
+    monkeypatch.setattr(lora_module, "_expert_grouped_lora_forward", adapter)
+    monkeypatch.setattr(kernel, "_quack_gemm", gemm)
+    output, bias = fc2(x, counts)
+    assert seen["pair_bytes"] == 2 * rows * 2048 * 2
+    assert output.shape == (rows, 2048) and bias is None
+    # Residual/output views are intentionally not covered by the capability.
+    monkeypatch.setattr(kernel, "_quack_gemm", lambda *args, **kwargs: None)
+    result = kernel._varlen_quack_gemm(
+        x,
+        b,
+        out_features=2048,
+        expert_offsets=torch.zeros(257, dtype=torch.int32),
+        tile_m=64,
+        tile_n=128,
+        residual=output,
+    )
+    assert result is output
+
+
+def test_memory_check_preserves_collective_order(monkeypatch):
+    import art.trainer_rank._impl as impl
+
+    rank = _rank()
+    rank._moe_output_bytes_per_token = 65536
+    rank._available_memory_bytes = lambda: 6_800_000_000
+    group = object()
+    rank._forward_memory_group = lambda: group
+    monkeypatch.setattr(impl.dist, "is_available", lambda: True)
+    monkeypatch.setattr(impl.dist, "is_initialized", lambda: True)
+    calls = []
+
+    def reduce(value, op, group):
+        calls.append((value.item(), op, group))
+
+    monkeypatch.setattr(impl.dist, "all_reduce", reduce)
+    estimate = rank._estimate_required_memory_bytes_from_values(
+        packed_tokens=106432,
+        output_bytes=0,
+        signature=_signature(),
+    )
+    assert calls == []
+    assert not rank._memory_check_required(estimate).fits
+    assert calls == [
+        (float(estimate), impl.dist.ReduceOp.MAX, group),
+        (6_800_000_000.0, impl.dist.ReduceOp.MIN, group),
+    ]

--- a/tests/unit/test_trainer_rank_split.py
+++ b/tests/unit/test_trainer_rank_split.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from contextlib import nullcontext
 from dataclasses import dataclass, replace
+import math
 import sys
 from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
@@ -966,38 +967,67 @@ def test_split_subforwards_track_independent_slot_graphs(
     rank._guard_checkpoint_can_step("teacher")
 
 
+@pytest.mark.parametrize("direction", (-math.inf, None, math.inf))
 def test_retained_ratio_bound_uses_original_guard_at_trusted_endpoint(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, direction: float | None
 ) -> None:
     rank = _retained_ratio_rank(monkeypatch)
-    tokens = (
-        torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
-        torch.tensor([0, 1, 8, 9, 10, 11, 12]),
-    )
-    original = [ForwardInput(input_tokens=t, target_tokens=t) for t in tokens]
+
+    def request(tokens: list[int], *, output: bool = True) -> ForwardInput:
+        values = torch.tensor(tokens)
+        return ForwardInput(
+            input_tokens=values, target_tokens=values if output else None
+        )
+
+    original = [
+        request([0, *range(1, 7)]),
+        request([0, *range(21, 27)]),
+        request([99], output=False),
+    ]
     observed = rank._plan_flat_forward(original, memory_minimal=True)
     assert (observed.packed_tokens, observed.logical_tokens) == (13, 15)
     rank._update_memory_profile(
-        observed, peak_delta_bytes=13 * 524288 + 60, retained_bytes=60
+        observed,
+        peak_delta_bytes=observed.output_bytes + 13,
+        retained_bytes=observed.output_bytes,
     )
-    requests = original * 64
-    plan = rank._plan_flat_forward(requests, memory_minimal=True)
-    profile = rank._memory_profiles[plan.signature]
+    requests = [
+        request([*range(24), *range(30, 58)]),
+        request([*range(24), *range(90, 118)]),
+        request(list(range(856)), output=False),
+    ]
+    minimal = rank._plan_flat_forward(requests, memory_minimal=True)
+    plan = rank._plan_flat_forward(requests)
+    profile = rank._memory_profiles[observed.signature]
     cap, limit = profile.packed_tokens * 8, profile.logical_per_packed * 8
-    assert (plan.packed_tokens, plan.logical_tokens, cap) == (13, 960, 104)
+    assert observed.signature == plan.signature
+    assert (minimal.packed_tokens, plan.packed_tokens, plan.logical_tokens) == (
+        80,
+        104,
+        960,
+    )
+    assert plan.packed_tokens == cap
     assert plan.logical_tokens / cap == limit
     # Rearranging the original comparison changes the answer at this equality.
     assert plan.logical_tokens / limit > cap
-    at_cap = rank._subforward_cost(
-        packed_tokens=cap,
-        logical_tokens=plan.logical_tokens,
-        output_bytes=plan.output_bytes,
-        signature=plan.signature,
+    if direction is not None:
+        rank._memory_profiles[plan.signature] = replace(
+            profile,
+            logical_per_packed=math.nextafter(profile.logical_per_packed, direction),
+        )
+    exact = rank._plan_cost(plan)
+    rows = [r.input_tokens for r in requests]
+    lower = rank._split_chunk_lower_cost(requests, rows, checkpoint=Unset)
+    assert (exact.retained < exact.required) == (direction != -math.inf)
+    assert (lower.retained < lower.required) == (direction != -math.inf)
+    assert lower.required <= exact.required and lower.retained <= exact.retained
+    exact_bytes = rank._split_rung_check([exact, exact]).estimated_required_bytes
+    monkeypatch.setattr(rank, "_available_memory_bytes", lambda: exact_bytes)
+    selected, check = rank._admit_split_rung(
+        [(0, 1, 2), (3, 4, 5)], requests * 2, rows * 2, checkpoint=Unset
     )
-    lower = rank._split_chunk_lower_cost(
-        requests, [r.input_tokens for r in requests], checkpoint=Unset
-    )
-    assert lower.retained == at_cap.retained == int(plan.output_bytes * 1.1)
+    assert selected is not None and check.fits
+    assert check.estimated_required_bytes == exact_bytes
 
 
 @pytest.mark.parametrize("retained", (None, 0, 2_000_000))

--- a/tests/unit/test_trainer_rank_split.py
+++ b/tests/unit/test_trainer_rank_split.py
@@ -573,12 +573,17 @@ def _retained_ratio_requests() -> list[ForwardInput]:
 
 
 @pytest.mark.parametrize("admit", (False, True))
+@pytest.mark.parametrize(("profile_packed", "budget_gib"), ((8000, 40), (1000, 20)))
 def test_retained_ratio_lower_bound_reaches_exact_split_admission(
-    monkeypatch: pytest.MonkeyPatch, admit: bool
+    monkeypatch: pytest.MonkeyPatch,
+    admit: bool,
+    profile_packed: int,
+    budget_gib: int,
 ) -> None:
     rank = _retained_ratio_rank(monkeypatch)
     # Actual packing: each child has 64k logical/no-sharing rows versus 4k
-    # full-sharing rows. The latter alone crosses the retained-ratio limit.
+    # full-sharing rows. The latter crosses the retained-ratio limit; the
+    # smaller profile also puts no-sharing beyond the packed-profile window.
     requests = _retained_ratio_requests()
     requests += [replace(request, no_grad=True) for request in requests]
     children = [rank._plan_flat_forward(requests[i : i + 16]) for i in (0, 16)]
@@ -586,11 +591,11 @@ def test_retained_ratio_lower_bound_reaches_exact_split_admission(
     rank._memory_profiles[parent.signature] = _MemoryProfile(16 * 131_072, 16_000)
     for child in children:
         rank._memory_profiles[child.signature] = _MemoryProfile(
-            4 * 131_072, 8000, retained_compute_bytes_per_token=128
+            4 * 131_072, profile_packed, retained_compute_bytes_per_token=128
         )
     costs = [rank._plan_cost(child) for child in children]
     exact_bytes = rank._split_rung_check(costs).estimated_required_bytes
-    budget = 40 * 2**30 if admit else exact_bytes - 1
+    budget = budget_gib * 2**30 if admit else exact_bytes - 1
     monkeypatch.setattr(rank, "_available_memory_bytes", lambda: budget)
     exact = rank._split_rung_check(costs)
     if admit:
@@ -666,12 +671,104 @@ def test_retained_ratio_lower_bound_preserves_exact_cost_and_trust_boundaries(
         requests, [request.input_tokens for request in requests], checkpoint=Unset
     )
     assert rank._plan_cost(plan) == exact
-    assert lower.required == exact.required
+    assert lower.required <= exact.required
     if relax:
         assert exact.retained == exact.required
         assert lower.retained == int(plan.output_bytes * 1.1) < exact.retained
     else:
-        assert lower == exact
+        assert lower.retained == min(exact.retained, lower.required)
+
+
+@pytest.mark.parametrize("profile_packed", (499, 500, 501, 1000, 7999, 8000, 8001))
+@pytest.mark.parametrize("retained_rate", (None, 128))
+def test_packed_profile_window_lower_bound_covers_both_cost_regimes(
+    monkeypatch: pytest.MonkeyPatch, profile_packed: int, retained_rate: float | None
+) -> None:
+    rank = _retained_ratio_rank(monkeypatch)
+    requests = _retained_ratio_requests()
+    minimal = rank._plan_flat_forward(requests, memory_minimal=True)
+    maximum = rank._plan_flat_forward(requests)
+    rank._memory_profiles[minimal.signature] = _MemoryProfile(
+        4 * 131_072, profile_packed, retained_compute_bytes_per_token=retained_rate
+    )
+    lower = rank._split_chunk_lower_cost(
+        requests, [request.input_tokens for request in requests], checkpoint=Unset
+    )
+    cap = profile_packed * 8
+    if cap >= maximum.packed_tokens:
+        # No legal layout crosses the packed cutoff: retain the tighter peak.
+        # Warm-only floating-point rounding is outside this correction.
+        assert lower.required == rank._plan_cost(minimal).required
+        return
+    # The full-sharing/no-sharing endpoints bound every legal layout. Price
+    # both sides of the discontinuity as well as hypothetical interior counts.
+    for packed in {4000, 4001, cap - 1, cap, cap + 1, cap + 2, 63_999, 64_000}:
+        if not minimal.packed_tokens <= packed <= maximum.packed_tokens:
+            continue
+        exact = rank._subforward_cost(
+            packed_tokens=packed,
+            logical_tokens=minimal.logical_tokens,
+            output_bytes=minimal.output_bytes,
+            signature=minimal.signature,
+        )
+        assert lower.required <= exact.required
+        assert lower.retained <= exact.retained
+        assert 0 <= lower.retained <= lower.required
+
+
+@pytest.mark.parametrize("profile_rate", (1.0, 4 * 131_072))
+def test_packed_profile_bound_handles_unattainable_tp_boundary_count(
+    monkeypatch: pytest.MonkeyPatch, profile_rate: float
+) -> None:
+    rank = _retained_ratio_rank(monkeypatch)
+    monkeypatch.setattr(rank, "_topology_key", lambda: (1, 4, 1, 1))
+    tokens = torch.arange(7)
+    requests = [
+        ForwardInput(input_tokens=tokens, target_tokens=tokens) for _ in range(16)
+    ]
+    minimal = rank._plan_flat_forward(requests, memory_minimal=True)
+    assert (minimal.packed_tokens, minimal.logical_tokens) == (8, 112)
+    rank._memory_profiles[minimal.signature] = _MemoryProfile(profile_rate, 4)
+    lower = rank._split_chunk_lower_cost(requests, [tokens] * 16, checkpoint=Unset)
+    # The cutoff is32. A hypothetical cold count33 is cheaper than the first
+    # physically possible post-cutoff count36, so it remains a valid bound.
+    for packed in range(8, 113, 4):
+        exact = rank._subforward_cost(
+            packed_tokens=packed,
+            logical_tokens=112,
+            output_bytes=minimal.output_bytes,
+            signature=minimal.signature,
+        )
+        assert lower.required <= exact.required
+        assert lower.retained <= exact.retained
+    if profile_rate == 1.0:
+        assert lower == rank._plan_cost(minimal)
+
+
+def test_packed_profile_bound_counts_each_groups_tp_padding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rank = _retained_ratio_rank(monkeypatch)
+    monkeypatch.setattr(rank, "_topology_key", lambda: (1, 8, 1, 1))
+    first, second = torch.arange(5), torch.arange(3)
+    requests = [
+        ForwardInput(input_tokens=first, target_tokens=first) for _ in range(13)
+    ] + [
+        ForwardInput(input_tokens=second, target_tokens=second, no_grad=True)
+        for _ in range(19)
+    ]
+    minimal = rank._plan_flat_forward(requests, memory_minimal=True)
+    maximum = rank._plan_flat_forward(requests)
+    assert (minimal.packed_tokens, minimal.logical_tokens) == (16, 122)
+    assert maximum.packed_tokens == 72 + 64
+    rank._memory_profiles[minimal.signature] = _MemoryProfile(4 * 131_072, 16)
+    # Logical122 is below cap128, but independent group padding permits136.
+    lower = rank._split_chunk_lower_cost(
+        requests, [request.input_tokens for request in requests], checkpoint=Unset
+    )
+    exact = rank._plan_cost(maximum)
+    assert lower.required <= exact.required < rank._plan_cost(minimal).required
+    assert lower.retained <= exact.retained
 
 
 @pytest.mark.parametrize("empty", (False, True))

--- a/tests/unit/test_trainer_rank_split.py
+++ b/tests/unit/test_trainer_rank_split.py
@@ -697,9 +697,7 @@ def test_packed_profile_window_lower_bound_covers_both_cost_regimes(
     cap = profile_packed * 8
     if cap >= maximum.packed_tokens:
         # No legal layout crosses the packed cutoff: retain the tighter peak.
-        # Warm-only floating-point rounding is outside this correction.
         assert lower.required == rank._plan_cost(minimal).required
-        return
     # The full-sharing/no-sharing endpoints bound every legal layout. Price
     # both sides of the discontinuity as well as hypothetical interior counts.
     for packed in {4000, 4001, cap - 1, cap, cap + 1, cap + 2, 63_999, 64_000}:
@@ -1000,3 +998,63 @@ def test_retained_ratio_bound_uses_original_guard_at_trusted_endpoint(
         requests, [r.input_tokens for r in requests], checkpoint=Unset
     )
     assert lower.retained == at_cap.retained == int(plan.output_bytes * 1.1)
+
+
+@pytest.mark.parametrize("retained", (None, 0, 2_000_000))
+@pytest.mark.parametrize("admit", (False, True))
+def test_warm_rounding_preserves_native_split_bound_and_exact_budget(
+    monkeypatch: pytest.MonkeyPatch, retained: int | None, admit: bool
+) -> None:
+    rank = _retained_ratio_rank(monkeypatch)
+    tokens = torch.arange(3)
+    part = [ForwardInput(input_tokens=tokens, target_tokens=tokens) for _ in range(5)]
+    requests = part + [replace(request, no_grad=True) for request in part]
+    chunks = [tuple(range(5)), tuple(range(5, 10))]
+    rows = [request.input_tokens for request in requests]
+    children = [rank._plan_flat_forward(requests[a : a + 5]) for a in (0, 5)]
+    assert [plan.packed_tokens for plan in children] == [15, 15]
+    for plan in children:
+        # The real profile update divides an observed integer peak by packed
+        # rows; the prior warm formula differs by two bytes at native N=3/15.
+        rank._update_memory_profile(
+            plan, peak_delta_bytes=7_864_390, retained_bytes=retained
+        )
+    costs = [rank._plan_cost(plan) for plan in children]
+    lower = [
+        rank._split_chunk_lower_cost(
+            requests[a : a + 5], rows[a : a + 5], checkpoint=Unset
+        )
+        for a in (0, 5)
+    ]
+    assert lower == costs
+    exact_bytes = rank._split_rung_check(costs).estimated_required_bytes
+    monkeypatch.setattr(
+        rank, "_available_memory_bytes", lambda: exact_bytes - (not admit)
+    )
+    split, check = rank._admit_split_rung(chunks, requests, rows, checkpoint=Unset)
+    assert check.estimated_required_bytes == exact_bytes and check.fits == admit
+    assert (split is not None) == admit
+
+
+@pytest.mark.parametrize("retained", (None, 0, 7864321 / 15))
+def test_normalized_warm_profile_is_monotone_through_ratio_floor(
+    monkeypatch: pytest.MonkeyPatch, retained: float | None
+) -> None:
+    rank = _retained_ratio_rank(monkeypatch)
+    signature = rank._plan_flat_forward([_request(0)]).signature
+    rank._memory_profiles[signature] = _MemoryProfile(
+        7864330 / 15, 1000, 15 / 13, retained_compute_bytes_per_token=retained
+    )
+    # All counts satisfy the retained guard. The logical term dominates until
+    # N=104, then packed-token growth dominates. Check every integer count.
+    costs = [
+        rank._subforward_cost(
+            packed_tokens=packed,
+            logical_tokens=120,
+            output_bytes=481,
+            signature=signature,
+        )
+        for packed in range(13, 201)
+    ]
+    assert all(a.required <= b.required for a, b in zip(costs, costs[1:]))
+    assert all(a.retained <= b.retained for a, b in zip(costs, costs[1:]))

--- a/tests/unit/test_trainer_rank_split.py
+++ b/tests/unit/test_trainer_rank_split.py
@@ -13,9 +13,9 @@ and expected to FAIL on the pre-split tree. Contract, as agreed:
   subforward plus the current transient peak. Until a retained-bytes profile
   exists, retained memory is conservatively the full estimate; a profile is
   trusted only near the scale it was observed at.
-- Failed rungs are rejected with cheap bounds; the planner runs only for the
-  rung that executes. Ensuring checkpoint slots is a collective, so it happens
-  exactly once per call regardless of how many rungs this rank tries.
+- Failed rungs use cheap bounds where possible; uncertain retained-profile
+  costs still need exact planning. Ensuring checkpoint slots is a collective,
+  so it happens exactly once regardless of how many rungs this rank tries.
 - Split execution creates an independent slot-graph sentinel per subforward,
   and any execution-time failure of an admitted split is reported as
   ``TrainerRankPartialExecutionError``.
@@ -49,7 +49,13 @@ from art.trainer_rank import (
     TrainerRankPartialExecutionError,
     TrainerRankSlotStateError,
 )
-from art.trainer_rank._impl import _FlatForwardPlan, _MemoryCheck, _MemoryProfile
+from art.trainer_rank._impl import (
+    Unset,
+    _FlatForwardPlan,
+    _MemoryCheck,
+    _MemoryProfile,
+    _SplitForwardPlan,
+)
 
 if TYPE_CHECKING:
     from art.megatron.lora import LoRASlotRef
@@ -544,6 +550,167 @@ def test_retained_compute_keeps_growth_and_sharing_trust_limits(
         assert observed.retained < observed.required
     else:
         assert observed.retained == observed.required
+
+
+def _retained_ratio_rank(monkeypatch: pytest.MonkeyPatch) -> TrainerRank:
+    rank = _rank(monkeypatch)
+    rank._hidden_size, rank._param_dtype_size, rank._num_layers = 4096, 2, 48
+    monkeypatch.setattr(
+        rank,
+        "_layout_anchor",
+        lambda *, memory_minimal=False: (
+            "full_sharing" if memory_minimal else "no_sharing"
+        ),
+    )
+    return rank
+
+
+def _retained_ratio_requests() -> list[ForwardInput]:
+    tokens = torch.arange(4000) % 31
+    labels = torch.full_like(tokens, -100)
+    labels[-1] = 1
+    return [ForwardInput(input_tokens=tokens, target_tokens=labels) for _ in range(16)]
+
+
+@pytest.mark.parametrize("admit", (False, True))
+def test_retained_ratio_lower_bound_reaches_exact_split_admission(
+    monkeypatch: pytest.MonkeyPatch, admit: bool
+) -> None:
+    rank = _retained_ratio_rank(monkeypatch)
+    # Actual packing: each child has 64k logical/no-sharing rows versus 4k
+    # full-sharing rows. The latter alone crosses the retained-ratio limit.
+    requests = _retained_ratio_requests()
+    requests += [replace(request, no_grad=True) for request in requests]
+    children = [rank._plan_flat_forward(requests[i : i + 16]) for i in (0, 16)]
+    parent = rank._plan_flat_forward(requests)
+    rank._memory_profiles[parent.signature] = _MemoryProfile(16 * 131_072, 16_000)
+    for child in children:
+        rank._memory_profiles[child.signature] = _MemoryProfile(
+            4 * 131_072, 8000, retained_compute_bytes_per_token=128
+        )
+    costs = [rank._plan_cost(child) for child in children]
+    exact_bytes = rank._split_rung_check(costs).estimated_required_bytes
+    budget = 40 * 2**30 if admit else exact_bytes - 1
+    monkeypatch.setattr(rank, "_available_memory_bytes", lambda: budget)
+    exact = rank._split_rung_check(costs)
+    if admit:
+        plan, check = rank._plan_admissible_forward(
+            requests, checkpoint=Unset, context="test"
+        )
+        assert isinstance(plan, _SplitForwardPlan) and plan.subforward_count == 2
+        assert check == exact
+        assert sorted(
+            index for chunk in plan.request_indices for index in chunk
+        ) == list(range(32))
+    lower = rank._split_rung_check(
+        [
+            rank._split_chunk_lower_cost(
+                requests[i : i + 16],
+                [request.input_tokens for request in requests[i : i + 16]],
+                checkpoint=Unset,
+            )
+            for i in (0, 16)
+        ]
+    )
+    assert [child.packed_tokens for child in children] == [64_000, 64_000]
+    assert lower.estimated_required_bytes <= exact.estimated_required_bytes
+    assert lower.fits and exact.fits == admit
+    if not admit:
+        # The optimistic bound survives, but exact pricing must reject this
+        # rung. A later rung with smaller chunks may still fit this budget.
+        split, rejected = rank._admit_split_rung(
+            [tuple(range(16)), tuple(range(16, 32))],
+            requests,
+            [request.input_tokens for request in requests],
+            checkpoint=Unset,
+        )
+        assert split is None and not rejected.fits
+
+
+@pytest.mark.parametrize(
+    ("profile_packed", "profile_ratio", "retained_rate", "relax"),
+    [
+        (999, 1.0, 0, False),  # The two trust windows do not overlap.
+        (1000, 1.0, 0, True),  # Packed=8000 can satisfy both limits exactly.
+        (1001, 1.0, 128, True),
+        (1000, 1.99, 128, True),
+        (1000, 2.0, 128, False),  # Full sharing itself is trusted at equality.
+        (1000, 2.01, 128, False),
+        (1000, 1.0, None, False),  # No retained observation to trust elsewhere.
+    ],
+)
+@pytest.mark.parametrize("hidden_states", (False, True))
+def test_retained_ratio_lower_bound_preserves_exact_cost_and_trust_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    profile_packed: int,
+    profile_ratio: float,
+    retained_rate: float | None,
+    relax: bool,
+    hidden_states: bool,
+) -> None:
+    rank = _retained_ratio_rank(monkeypatch)
+    requests = [
+        replace(request, hidden_states=hidden_states)
+        for request in _retained_ratio_requests()
+    ]
+    plan = rank._plan_flat_forward(requests, memory_minimal=True)
+    assert (plan.packed_tokens, plan.logical_tokens) == (4000, 64_000)
+    rank._memory_profiles[plan.signature] = _MemoryProfile(
+        4 * 131_072,
+        profile_packed,
+        profile_ratio,
+        retained_compute_bytes_per_token=retained_rate,
+    )
+    exact = rank._plan_cost(plan)
+    lower = rank._split_chunk_lower_cost(
+        requests, [request.input_tokens for request in requests], checkpoint=Unset
+    )
+    assert rank._plan_cost(plan) == exact
+    assert lower.required == exact.required
+    if relax:
+        assert exact.retained == exact.required
+        assert lower.retained == int(plan.output_bytes * 1.1) < exact.retained
+    else:
+        assert lower == exact
+
+
+@pytest.mark.parametrize("empty", (False, True))
+def test_retained_ratio_lower_bound_without_profile_or_tokens(
+    monkeypatch: pytest.MonkeyPatch, empty: bool
+) -> None:
+    rank = _retained_ratio_rank(monkeypatch)
+    requests = [] if empty else _retained_ratio_requests()
+    plan = rank._plan_flat_forward(requests, memory_minimal=True)
+    cost = rank._plan_cost(plan)
+    lower = rank._split_chunk_lower_cost(
+        requests, [request.input_tokens for request in requests], checkpoint=Unset
+    )
+    assert lower == cost and lower.retained == lower.required
+    if empty:
+        assert lower.required == 0
+
+
+def test_retained_ratio_original_cost_witness_stays_conservative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rank = _retained_ratio_rank(monkeypatch)
+    signature = rank._plan_flat_forward([_request(0)]).signature
+    rank._memory_profiles[signature] = _MemoryProfile(
+        4 * 131_072, 1000, retained_compute_bytes_per_token=0
+    )
+    small, large = [
+        rank._subforward_cost(
+            packed_tokens=packed,
+            logical_tokens=64_000,
+            output_bytes=10_000,
+            signature=signature,
+        )
+        for packed in (4000, 8000)
+    ]
+    # Exact retention keeps its conservative fallback. Only treating that
+    # fallback as an optimistic split-search bound was incorrect.
+    assert small.required == large.required == 36_909_886_200
+    assert small.retained == small.required and large.retained == 11_000
 
 
 @pytest.mark.parametrize("failing_ordinal", (0, 1))

--- a/tests/unit/test_trainer_rank_split.py
+++ b/tests/unit/test_trainer_rank_split.py
@@ -966,3 +966,37 @@ def test_split_subforwards_track_independent_slot_graphs(
     loss(second).backward()
     rank._guard_slot_can_load(ref)
     rank._guard_checkpoint_can_step("teacher")
+
+
+def test_retained_ratio_bound_uses_original_guard_at_trusted_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rank = _retained_ratio_rank(monkeypatch)
+    tokens = (
+        torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
+        torch.tensor([0, 1, 8, 9, 10, 11, 12]),
+    )
+    original = [ForwardInput(input_tokens=t, target_tokens=t) for t in tokens]
+    observed = rank._plan_flat_forward(original, memory_minimal=True)
+    assert (observed.packed_tokens, observed.logical_tokens) == (13, 15)
+    rank._update_memory_profile(
+        observed, peak_delta_bytes=13 * 524288 + 60, retained_bytes=60
+    )
+    requests = original * 64
+    plan = rank._plan_flat_forward(requests, memory_minimal=True)
+    profile = rank._memory_profiles[plan.signature]
+    cap, limit = profile.packed_tokens * 8, profile.logical_per_packed * 8
+    assert (plan.packed_tokens, plan.logical_tokens, cap) == (13, 960, 104)
+    assert plan.logical_tokens / cap == limit
+    # Rearranging the original comparison changes the answer at this equality.
+    assert plan.logical_tokens / limit > cap
+    at_cap = rank._subforward_cost(
+        packed_tokens=cap,
+        logical_tokens=plan.logical_tokens,
+        output_bytes=plan.output_bytes,
+        signature=plan.signature,
+    )
+    lower = rank._split_chunk_lower_cost(
+        requests, [r.input_tokens for r in requests], checkpoint=Unset
+    )
+    assert lower.retained == at_cap.retained == int(plan.output_bytes * 1.1)


### PR DESCRIPTION
A cold MoE forward can omit expert output-buffer costs from its admission estimate, while split-search pruning can skip feasible layouts across learned-profile trust boundaries. Account for supported FC2 base/LoRA buffers and make the pruning bound valid across retained-ratio and packed-token cutoffs, including physical padding.

Use the original retained-trust predicate at boundaries and normalize warm arithmetic to preserve monotonicity despite floating-point cancellation. This keeps the real-number pricing policy; exact estimated bytes and boundary admissions can change. Final exact layout pricing remains required. The cold component is restricted to recognized TP1/CP1 unsharded MoE paths and is not a total peak-memory guarantee.

Runtime changes are limited to `art.trainer_rank`, with no public `TrainerRank` API or `art.megatron` changes. Both independent reviewers clear the current head. Validation includes 287 adjacent CPU tests, native exact/one-byte-below and nextafter regressions, independent split/property comparisons, and clean scoped typing/Ruff/format checks. Hosted two-H200 qualification passed at exact head `bd656b823`: 61 GPU tests / 1 four-GPU-only skip, plus CP2 and TP2 public-API smokes. Quality checks are green. The successful same-head retry and the preceding attached-log transport failure are both preserved; the latter is tracked separately in #878. Exact owned pods, services and supervision processes were independently confirmed absent after cleanup.

Related to #848; broader admission correctness remains open.

