### PR TITLE
Decouple TrainerRank CI results from attached log transport

### DIFF
--- a/.github/workflows/trainer-rank-gpu.yml
+++ b/.github/workflows/trainer-rank-gpu.yml
@@ -134,6 +134,8 @@ jobs:
           YAML
 
       - name: Run TrainerRank GPU validation
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.classify.outputs.head_sha }}
         run: |
           set -euo pipefail
           sky_venv="${RUNNER_TEMP}/skypilot"
@@ -145,9 +147,16 @@ jobs:
           cleanup() { "${sky}" down -y "${cluster}" || true; }
           trap cleanup EXIT
           "${sky}" check kubernetes
-          "${sky}" launch -y -c "${cluster}" \
-            --infra "${SKY_INFRA}" \
-            scripts/ci/trainer-rank-gpu.sky.yaml
+          "${sky_venv}/bin/python" scripts/ci/trainer-rank-gpu.py \
+            "${RUNNER_TEMP}/trainer-rank-result"
+
+      - name: Preserve remote result and diagnostic logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trainer-rank-result-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/trainer-rank-result
+          if-no-files-found: warn
 
   gate:
     name: trainer-rank-gpu-validation

--- a/scripts/ci/trainer-rank-gpu.py
+++ b/scripts/ci/trainer-rank-gpu.py
@@ -53,7 +53,11 @@ def worker(root, operation):
         try:
             write_json(root / "request.json", {**owner, "request_id": request_id})
             job_id, handle = sky.get(request_id)
-            if type(job_id) is not int or job_id < 1 or handle.cluster_name != cluster:
+            if (
+                type(job_id) is not int
+                or job_id < 1
+                or getattr(handle, "cluster_name", None) != cluster
+            ):
                 raise ValueError(
                     "Sky launch returned a different cluster or invalid job ID"
                 )
@@ -121,33 +125,61 @@ def run_child(command, timeout, output):
     if timeout <= 0:
         raise TimeoutError("CI remote-result deadline reached")
     with output.open("ab") as stream:
-        process = subprocess.Popen(
-            command, stdout=stream, stderr=subprocess.STDOUT, start_new_session=True
-        )
-        original = None
+        interruption = None
+
+        def defer_interrupt(signum, frame):
+            nonlocal interruption
+            if interruption is None:
+                interruption = InterruptedError(f"CI interrupted by signal {signum}")
+
+        # Recording instead of raising also covers interruption *inside* Popen,
+        # before its process handle is returned. Unlike masking, this does not
+        # leave SIGINT/SIGTERM blocked in the exec'd SDK worker.
+        handlers = {
+            sig: signal.getsignal(sig) for sig in (signal.SIGINT, signal.SIGTERM)
+        }
         try:
-            deadline = time.monotonic() + timeout
-            # WNOWAIT observes exit without freeing the PID/PGID for reuse.
-            while (
-                os.waitid(os.P_PID, process.pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
-                is None
-            ):
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    raise subprocess.TimeoutExpired(command, timeout)
-                time.sleep(min(0.05, remaining))
-        except BaseException as error:
-            original = error
-        try:
-            code = finish_child(process)
-        except BaseException as cleanup_error:
+            for sig in handlers:
+                signal.signal(sig, defer_interrupt)
+            if interruption is not None:
+                raise interruption
+            process = subprocess.Popen(
+                command, stdout=stream, stderr=subprocess.STDOUT, start_new_session=True
+            )
+            original = None
+            try:
+                deadline = time.monotonic() + timeout
+                # WNOWAIT observes exit without freeing the PID/PGID for reuse.
+                while (
+                    os.waitid(
+                        os.P_PID, process.pid, os.WEXITED | os.WNOHANG | os.WNOWAIT
+                    )
+                    is None
+                ):
+                    if interruption is not None:
+                        raise interruption
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise subprocess.TimeoutExpired(command, timeout)
+                    time.sleep(min(0.05, remaining))
+            except BaseException as error:
+                original = error
+            try:
+                code = finish_child(process)
+            except BaseException as cleanup_error:
+                if original is not None:
+                    raise original from cleanup_error
+                raise
             if original is not None:
-                raise original from cleanup_error
-            raise
-        if original is not None:
-            raise original
-        if code:
-            raise subprocess.CalledProcessError(code, command)
+                raise original
+            if interruption is not None:
+                raise interruption
+            if code:
+                raise subprocess.CalledProcessError(code, command)
+        finally:
+            # Repeated interrupts cannot abort mandatory group retirement.
+            for sig, handler in handlers.items():
+                signal.signal(sig, handler)
 
 
 def run_worker(root, operation, timeout):

--- a/scripts/ci/trainer-rank-gpu.py
+++ b/scripts/ci/trainer-rank-gpu.py
@@ -1,0 +1,229 @@
+"""Run the CI job without making an attached log stream its result gate.
+
+SkyPilot 0.12 returns an actual job ID from launch. Each SDK operation runs in a
+bounded child; only that job's SUCCEEDED status passes. The workflow EXIT trap
+still owns cluster teardown, including launch failures before a job ID is known.
+"""
+
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+
+NONTERMINAL = {"INIT", "PENDING", "SETTING_UP", "RUNNING"}
+EXIT_CODES = {
+    "SUCCEEDED": 0,
+    "FAILED": 100,
+    "FAILED_SETUP": 100,
+    "FAILED_DRIVER": 100,
+    "CANCELLED": 103,
+    None: 102,
+}
+
+
+def write_json(path, data):
+    temporary = path.with_suffix(".tmp")
+    with temporary.open("w") as stream:
+        json.dump(data, stream, indent=2)
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    temporary.replace(path)
+
+
+def read_bound(root, filename, owner):
+    data = json.loads((root / filename).read_text())
+    if any(data.get(key) != value for key, value in owner.items()):
+        raise ValueError(f"Wrong CI identity in {filename}")
+    return data
+
+
+def worker(root, operation):
+    import sky
+
+    owner = json.loads((root / "owner.json").read_text())
+    cluster = owner["cluster"]
+    if operation == "launch":
+        task = sky.Task.from_yaml("scripts/ci/trainer-rank-gpu.sky.yaml")
+        task.set_resources_override({"infra": "k8s/cks-wb3"})
+        request_id = sky.launch(task, cluster_name=cluster, retry_until_up=False)
+        try:
+            write_json(root / "request.json", {**owner, "request_id": request_id})
+            job_id, handle = sky.get(request_id)
+            if type(job_id) is not int or job_id < 1 or handle.cluster_name != cluster:
+                raise ValueError(
+                    "Sky launch returned a different cluster or invalid job ID"
+                )
+            write_json(root / "job.json", {**owner, "job_id": job_id})
+        except BaseException:
+            try:
+                sky.get(sky.api_cancel(request_ids=[request_id]))
+            except Exception as error:
+                print(
+                    f"Launch request cancellation also failed: {error}", file=sys.stderr
+                )
+            raise
+        return
+    if operation == "cancel_request":
+        request = read_bound(root, "request.json", owner)["request_id"]
+        sky.get(sky.api_cancel(request_ids=[request]))
+        return
+    job_id = read_bound(root, "job.json", owner)["job_id"]
+    if operation == "status":
+        statuses = sky.get(sky.job_status(cluster, job_ids=[job_id]))
+        if set(statuses) != {job_id}:
+            raise ValueError("Sky returned a different job's status")
+        value = statuses[job_id]
+        status = None if value is None else value.value
+        if status not in NONTERMINAL and status not in EXIT_CODES:
+            raise ValueError(f"Unknown Sky job status: {status}")
+        write_json(root / "status.json", {**owner, "job_id": job_id, "status": status})
+    elif operation == "cancel":
+        sky.get(sky.cancel(cluster, job_ids=[job_id]))
+    elif operation == "logs":
+        # Diagnostic retrieval has a separate timeout and never follows the job.
+        sys.exit(sky.tail_logs(cluster, job_id=job_id, follow=False))
+    else:
+        raise ValueError(operation)
+
+
+def run_child(command, timeout, output):
+    if timeout <= 0:
+        raise TimeoutError("CI remote-result deadline reached")
+    with output.open("ab") as stream:
+        process = subprocess.Popen(
+            command, stdout=stream, stderr=subprocess.STDOUT, start_new_session=True
+        )
+        try:
+            code = process.wait(timeout=timeout)
+        except BaseException:
+            # The unreaped direct child reserves this process-group identity.
+            if process.returncode is None:
+                try:
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    process.wait(timeout=5)
+                except Exception as cleanup_error:
+                    print(
+                        f"Child cleanup also failed: {cleanup_error}", file=sys.stderr
+                    )
+            raise
+        if code:
+            raise subprocess.CalledProcessError(code, command)
+
+
+def run_worker(root, operation, timeout):
+    run_child(
+        [sys.executable, str(Path(__file__).resolve()), "worker", str(root), operation],
+        timeout,
+        root / f"{operation}.log",
+    )
+
+
+def supervise(root, owner, timeout=35 * 60, poll_seconds=10):
+    deadline = time.monotonic() + timeout
+    remote_status = None
+    terminal = False
+    job = None
+    errors = 0
+    try:
+        run_worker(root, "launch", deadline - time.monotonic())
+        job = read_bound(root, "job.json", owner)
+        while True:
+            try:
+                run_worker(root, "status", min(30, deadline - time.monotonic()))
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+                errors += 1
+                print(f"Status query failed ({errors}/3): {error}", flush=True)
+                if errors >= 3:
+                    raise
+            else:
+                observed = read_bound(root, "status.json", job)
+                remote_status = observed["status"]
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("CI remote-result deadline reached")
+                errors = 0
+                print(f"Job {job['job_id']}: {remote_status}", flush=True)
+                if remote_status in EXIT_CODES:
+                    terminal = remote_status is not None
+                    write_json(root / "result.json", observed)
+                    return EXIT_CODES[remote_status]
+                if remote_status not in NONTERMINAL:
+                    raise ValueError(f"Unknown Sky job status: {remote_status}")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("CI remote-result deadline reached")
+            time.sleep(min(poll_seconds, remaining))
+    except BaseException as error:
+        try:
+            write_json(
+                root / "failure.json",
+                {**owner, "remote_status": remote_status, "error": repr(error)},
+            )
+        except Exception as receipt_error:
+            print(f"Failure receipt also failed: {receipt_error}", file=sys.stderr)
+        raise
+    finally:
+        # Also recover the exact ID if a receipt read failed after launch.
+        # No guessed/latest job is ever cancelled. The outer trap handles unknown ID.
+        if job is None:
+            try:
+                job = read_bound(root, "job.json", owner)
+            except Exception:
+                pass
+        operations = (["cancel"] if not terminal else []) + ["logs"] if job else []
+        if job is None and (root / "request.json").exists():
+            operations = ["cancel_request"]
+        outcomes = {}
+        for operation in operations:
+            try:
+                run_worker(root, operation, 30)
+                outcomes[operation] = {"success": True}
+            except Exception as error:
+                outcomes[operation] = {"success": False, "error": repr(error)}
+                print(f"::warning::{operation} failed: {error}", flush=True)
+        try:
+            write_json(root / "diagnostics.json", {**owner, "operations": outcomes})
+        except Exception as error:
+            print(f"::warning::Diagnostic receipt failed: {error}", flush=True)
+
+
+def main(root):
+    root.mkdir(parents=True, exist_ok=False)
+    run_id, attempt = os.environ["GITHUB_RUN_ID"], os.environ["GITHUB_RUN_ATTEMPT"]
+    if not run_id.isdecimal() or not attempt.isdecimal():
+        raise ValueError("Expected numeric GitHub run ID and attempt")
+    if os.environ["SKY_INFRA"] != "k8s/cks-wb3":
+        raise ValueError("TrainerRank CI requires free cks-wb3")
+    owner = {
+        "run_id": run_id,
+        "attempt": attempt,
+        "head": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+        "cluster": f"trainer-rank-gpu-{run_id}-{attempt}",
+        "repository": os.environ["GITHUB_REPOSITORY"],
+        "event": os.environ["GITHUB_EVENT_NAME"],
+    }
+    if owner["head"] != os.environ["EXPECTED_HEAD_SHA"]:
+        raise ValueError("Checkout differs from classified CI head")
+    write_json(root / "owner.json", owner)
+
+    def interrupted(signum, frame):
+        raise InterruptedError(f"CI interrupted by signal {signum}")
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(signum, interrupted)
+    return supervise(root, owner)
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "worker":
+        worker(Path(sys.argv[2]), sys.argv[3])
+    else:
+        sys.exit(main(Path(sys.argv[1])))

--- a/scripts/ci/trainer-rank-gpu.py
+++ b/scripts/ci/trainer-rank-gpu.py
@@ -90,6 +90,33 @@ def worker(root, operation):
         raise ValueError(operation)
 
 
+def finish_child(process):
+    """Keep the unreaped Linux child as the group identity until cleanup finishes."""
+    deadline = time.monotonic() + 5
+    while True:
+        # If another reaper consumed the child, fail without signaling a number
+        # whose identity is no longer reserved by this parent.
+        os.waitid(os.P_PID, process.pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        alive = False
+        for path in Path("/proc").glob("[0-9]*/stat"):
+            try:
+                fields = path.read_text().rsplit(") ", 1)[1].split()
+            except FileNotFoundError:
+                continue
+            if int(fields[2]) == process.pid and fields[0] != "Z":
+                alive = True
+                break
+        if not alive:
+            return process.wait(timeout=max(0.001, deadline - time.monotonic()))
+        if time.monotonic() >= deadline:
+            raise TimeoutError("SDK worker process group did not stop")
+        time.sleep(0.01)
+
+
 def run_child(command, timeout, output):
     if timeout <= 0:
         raise TimeoutError("CI remote-result deadline reached")
@@ -97,22 +124,28 @@ def run_child(command, timeout, output):
         process = subprocess.Popen(
             command, stdout=stream, stderr=subprocess.STDOUT, start_new_session=True
         )
+        original = None
         try:
-            code = process.wait(timeout=timeout)
-        except BaseException:
-            # The unreaped direct child reserves this process-group identity.
-            if process.returncode is None:
-                try:
-                    try:
-                        os.killpg(process.pid, signal.SIGKILL)
-                    except ProcessLookupError:
-                        pass
-                    process.wait(timeout=5)
-                except Exception as cleanup_error:
-                    print(
-                        f"Child cleanup also failed: {cleanup_error}", file=sys.stderr
-                    )
+            deadline = time.monotonic() + timeout
+            # WNOWAIT observes exit without freeing the PID/PGID for reuse.
+            while (
+                os.waitid(os.P_PID, process.pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+                is None
+            ):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise subprocess.TimeoutExpired(command, timeout)
+                time.sleep(min(0.05, remaining))
+        except BaseException as error:
+            original = error
+        try:
+            code = finish_child(process)
+        except BaseException as cleanup_error:
+            if original is not None:
+                raise original from cleanup_error
             raise
+        if original is not None:
+            raise original
         if code:
             raise subprocess.CalledProcessError(code, command)
 

--- a/tests/unit/test_trainer_rank_gpu_ci.py
+++ b/tests/unit/test_trainer_rank_gpu_ci.py
@@ -15,6 +15,7 @@ import pytest
 
 SCRIPT = Path(__file__).parents[2] / "scripts/ci/trainer-rank-gpu.py"
 spec = importlib.util.spec_from_file_location("trainer_rank_gpu_ci", SCRIPT)
+assert spec is not None and spec.loader is not None
 ci = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(ci)
 

--- a/tests/unit/test_trainer_rank_gpu_ci.py
+++ b/tests/unit/test_trainer_rank_gpu_ci.py
@@ -371,3 +371,62 @@ def tail_logs(cluster, *, job_id, follow):
     assert result.returncode == 0, result.stderr
     assert json.loads((root / "result.json").read_text())["job_id"] == 17
     assert "fake complete log" in (root / "logs.log").read_text()
+
+
+@pytest.mark.parametrize("code", [0, 17])
+def test_early_worker_exit_stops_descendant_before_reaping_leader(tmp_path, code):
+    import ctypes
+
+    libc = ctypes.CDLL(None)
+    previous = ctypes.c_int()
+    assert libc.prctl(37, ctypes.byref(previous), 0, 0, 0) == 0
+    assert libc.prctl(36, 1, 0, 0, 0) == 0
+    receipt = tmp_path / "child.json"
+    program = """
+import json,os,pathlib,signal,sys,time
+child=os.fork()
+if child==0:
+    signal.signal(signal.SIGTERM,signal.SIG_IGN)
+    pathlib.Path(sys.argv[1]).write_text(json.dumps({'pid':os.getpid(),'pgid':os.getpgrp()}))
+    time.sleep(60)
+    os._exit(0)
+while not pathlib.Path(sys.argv[1]).exists():time.sleep(.005)
+os._exit(int(sys.argv[2]))
+"""
+    info = None
+    try:
+        command = [sys.executable, "-c", program, str(receipt), str(code)]
+        if code:
+            with pytest.raises(subprocess.CalledProcessError) as raised:
+                ci.run_child(command, 1, tmp_path / "out.log")
+            assert raised.value.returncode == code
+        else:
+            ci.run_child(command, 1, tmp_path / "out.log")
+        info = json.loads(receipt.read_text())
+        stat = Path(f"/proc/{info['pid']}/stat")
+        assert (
+            not stat.exists() or stat.read_text().rsplit(") ", 1)[1].split()[0] == "Z"
+        )
+        assert not Path(f"/proc/{info['pgid']}").exists()
+    finally:
+        if info is None and receipt.exists():
+            info = json.loads(receipt.read_text())
+        if info:
+            try:
+                os.kill(info["pid"], signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            try:
+                os.waitpid(info["pid"], 0)
+            except ChildProcessError:
+                pass
+        assert libc.prctl(36, previous.value, 0, 0, 0) == 0
+
+
+def test_lost_waitable_child_identity_never_signals_group(monkeypatch):
+    monkeypatch.setattr(ci.os, "waitid", Mock(side_effect=ChildProcessError))
+    kill = Mock()
+    monkeypatch.setattr(ci.os, "killpg", kill)
+    with pytest.raises(ChildProcessError):
+        ci.finish_child(NS(pid=42))
+    kill.assert_not_called()

--- a/tests/unit/test_trainer_rank_gpu_ci.py
+++ b/tests/unit/test_trainer_rank_gpu_ci.py
@@ -1,0 +1,373 @@
+"""No Sky service or GPU calls: exercise the real CI driver at its SDK boundary."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+from types import SimpleNamespace as NS
+from unittest.mock import Mock
+
+import pytest
+
+SCRIPT = Path(__file__).parents[2] / "scripts/ci/trainer-rank-gpu.py"
+spec = importlib.util.spec_from_file_location("trainer_rank_gpu_ci", SCRIPT)
+ci = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ci)
+
+
+@pytest.fixture
+def owner(tmp_path):
+    value = {"cluster": "trainer-rank-gpu-42-2", "head": "a" * 40, "attempt": "2"}
+    ci.write_json(tmp_path / "owner.json", value)
+    return value
+
+
+@pytest.fixture
+def sky(monkeypatch):
+    task = Mock()
+    api = NS(
+        Task=NS(from_yaml=Mock(return_value=task)),
+        launch=Mock(return_value="request-17"),
+        get=Mock(),
+        job_status=Mock(return_value="status-request"),
+        cancel=Mock(return_value="cancel-request"),
+        api_cancel=Mock(return_value="api-cancel-request"),
+        tail_logs=Mock(return_value=0),
+    )
+    monkeypatch.setitem(sys.modules, "sky", api)
+    return api
+
+
+def test_submit_once_records_request_before_wait_and_actual_job(tmp_path, owner, sky):
+    def get(request):
+        assert request == "request-17"
+        assert ci.read_bound(tmp_path, "request.json", owner)["request_id"] == request
+        return 17, NS(cluster_name=owner["cluster"])
+
+    sky.get.side_effect = get
+    ci.worker(tmp_path, "launch")
+    task = sky.Task.from_yaml.return_value
+    task.set_resources_override.assert_called_once_with({"infra": "k8s/cks-wb3"})
+    sky.launch.assert_called_once_with(
+        task, cluster_name=owner["cluster"], retry_until_up=False
+    )
+    assert ci.read_bound(tmp_path, "job.json", owner)["job_id"] == 17
+    sky.tail_logs.assert_not_called()
+
+
+@pytest.mark.parametrize("job_id,cluster", [(True, None), (0, None), (17, "peer")])
+def test_launch_rejects_wrong_identity(tmp_path, owner, sky, job_id, cluster):
+    sky.get.return_value = job_id, NS(cluster_name=cluster or owner["cluster"])
+    with pytest.raises(ValueError):
+        ci.worker(tmp_path, "launch")
+    assert not (tmp_path / "job.json").exists()
+
+
+@pytest.mark.parametrize("status", [*ci.NONTERMINAL, *ci.EXIT_CODES])
+def test_exact_sdk_status_mapping(tmp_path, owner, sky, status):
+    ci.write_json(tmp_path / "job.json", {**owner, "job_id": 17})
+    sky.get.return_value = {17: None if status is None else NS(value=status)}
+    ci.worker(tmp_path, "status")
+    sky.job_status.assert_called_once_with(owner["cluster"], job_ids=[17])
+    assert ci.read_bound(tmp_path, "status.json", owner)["status"] == status
+
+
+@pytest.mark.parametrize(
+    "response", [{1: NS(value="SUCCEEDED")}, {}, {17: NS(value="NEW")}]
+)
+def test_status_rejects_wrong_job_or_unknown_state(tmp_path, owner, sky, response):
+    ci.write_json(tmp_path / "job.json", {**owner, "job_id": 17})
+    sky.get.return_value = response
+    with pytest.raises(ValueError):
+        ci.worker(tmp_path, "status")
+
+
+def test_cancel_and_logs_use_exact_job_and_never_follow(tmp_path, owner, sky):
+    ci.write_json(tmp_path / "job.json", {**owner, "job_id": 17})
+    ci.worker(tmp_path, "cancel")
+    sky.cancel.assert_called_once_with(owner["cluster"], job_ids=[17])
+    with pytest.raises(SystemExit) as outcome:
+        ci.worker(tmp_path, "logs")
+    assert outcome.value.code == 0
+    sky.tail_logs.assert_called_once_with(owner["cluster"], job_id=17, follow=False)
+
+
+def scenario(monkeypatch, root, owner, statuses, *, failures=None):
+    iterator = iter(statuses)
+    calls = []
+    failures = failures or {}
+
+    def run(root, operation, timeout):
+        calls.append(operation)
+        if timeout <= 0:
+            raise TimeoutError("expired")
+        if operation in failures:
+            raise failures[operation]
+        if operation == "launch":
+            ci.write_json(root / "job.json", {**owner, "job_id": 17})
+        if operation == "status":
+            status = next(iterator)
+            if isinstance(status, BaseException):
+                raise status
+            ci.write_json(
+                root / "status.json", {**owner, "job_id": 17, "status": status}
+            )
+
+    monkeypatch.setattr(ci, "run_worker", run)
+    return calls
+
+
+@pytest.mark.parametrize("status,code", list(ci.EXIT_CODES.items()))
+def test_remote_terminal_result_controls_exit(
+    tmp_path, owner, monkeypatch, status, code
+):
+    calls = scenario(monkeypatch, tmp_path, owner, ["SETTING_UP", "RUNNING", status])
+    assert ci.supervise(tmp_path, owner, poll_seconds=0) == code
+    assert calls.count("launch") == 1
+    assert calls[-1] == "logs"
+    assert ("cancel" in calls) is (status is None)
+    assert json.loads((tmp_path / "result.json").read_text())["status"] == status
+
+
+def test_status_transport_loss_recovers_without_resubmitting(
+    tmp_path, owner, monkeypatch
+):
+    calls = scenario(
+        monkeypatch,
+        tmp_path,
+        owner,
+        [subprocess.CalledProcessError(1, "status"), "RUNNING", "SUCCEEDED"],
+    )
+    assert ci.supervise(tmp_path, owner, poll_seconds=0) == 0
+    assert calls.count("launch") == 1
+    assert "cancel" not in calls
+
+
+def test_log_failure_does_not_rewrite_known_remote_success(
+    tmp_path, owner, monkeypatch
+):
+    scenario(
+        monkeypatch, tmp_path, owner, ["SUCCEEDED"], failures={"logs": OSError("EOF")}
+    )
+    assert ci.supervise(tmp_path, owner, poll_seconds=0) == 0
+    assert json.loads((tmp_path / "result.json").read_text())["status"] == "SUCCEEDED"
+
+
+@pytest.mark.parametrize(
+    "error", [InterruptedError("signal"), TimeoutError("deadline")]
+)
+def test_interruption_attempts_exact_cancel_and_logs(
+    tmp_path, owner, monkeypatch, error
+):
+    calls = scenario(monkeypatch, tmp_path, owner, [error])
+    with pytest.raises(type(error)) as raised:
+        ci.supervise(tmp_path, owner, poll_seconds=0)
+    assert raised.value is error
+    assert calls[-2:] == ["cancel", "logs"]
+
+
+def test_repeated_query_failure_and_cleanup_errors_preserve_primary(
+    tmp_path, owner, monkeypatch
+):
+    primary = subprocess.CalledProcessError(1, "status")
+    calls = scenario(
+        monkeypatch,
+        tmp_path,
+        owner,
+        [primary] * 3,
+        failures={"cancel": OSError("cancel failed"), "logs": OSError("EOF")},
+    )
+    with pytest.raises(subprocess.CalledProcessError) as raised:
+        ci.supervise(tmp_path, owner, poll_seconds=0)
+    assert raised.value is primary
+    assert calls.count("status") == 3
+    assert calls[-2:] == ["cancel", "logs"]
+
+
+def test_receipt_failure_still_cancels_and_preserves_error(
+    tmp_path, owner, monkeypatch
+):
+    calls = scenario(monkeypatch, tmp_path, owner, ["RUNNING"])
+    read = ci.read_bound
+    primary = OSError("receipt failed")
+
+    def fail_read(root, filename, expected):
+        if filename == "status.json":
+            raise primary
+        return read(root, filename, expected)
+
+    monkeypatch.setattr(ci, "read_bound", fail_read)
+    with pytest.raises(OSError) as raised:
+        ci.supervise(tmp_path, owner, poll_seconds=0)
+    assert raised.value is primary
+    assert calls[-2:] == ["cancel", "logs"]
+
+
+def test_late_success_does_not_bypass_deadline(tmp_path, owner, monkeypatch):
+    calls = scenario(monkeypatch, tmp_path, owner, ["SUCCEEDED"])
+    clock = iter([0, 0, 0, 2])
+    monkeypatch.setattr(ci.time, "monotonic", lambda: next(clock))
+    with pytest.raises(TimeoutError):
+        ci.supervise(tmp_path, owner, timeout=1)
+    assert calls[-2:] == ["cancel", "logs"]
+
+
+def test_real_bounded_child_kills_waiting_fork_descendant(tmp_path):
+    """The descendant ignores TERM; the timed-out SDK process group is killed."""
+    receipt = tmp_path / "descendant"
+    program = """
+import os, pathlib, signal, sys, time
+child = os.fork()
+if child == 0:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    pathlib.Path(sys.argv[1]).write_text(str(os.getpid()))
+time.sleep(60)
+"""
+    started = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired):
+        ci.run_child(
+            [sys.executable, "-c", program, str(receipt)], 0.5, tmp_path / "child.log"
+        )
+    assert time.monotonic() - started < 3
+    pid = int(receipt.read_text())
+    # An exited descendant may remain a zombie until init reaps it.
+    stat = Path(f"/proc/{pid}/stat")
+    for _ in range(100):
+        if not stat.exists() or stat.read_text().split(") ", 1)[1].split()[0] == "Z":
+            break
+        time.sleep(0.01)
+    else:
+        os.kill(pid, signal.SIGKILL)
+        pytest.fail("owned descendant survived command timeout")
+
+
+def test_run_child_preserves_remote_failure_code(tmp_path):
+    with pytest.raises(subprocess.CalledProcessError) as raised:
+        ci.run_child(
+            [sys.executable, "-c", "raise SystemExit(17)"], 2, tmp_path / "exit.log"
+        )
+    assert raised.value.returncode == 17
+
+
+def test_launch_receipt_failure_cancels_request_and_preserves_error(
+    tmp_path, owner, sky, monkeypatch
+):
+    primary = OSError("disk full")
+    monkeypatch.setattr(ci, "write_json", Mock(side_effect=primary))
+    sky.api_cancel.side_effect = OSError("cancel failed")
+    with pytest.raises(OSError) as raised:
+        ci.worker(tmp_path, "launch")
+    assert raised.value is primary
+    sky.api_cancel.assert_called_once_with(request_ids=["request-17"])
+
+
+def test_cancel_request_requires_own_receipt(tmp_path, owner, sky):
+    ci.write_json(tmp_path / "request.json", {**owner, "request_id": "request-17"})
+    ci.worker(tmp_path, "cancel_request")
+    sky.api_cancel.assert_called_once_with(request_ids=["request-17"])
+    sky.api_cancel.reset_mock()
+    ci.write_json(
+        tmp_path / "request.json",
+        {**owner, "cluster": "peer", "request_id": "peer-request"},
+    )
+    with pytest.raises(ValueError):
+        ci.worker(tmp_path, "cancel_request")
+    sky.api_cancel.assert_not_called()
+
+
+@pytest.mark.parametrize("known_request", [False, True])
+def test_launch_timeout_cancels_only_recorded_request(
+    tmp_path, owner, monkeypatch, known_request
+):
+    if known_request:
+        ci.write_json(tmp_path / "request.json", {**owner, "request_id": "request-17"})
+    error = TimeoutError("launch wait")
+    calls = scenario(monkeypatch, tmp_path, owner, [], failures={"launch": error})
+    with pytest.raises(TimeoutError) as raised:
+        ci.supervise(tmp_path, owner)
+    assert raised.value is error
+    assert calls == (["launch", "cancel_request"] if known_request else ["launch"])
+
+
+@pytest.mark.parametrize("bad", ["head", "infra", "run_id"])
+def test_main_rejects_invalid_scope_before_launch(tmp_path, monkeypatch, bad):
+    environment = {
+        "GITHUB_RUN_ID": "42",
+        "GITHUB_RUN_ATTEMPT": "2",
+        "GITHUB_REPOSITORY": "OpenPipe/ART",
+        "GITHUB_EVENT_NAME": "pull_request",
+        "EXPECTED_HEAD_SHA": "a" * 40,
+        "SKY_INFRA": "k8s/cks-wb3",
+    }
+    environment[
+        {"head": "EXPECTED_HEAD_SHA", "infra": "SKY_INFRA", "run_id": "GITHUB_RUN_ID"}[
+            bad
+        ]
+    ] = "invalid"
+    for key, value in environment.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(ci.subprocess, "check_output", lambda *args, **kwargs: "a" * 40)
+    run = Mock()
+    monkeypatch.setattr(ci, "supervise", run)
+    with pytest.raises(ValueError):
+        ci.main(tmp_path / "evidence")
+    run.assert_not_called()
+
+
+def test_real_worker_round_trip_with_fake_sdk(tmp_path):
+    """Exercise the actual direct Python parent/worker JSON transport, without Sky."""
+    (tmp_path / "sky.py").write_text("""
+import os
+from pathlib import Path
+from types import SimpleNamespace as NS
+class Task:
+    @classmethod
+    def from_yaml(cls, path): return cls()
+    def set_resources_override(self, options): assert options == {"infra":"k8s/cks-wb3"}
+def launch(task, *, cluster_name, retry_until_up):
+    assert retry_until_up is False
+    Path(os.environ["FAKE_CLUSTER"]).write_text(cluster_name)
+    return "launch-request"
+def get(value):
+    if value == "launch-request":
+        return 17, NS(cluster_name=Path(os.environ["FAKE_CLUSTER"]).read_text())
+    return value
+def job_status(cluster, *, job_ids):
+    assert job_ids == [17]
+    return {17:NS(value="SUCCEEDED")}
+def tail_logs(cluster, *, job_id, follow):
+    assert job_id == 17 and follow is False
+    print("fake complete log")
+    return 0
+""")
+    repo = SCRIPT.parents[2]
+    head = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo, text=True
+    ).strip()
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(tmp_path),
+        "FAKE_CLUSTER": str(tmp_path / "cluster"),
+        "GITHUB_RUN_ID": "42",
+        "GITHUB_RUN_ATTEMPT": "2",
+        "GITHUB_REPOSITORY": "OpenPipe/ART",
+        "GITHUB_EVENT_NAME": "pull_request",
+        "SKY_INFRA": "k8s/cks-wb3",
+        "EXPECTED_HEAD_SHA": head,
+    }
+    root = tmp_path / "evidence"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(root)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads((root / "result.json").read_text())["job_id"] == 17
+    assert "fake complete log" in (root / "logs.log").read_text()

--- a/tests/unit/test_trainer_rank_gpu_ci.py
+++ b/tests/unit/test_trainer_rank_gpu_ci.py
@@ -1,5 +1,6 @@
 """No Sky service or GPU calls: exercise the real CI driver at its SDK boundary."""
 
+import ast
 import importlib.util
 import json
 import os
@@ -65,6 +66,14 @@ def test_launch_rejects_wrong_identity(tmp_path, owner, sky, job_id, cluster):
     sky.get.return_value = job_id, NS(cluster_name=cluster or owner["cluster"])
     with pytest.raises(ValueError):
         ci.worker(tmp_path, "launch")
+    assert not (tmp_path / "job.json").exists()
+
+
+def test_launch_missing_handle_cancels_recorded_request(tmp_path, owner, sky):
+    sky.get.return_value = 17, None
+    with pytest.raises(ValueError):
+        ci.worker(tmp_path, "launch")
+    sky.api_cancel.assert_called_once_with(request_ids=["request-17"])
     assert not (tmp_path / "job.json").exists()
 
 
@@ -431,3 +440,85 @@ def test_lost_waitable_child_identity_never_signals_group(monkeypatch):
     with pytest.raises(ChildProcessError):
         ci.finish_child(NS(pid=42))
     kill.assert_not_called()
+
+
+@pytest.mark.parametrize("signum", [signal.SIGINT, signal.SIGTERM])
+@pytest.mark.parametrize("boundary", ["acquiring", "acquired", "cleanup", "repeated"])
+def test_interrupt_boundaries_retire_worker_before_propagating(
+    tmp_path, monkeypatch, signum, boundary
+):
+    """Real signals at acquisition/retirement boundaries, never a Sky call."""
+    tree = ast.parse(SCRIPT.read_text())
+    functions = {n.name: n for n in tree.body if isinstance(n, ast.FunctionDef)}
+    acquired_line = next(
+        n.lineno
+        for n in ast.walk(functions["run_child"])
+        if isinstance(n, ast.Assign)
+        and any(isinstance(t, ast.Name) and t.id == "original" for t in n.targets)
+        and isinstance(n.value, ast.Constant)
+        and n.value.value is None
+    )
+    cleanup_line = next(
+        n.lineno
+        for n in ast.walk(functions["finish_child"])
+        if isinstance(n, ast.Expr)
+        and isinstance(n.value, ast.Call)
+        and isinstance(n.value.func, ast.Attribute)
+        and n.value.func.attr == "killpg"
+    )
+    children, delivered = [], []
+    popen = subprocess.Popen
+
+    def acquire(*args, **kwargs):
+        process = popen(*args, **kwargs)
+        children.append(process)
+        if boundary == "acquiring":
+            os.kill(os.getpid(), signum)
+            delivered.append("acquiring")
+        return process
+
+    def trace(frame, event, arg):
+        if event == "line" and frame.f_code.co_filename == str(SCRIPT):
+            if frame.f_lineno == acquired_line and boundary in {"acquired", "repeated"}:
+                if "acquired" not in delivered:
+                    os.kill(os.getpid(), signum)
+                    delivered.append("acquired")
+            if frame.f_lineno == cleanup_line and boundary in {"cleanup", "repeated"}:
+                # Both signals must remain non-raising throughout group cleanup.
+                if "cleanup" not in delivered:
+                    os.kill(os.getpid(), signal.SIGTERM)
+                    os.kill(os.getpid(), signal.SIGINT)
+                    delivered.append("cleanup")
+        return trace
+
+    def interrupted(signum, frame):
+        raise InterruptedError(f"CI interrupted by signal {signum}")
+
+    handlers = {sig: signal.getsignal(sig) for sig in (signal.SIGINT, signal.SIGTERM)}
+    monkeypatch.setattr(ci.subprocess, "Popen", acquire)
+    try:
+        for sig in handlers:
+            signal.signal(sig, interrupted)
+        sys.settrace(trace)
+        expected = (
+            subprocess.TimeoutExpired if boundary == "cleanup" else InterruptedError
+        )
+        with pytest.raises(expected) as raised:
+            ci.run_child(
+                [sys.executable, "-c", "import time; time.sleep(20)"],
+                0.1,
+                tmp_path / "worker.log",
+            )
+        sys.settrace(None)
+        assert raised.value.__cause__ is None
+        assert len(children) == 1 and delivered
+        assert not Path(f"/proc/{children[0].pid}").exists()
+        assert all(signal.getsignal(sig) is interrupted for sig in handlers)
+    finally:
+        sys.settrace(None)
+        for sig, handler in handlers.items():
+            signal.signal(sig, handler)
+        for process in children:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=2)


### PR DESCRIPTION
An attached SkyPilot log stream can fail after the remote TrainerRank validation job succeeds, incorrectly failing CI. Submit the existing task detached, bind the returned cluster/job identity, and poll only that job’s terminal status. Retrieve logs under a separate deadline and retain their errors as diagnostics; missing, unknown and failed job outcomes still fail.

Each SDK operation runs in a bounded subprocess. The parent records interrupts through process acquisition and group retirement, preserves the original failure, and kills descendants before reaping the process-group identity. The existing exact-cluster workflow teardown and GPU task geometry remain unchanged; execution is restricted to free cks-wb3.

Validation:53 CPU tests pass, including eight real-signal acquisition/cleanup regressions that fail on the parent, fork-descendant cleanup and exact job/cancellation controls. Scoped types, lint/format and hosted CI pass. McCarthy and Minsky independently clear head23167f5cfff9d5f9471a61b4f1a54838eed598a6. CI-only changes are excluded by the existing GPU classifier, so this driver has not been exercised against a live Sky job; monitor its first eligible GPU run. This change does not identify the underlying websocket EOF cause.

Closes #878.
