### PR TITLE
Preserve first-captured MoE routes for extending prompts

### DIFF
--- a/src/art/preprocessing/moe_routing.py
+++ b/src/art/preprocessing/moe_routing.py
@@ -418,10 +418,7 @@ def _overlay_routes(
         return
     end = start + routes.shape[0]
     existing = route_mask[start:end]
-    if bool(existing.any()) and not np.array_equal(
-        aligned[start:end][existing], routes[existing]
-    ):
-        raise RuntimeError("Overlapping routed experts disagree for the same token")
+    # Keep first-captured routes; an extended prompt may reroute its uncached tail.
     fill = ~existing
     if bool(fill.any()):
         aligned[start:end][fill] = routes[fill]


### PR DESCRIPTION
## Summary

- Make overlapping MoE route assembly first-write-wins for multi-call trajectories with extending prompts.
- Fill only route positions that have not already been covered.
- Leave token identity, route shape, expert bounds, and downstream prefix-tree packing validation unchanged.

## Why

vLLM retains routed experts for full prefix-cache blocks, but an unaligned suffix can be recomputed when a later request extends the prompt. Those tokens may move from decode execution to prefill execution and legitimately select different experts. A request that crosses an in-flight policy update can also recompute prompt positions under the new policy.

The earlier capture remains the replay authority for already-recorded tokens. Rejecting a later disagreement therefore aborts a valid trajectory instead of preserving its original routes.

## Validation

- Real captured three-call trajectory: one 4,184-token sequence, 704 intended loss tokens, exact first-capture route ownership, unchanged tokens, masks, logprobs, offsets, and serialized trajectory.
- Focused MoE routing path: 14 passed.
- Adjacent preprocessing and prefix-tree tests: 44 passed, 2 environment-dependent Gemma tests deselected because the local CPU environment lacks the Transformer Engine shared library.
- Scratch overlap controls cover partial, empty, repeated, uint8, and uint16 inputs.
- Ruff, formatting, type checking, lock sync, and git diff checks pass.
